### PR TITLE
(SIMP-458) Set keylength to 2048 in runpuppet if FIPS mode is enabled.

### DIFF
--- a/templates/www/ks/runpuppet.erb
+++ b/templates/www/ks/runpuppet.erb
@@ -98,9 +98,9 @@ case "$1" in
 
 <% 
   if @_fips_enabled_on_system || @_fips_enabled_in_hiera
-    t_keylength = '2048'
+    _keylength = '2048'
   else
-    t_keylength = '4096'
+    _keylength = '4096'
   end
 -%>
     read -r -d '' puppet_conf <<'EOM'


### PR DESCRIPTION
Quick update to fix a typo in the template.

SIMP-458 #close