### PR TITLE
(SIMP-632) Fix SSSD includes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,30 +142,26 @@ class simp (
   if $is_mail_server {
     $l_mta = hiera('mta','')
     if !empty($l_mta) {
-      include 'postfix::server'
+      include '::postfix::server'
     }
     else {
-      include 'postfix'
+      include '::postfix'
     }
   }
 
   if $use_ldap {
-    include 'openldap::pam'
-    include 'openldap::client'
+    include '::openldap::pam'
+    include '::openldap::client'
   }
 
   if $use_sssd {
-    include 'sssd'
+    if $use_stock_sssd {
+      include '::simp::sssd::client'
+    }
   }
   else {
-    if $use_nscd { include 'nscd' }
-  }
-
-  if $use_sssd and $use_stock_sssd {
-    include 'simp::sssd::client'
-  }
-  else {
-    if  $use_nscd {
+    if $use_nscd {
+      include 'nscd'
       include 'nscd::passwd'
       include 'nscd::group'
       include 'nscd::services'

--- a/manifests/sssd/client.pp
+++ b/manifests/sssd/client.pp
@@ -10,17 +10,21 @@
 class simp::sssd::client (
   $use_ldap = defined('$::use_ldap') ? { true => $::use_ldap, default => hiera('use_ldap',true) }
 ){
-  include 'sssd'
-
-  include 'sssd::service::nss'
-  include 'sssd::service::pam'
-
   if $use_ldap {
+    # We include these here because, without a domain, SSSD should not be
+    # running and will, in fact, complain if you attempt to run without a
+    # domain.
+    include '::sssd'
+
+    include '::sssd::service::nss'
+    include '::sssd::service::pam'
+
     sssd::domain { 'LDAP':
       description       => 'LDAP Users domain',
       id_provider       => 'ldap',
       auth_provider     => 'ldap',
       chpass_provider   => 'ldap',
+      # This needs to change in SIMP 6!
       min_id            => '501',
       enumerate         => true,
       cache_credentials => true


### PR DESCRIPTION
SSSD should not be included unless you are going to actually configure a
domain.

SIMP-632 #close #comment Only include with domain creation

Change-Id: Ib998cd0cf8ac103c945cb265f8d173d529830c9d