### PR TITLE
(SIMP-192) Updates to work with the latest rsyslog

### DIFF
--- a/manifests/rsyslog/stock/log_server/forward.pp
+++ b/manifests/rsyslog/stock/log_server/forward.pp
@@ -14,11 +14,15 @@
 #
 # [*forward_hosts*]
 #   Type: Array
-#   The hosts to which to forward the logs.
+#     The hosts to which to forward the logs.
+#     Be sure to append the port to the host if you wish to send to an
+#     alternate port.
 #
-# [*forward_port*]
-#   Type: Port
-#   The port to which to forward the logs.
+# [*failover_forward_hosts*]
+#   Type: Array
+#   Default: []
+#     If present, the listed systems will be used as failover servers for the
+#     forwarded records.
 #
 # [*log_transport*]
 #   Type: One of ['tcp','udp','relp']
@@ -30,12 +34,10 @@
 #
 class simp::rsyslog::stock::log_server::forward (
   $forward_hosts,
-  $forward_port = '6514',
+  $failover_forward_hosts = [],
   $log_transport = 'tcp'
 ) {
-  validate_array($forward_hosts)
   validate_net_list($forward_hosts)
-  validate_integer($forward_port)
   validate_array_member($log_transport,['tcp','udp','relp'])
 
   include '::rsyslog'

--- a/manifests/rsyslog/stock/log_shipper.pp
+++ b/manifests/rsyslog/stock/log_shipper.pp
@@ -11,16 +11,18 @@
 #
 class simp::rsyslog::stock::log_shipper (
   $log_servers = hiera('log_servers',[]),
+  $failover_log_servers = hiera('failover_log_servers',[]),
   $security_relevant_logs = $::simp::rsyslog::stock::security_relevant_logs
 ){
-  include '::simp::rsyslog::stock'
+  #include '::simp::rsyslog::stock'
 
   if !empty($log_servers) {
     # Remote rules come before everything else so that we don't lose anything.
     rsyslog::rule::remote { 'simp_stock_remote':
-      rule      => $security_relevant_logs,
-      dest      => $log_servers,
-      dest_type => 'tcp'
+      rule                 => $security_relevant_logs,
+      dest                 => $log_servers,
+      failover_log_servers => $failover_log_servers,
+      dest_type            => 'tcp'
     }
   }
 }

--- a/spec/classes/rsyslog/stock/log_shipper_spec.rb
+++ b/spec/classes/rsyslog/stock/log_shipper_spec.rb
@@ -17,6 +17,11 @@ describe 'simp::rsyslog::stock::log_shipper' do
     }
   }}
 
+  let(:params) {{
+    :log_servers => ['1.2.3.4','5.6.7.8'],
+    :failover_log_servers => ['1.1.1.1']
+  }}
+
   it { should compile.with_all_deps }
   it { should create_class('simp::rsyslog::stock::log_shipper') }
 end


### PR DESCRIPTION
These updates ensure that the simp::rsyslog code works with the latest
version of the rsyslog module.

SIMP-192 #comment Updated the simp module for compatibility

Change-Id: I1b4ae1afa113cc8da11bdbb56fd2efa749ba9cd2