### PR TITLE
(SIMP-590)

### DIFF
--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -94,8 +94,8 @@ class simp::yum (
   }
 
   yumrepo { 'simp':
-    baseurl         => simp_yumrepo_mangle("${simp_update_url}/${$::hardwaremodel}",$servers),
-    descr           => "SIMP Packages (${::hardwaremodel})",
+    baseurl         => simp_yumrepo_mangle("${simp_update_url}",$servers),
+    descr           => "SIMP Packages",
     enabled         => $l_simp_repo_enable,
     enablegroups    => 0,
     gpgcheck        => 1,

--- a/spec/classes/yum_spec.rb
+++ b/spec/classes/yum_spec.rb
@@ -31,7 +31,7 @@ describe 'simp::yum' do
   it { should compile.with_all_deps }
   it { should create_yumrepo('simp').with({
       :gpgkey => /http:\/\/yum1.bar.baz\/yum\/SIMP*/,
-      :baseurl => /http:\/\/yum1.bar.baz\/yum\/SIMP\/x86_64\/*/,
+      :baseurl => /http:\/\/yum1.bar.baz\/yum\/SIMP\/*/,
     })
   }
 end


### PR DESCRIPTION
Removed strict requirements for simp repo baseurl to use $::hardwaremodel allowing the current bintray implementation without archetype.