### PR TITLE
(SIMP-362) Update default simp repo GPG key list

### DIFF
--- a/lib/puppet/parser/functions/simp_yumrepo_gpgkeys.rb
+++ b/lib/puppet/parser/functions/simp_yumrepo_gpgkeys.rb
@@ -20,27 +20,41 @@ module Puppet::Parser::Functions
 
     # Common GPG Keys
     gpg_keys = %w(
-      RPM-GPG-KEY-aegisco
-      RPM-GPG-KEY-Jenkins-CI
       RPM-GPG-KEY-puppetlabs
-      RPM-GPG-KEY-redhat-release
-      RPM-GPG-KEY-SIMP-Release
+      RPM-GPG-KEY-SIMP
+      RPM-GPG-KEY-EPEL
     )
 
     case "#{Facter.value('operatingsystem')}#{Facter.value('lsbmajdistrelease')}"
       when /(RedHat|CentOS)6/
         gpg_keys += %w(
-          RPM-GPG-KEY-CentOS-6
-          RPM-GPG-KEY-CentOS-Security-6
           RPM-GPG-KEY-EPEL-6
-          RPM-GPG-KEY-fedora-16-primary
-          RPM-GPG-KEY-fedora-16-secondary
         )
+        case "#{Facter.value('operatingsystem')}"
+          when /CentOS/
+            gpg_keys += %w(
+              RPM-GPG-KEY-CentOS-6
+              RPM-GPG-KEY-CentOS-Security-6
+            )
+          when /RedHat/
+            gpg_keys += %w(
+              RPM-GPG-KEY-redhat-release
+            )
+        end
       when /(RedHat|CentOS)7/
         gpg_keys += %w(
-          RPM-GPG-KEY-CentOS-7
           RPM-GPG-KEY-EPEL-7
         )
+        case "#{Facter.value('operatingsystem')}"
+          when /CentOS/
+            gpg_keys += %w(
+              RPM-GPG-KEY-CentOS-7
+            )
+          when /RedHat/
+            gpg_keys += %w(
+              RPM-GPG-KEY-redhat-release
+            )
+        end
       else
         Puppet.warning("#{Facter.value('operatingsystem')} #{Facter.value('lsbmajdistrelease')}  support not yet complete")
     end


### PR DESCRIPTION
Attempt at populating default gpg key list with what exists on the
system by default.  If we find we need to copy more keys from the
system later, we can.

SIMP-362 #close Update default simp GPG list