### PR TITLE
(SIMP-667) Normalize common module assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
-Gemfile.lock
+.*.sw?
+.yardoc
 dist
-spec/fixtures/modules
-spec/fixtures/hieradata/hiera.yaml
+/pkg
+/spec/fixtures
+!/spec/hieradata/default.yaml
+!/spec/fixtures/site.pp
+/.rspec_system
+/.vagrant
+/.bundle
+/Gemfile.lock
+/vendor
+/junit
+/log

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,7 +1,4 @@
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
---no-variables_not_enclosed-check
 --no-class_inherits_from_params_class-check
 --no-80chars-check
-# We know that we're doing this here for puppetdb
---no-inherits_across_namespaces-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,27 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
+before_script:
+  - bundle
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
+script:
+  - bundle exec rake test
+notifications:
+  email: false
 rvm:
-#  - 1.8.7  # bombs out on mime-types gem
+  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.1
-script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
-# NOTE: `:environmentpath` was not supported before Puppet 3.5
 env:
   global:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
     - PUPPET_VERSION="~> 3.5.0"
     - PUPPET_VERSION="~> 3.6.0"
     - PUPPET_VERSION="~> 3.7.0"
@@ -28,7 +31,6 @@ env:
     - PUPPET_VERSION="~> 4.0.0"
     - PUPPET_VERSION="~> 4.1.0"
     - PUPPET_VERSION="~> 4.2.0"
-
 matrix:
   fast_finish: true
   allow_failures:
@@ -39,33 +41,50 @@ matrix:
     - env: PUPPET_VERSION="~> 3.6.0"
     - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
     - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
     - env: PUPPET_VERSION="~> 4.1.0"
     - env: PUPPET_VERSION="~> 4.2.0"
 
   exclude:
   # Ruby 1.8.7
   # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
 
   # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
   # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
   # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
-
-  # Ruby 1.9.3
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-
-  # Ruby 2.0.0
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
 
   # Ruby 2.1.0
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
 
   # Ruby 2.2.1
   - rvm: 2.2.1
     env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.2.1
     env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
@@ -50,4 +50,3 @@ group :system_tests do
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh', '~> 2.9.0'
 end
-

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,105 @@
+{
+  "name":    "simp-simp",
+  "version": "1.1.0",
+  "author":  "simp",
+  "summary": "default profiles for core SIMP installations",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-simp",
+  "project_page": "https://github.com/simp/pupmod-simp-simp",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "profiles"],
+  "dependencies": [
+    {
+      "name": "simp-aide",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-apache",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-auditd",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "herculesteam-augeasproviders_puppet",
+      "version_requirement": ">= 2.0.2"
+    },
+    {
+      "name": "simp-clamav",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-dhcp",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-iptables",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-logrotate",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-named",
+      "version_requirement": ">= 4.2.0"
+    },
+    {
+      "name": "simp-ncsd",
+      "version_requirement": ">= 5.0.0"
+    },
+    {
+      "name": "simp-ntpd",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-openldap",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-pam",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-pki",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-postfix",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-pupmod",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-rsync",
+      "version_requirement": ">= 4.0.0"
+    },
+    {
+      "name": "simp-simpcat",
+      "version_requirement": ">= 4.0.0"
+    },
+    {
+      "name": "simp-simplib",
+      "version_requirement": ">= 1.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/classes/admin_spec.rb
+++ b/spec/classes/admin_spec.rb
@@ -24,7 +24,7 @@ describe 'simp::admin' do
 
   let(:facts){base_facts}
 
-  it { should compile.with_all_deps }
-  it { should create_sudo__alias__user('admins') }
-  it { should create_sudo__alias__user('auditors') }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_sudo__alias__user('admins') }
+  it { is_expected.to create_sudo__alias__user('auditors') }
 end

--- a/spec/classes/base_apps_spec.rb
+++ b/spec/classes/base_apps_spec.rb
@@ -24,6 +24,6 @@ describe 'simp::base_apps' do
 
   let(:facts){base_facts}
 
-  it { should create_class('simp::base_apps').with_ensure('latest') }
-  it { should compile.with_all_deps }
+  it { is_expected.to create_class('simp::base_apps').with_ensure('latest') }
+  it { is_expected.to compile.with_all_deps }
 end

--- a/spec/classes/base_services_spec.rb
+++ b/spec/classes/base_services_spec.rb
@@ -24,5 +24,5 @@ describe 'simp::base_services' do
 
   let(:facts){base_facts}
 
-  it { should compile.with_all_deps }
+  it { is_expected.to compile.with_all_deps }
 end

--- a/spec/classes/freeradius/stock_ldap_spec.rb
+++ b/spec/classes/freeradius/stock_ldap_spec.rb
@@ -21,7 +21,7 @@ describe 'simp::freeradius::stock_ldap' do
 
   let(:facts) {base_facts}
 
-  it { should create_class('simp::freeradius::stock_ldap') }
-  it { should compile.with_all_deps }
-  it { should create_file('/etc/raddb/modules/ldap') }
+  it { is_expected.to create_class('simp::freeradius::stock_ldap') }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_file('/etc/raddb/modules/ldap') }
 end

--- a/spec/classes/freeradius/stock_spec.rb
+++ b/spec/classes/freeradius/stock_spec.rb
@@ -22,20 +22,20 @@ describe 'simp::freeradius::stock' do
 
   let(:facts) {base_facts}
 
-  it { should compile.with_all_deps }
+  it { is_expected.to compile.with_all_deps }
 
-  it { should contain_class('freeradius::users') }
-  it { should contain_class('freeradius::conf::client') }
-  it { should contain_class('freeradius::conf') }
+  it { is_expected.to contain_class('freeradius::users') }
+  it { is_expected.to contain_class('freeradius::conf::client') }
+  it { is_expected.to contain_class('freeradius::conf') }
 
   # Check to ensure the client is added
-  it { should create_file('/etc/raddb/conf/clients/default.conf').with_content(/ipaddr = 127.0.0.1/) }
+  it { is_expected.to create_file('/etc/raddb/conf/clients/default.conf').with_content(/ipaddr = 127.0.0.1/) }
 
   # Check to ensure that the default_auth listen is added
-  it { should create_file('/etc/raddb/conf/listen.inc/default_auth').with_content(/type = auth/) }
+  it { is_expected.to create_file('/etc/raddb/conf/listen.inc/default_auth').with_content(/type = auth/) }
 
   # Check to ensure default users are added (default_ppp, default_cslip, default_slip)
-  it { should create_file('/etc/raddb/users.inc/100.default_ppp').with_content(/Framed-Protocol = PPP/) }
-  it { should create_file('/etc/raddb/users.inc/100.default_cslip').with_content(/Hint == "CSLIP"/) }
-  it { should create_file('/etc/raddb/users.inc/100.default_slip').with_content(/Hint == "SLIP"/) }
+  it { is_expected.to create_file('/etc/raddb/users.inc/100.default_ppp').with_content(/Framed-Protocol = PPP/) }
+  it { is_expected.to create_file('/etc/raddb/users.inc/100.default_cslip').with_content(/Hint == "CSLIP"/) }
+  it { is_expected.to create_file('/etc/raddb/users.inc/100.default_slip').with_content(/Hint == "SLIP"/) }
 end

--- a/spec/classes/ganglia/stock_spec.rb
+++ b/spec/classes/ganglia/stock_spec.rb
@@ -46,9 +46,9 @@ describe 'simp::ganglia::stock' do
 
 
   shared_examples_for "a fact set ganglia" do
-    it { should create_class('simp::ganglia::monitor') }
-    it { should create_class('simp::ganglia::meta') }
-    it { should create_class('simp::ganglia::web') }
+    it { is_expected.to create_class('simp::ganglia::monitor') }
+    it { is_expected.to create_class('simp::ganglia::meta') }
+    it { is_expected.to create_class('simp::ganglia::web') }
   end
 
   describe "RHEL 6" do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -30,11 +30,11 @@ describe 'simp' do
     mod_site_pp("hiera_include('classes')")
   end
 
-  it { should compile.with_all_deps }
+  it { is_expected.to compile.with_all_deps }
 
   context 'with_puppet_server' do
     let(:params) {{ :puppet_server_ip => '1.2.3.4' }}
 
-    it { should create_host('puppet.bar.baz').with_ip('1.2.3.4') }
+    it { is_expected.to create_host('puppet.bar.baz').with_ip('1.2.3.4') }
   end
 end

--- a/spec/classes/kickstart_server_spec.rb
+++ b/spec/classes/kickstart_server_spec.rb
@@ -26,48 +26,48 @@ describe 'simp::kickstart_server' do
   let(:facts){base_facts}
   let(:params){{:data_dir => '/var/www'}}
 
-  it { should compile.with_all_deps }
-  it { should create_class('apache') }
-  it { should create_class('dhcp::dhcpd') }
-  it { should create_class('tftpboot') }
-  it { should create_apache__add_site('ks').with_content(/Allow from 1.2.3.4\/24/) }
-  it { should create_file('/var/www/ks').with_mode('2640') }
-  it { should create_file('/var/www/ks/runpuppet').with_content(/puppet=.*--waitforcert 10.*--evaltrace --summarize/) }
-  it { should create_file('/var/www/ks/runpuppet').with_content(/puppet_server="puppet.bar.baz"/) }
-  it { should create_file('/var/www/ks/runpuppet').with_content(/ca_server = puppet.bar.baz/) }
-  it { should create_file('/var/www/ks/runpuppet').with_content(/ca_port = 8141/) }
-  it { should_not create_file('/var/www/ks/runpuppet').with_content(/ntpdate/) }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_class('apache') }
+  it { is_expected.to create_class('dhcp::dhcpd') }
+  it { is_expected.to create_class('tftpboot') }
+  it { is_expected.to create_apache__add_site('ks').with_content(/Allow from 1.2.3.4\/24/) }
+  it { is_expected.to create_file('/var/www/ks').with_mode('2640') }
+  it { is_expected.to create_file('/var/www/ks/runpuppet').with_content(/puppet=.*--waitforcert 10.*--evaltrace --summarize/) }
+  it { is_expected.to create_file('/var/www/ks/runpuppet').with_content(/puppet_server="puppet.bar.baz"/) }
+  it { is_expected.to create_file('/var/www/ks/runpuppet').with_content(/ca_server = puppet.bar.baz/) }
+  it { is_expected.to create_file('/var/www/ks/runpuppet').with_content(/ca_port = 8141/) }
+  it { is_expected.not_to create_file('/var/www/ks/runpuppet').with_content(/ntpdate/) }
 
   context 'alternate_data_dir' do
     let(:params){{ :data_dir => '/srv/www' }}
-    it { should create_file('/var/www/ks').with_target('/srv/www/ks') }
+    it { is_expected.to create_file('/var/www/ks').with_target('/srv/www/ks') }
   end
 
   context 'specify_ntp_servers_array' do
     let(:params){{ :data_dir => '/var/www', :ntp_servers => ['1.2.3.4','5.6.7.8'] }}
 
-    it { should compile.with_all_deps }
-    it { should create_file('/var/www/ks/runpuppet').with_content(/ntpdate -b 1.2.3.4 5.6.7.8/) }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_file('/var/www/ks/runpuppet').with_content(/ntpdate -b 1.2.3.4 5.6.7.8/) }
   end
 
   context 'specify_ntp_servers_hash' do
     let (:params){{ :data_dir => '/var/www', :ntp_servers => { '1.2.3.4' => ['foo, bar'], '5.6.7.8' => ['baz'] } }}
 
-    it { should compile.with_all_deps }
-    it { should create_file('/var/www/ks/runpuppet').with_content(/ntpdate -b 1.2.3.4 5.6.7.8/) }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_file('/var/www/ks/runpuppet').with_content(/ntpdate -b 1.2.3.4 5.6.7.8/) }
   end
 
   context 'no_print_stats' do
     let(:params){{ :data_dir => '/var/www', :runpuppet_print_stats => false }}
 
-    it { should compile.with_all_deps }
-    it { should_not create_file('/var/www/ks/runpuppet').with_content(/--evaltrace/) }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to create_file('/var/www/ks/runpuppet').with_content(/--evaltrace/) }
   end
 
   context 'no_wait_for_cert' do
     let(:params){{ :data_dir => '/var/www', :runpuppet_wait_for_cert => '' }}
 
-    it { should compile.with_all_deps }
-    it { should_not create_file('/var/www/ks/runpuppet').with_content(/--waitforcert/) }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to create_file('/var/www/ks/runpuppet').with_content(/--waitforcert/) }
   end
 end

--- a/spec/classes/ldap_server_spec.rb
+++ b/spec/classes/ldap_server_spec.rb
@@ -26,19 +26,19 @@ describe 'simp::ldap_server' do
 
   let(:facts){base_facts}
 
-  it { should compile.with_all_deps }
+  it { is_expected.to compile.with_all_deps }
 
   context 'is_slave' do
     let(:params){{ :is_slave => true }}
 
-    it { should compile.with_all_deps }
-    it { should create_openldap__server__syncrepl('111') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_openldap__server__syncrepl('111') }
   end
 
   context 'use_lastbind' do
     let(:params){{ :enable_lastbind => true }}
 
-    it { should compile.with_all_deps }
-    it { should create_class('openldap::slapo::lastbind') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('openldap::slapo::lastbind') }
   end
 end

--- a/spec/classes/nfs/export_home_spec.rb
+++ b/spec/classes/nfs/export_home_spec.rb
@@ -20,12 +20,12 @@ describe 'simp::nfs::export_home' do
 
   let(:params){{ :data_dir => '/var' }}
 
-  it { should create_class('simp::nfs::export_home') }
-  it { should compile.with_all_deps }
-  it { should contain_class('nfs') }
-  it { should contain_class('nfs::idmapd') }
-  it { should contain_class('nfs::server') }
-  it { should create_file('/var/nfs/exports').with_ensure('directory') }
-  it { should create_file('/var/nfs/exports/home').with_ensure('directory') }
-  it { should create_file('/var/nfs/home').with_ensure('directory') }
+  it { is_expected.to create_class('simp::nfs::export_home') }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to contain_class('nfs') }
+  it { is_expected.to contain_class('nfs::idmapd') }
+  it { is_expected.to contain_class('nfs::server') }
+  it { is_expected.to create_file('/var/nfs/exports').with_ensure('directory') }
+  it { is_expected.to create_file('/var/nfs/exports/home').with_ensure('directory') }
+  it { is_expected.to create_file('/var/nfs/home').with_ensure('directory') }
 end

--- a/spec/classes/nfs/home_client_spec.rb
+++ b/spec/classes/nfs/home_client_spec.rb
@@ -18,10 +18,10 @@ describe 'simp::nfs::home_client' do
     }
   }}
 
-  it { should create_class('simp::nfs::home_client') }
-  it { should compile.with_all_deps }
-  it { should contain_class('nfs') }
-  it { should contain_class('nfs::client') }
-  it { should contain_class('autofs') }
-  it { should contain_selboolean('use_nfs_home_dirs') }
+  it { is_expected.to create_class('simp::nfs::home_client') }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to contain_class('nfs') }
+  it { is_expected.to contain_class('nfs::client') }
+  it { is_expected.to contain_class('autofs') }
+  it { is_expected.to contain_selboolean('use_nfs_home_dirs') }
 end

--- a/spec/classes/rsyslog/stock/log_server/forward_spec.rb
+++ b/spec/classes/rsyslog/stock/log_server/forward_spec.rb
@@ -19,9 +19,9 @@ describe 'simp::rsyslog::stock::log_server::forward' do
     }
   }}
 
-  it { should create_class('simp::rsyslog::stock::log_server::forward') }
+  it { is_expected.to create_class('simp::rsyslog::stock::log_server::forward') }
 
   context 'base' do
-    it { should compile.with_all_deps }
+    it { is_expected.to compile.with_all_deps }
   end
 end

--- a/spec/classes/rsyslog/stock/log_server_spec.rb
+++ b/spec/classes/rsyslog/stock/log_server_spec.rb
@@ -21,14 +21,14 @@ describe 'simp::rsyslog::stock::log_server' do
     }
   }}
 
-  it { should create_class('simp::rsyslog::stock::log_server') }
+  it { is_expected.to create_class('simp::rsyslog::stock::log_server') }
 
   context 'base' do
-    it { should compile.with_all_deps }
-    it { should create_file('/etc/rsyslog.conf') }
-    it { should create_file('/etc/cron.hourly/logrotate') }
-    it { should create_file('/etc/cron.daily/logrotate').with_ensure('absent') }
-    it { should create_file('/etc/cron.monthly/logrotate').with_ensure('absent') }
-    it { should create_file('/etc/cron.yearly/logrotate').with_ensure('absent') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_file('/etc/rsyslog.conf') }
+    it { is_expected.to create_file('/etc/cron.hourly/logrotate') }
+    it { is_expected.to create_file('/etc/cron.daily/logrotate').with_ensure('absent') }
+    it { is_expected.to create_file('/etc/cron.monthly/logrotate').with_ensure('absent') }
+    it { is_expected.to create_file('/etc/cron.yearly/logrotate').with_ensure('absent') }
   end
 end

--- a/spec/classes/rsyslog/stock_spec.rb
+++ b/spec/classes/rsyslog/stock_spec.rb
@@ -19,6 +19,6 @@ describe 'simp::rsyslog::stock' do
     }
   }}
 
-  it { should compile.with_all_deps }
-  it { should create_class('rsyslog') }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_class('rsyslog') }
 end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -30,9 +30,9 @@ describe 'simp::server' do
 
   let(:facts){base_facts}
 
-  it { should compile.with_all_deps }
-  it { should create_class('acpid') }
-  it { should create_class('pupmod::master') }
-  it { should create_class('simp::server') }
-  it { should create_rsync__server__section('default') }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_class('acpid') }
+  it { is_expected.to create_class('pupmod::master') }
+  it { is_expected.to create_class('simp::server') }
+  it { is_expected.to create_rsync__server__section('default') }
 end

--- a/spec/classes/snmpd/server_spec.rb
+++ b/spec/classes/snmpd/server_spec.rb
@@ -20,8 +20,8 @@ describe 'simp::snmpd::server' do
     }
   }}
 
-  it { should create_class('simp::snmpd::server') }
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should contain_class('snmpd::authtrapenable') }
+  it { is_expected.to create_class('simp::snmpd::server') }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to contain_class('snmpd') }
+  it { is_expected.to contain_class('snmpd::authtrapenable') }
 end

--- a/spec/classes/yum_server_spec.rb
+++ b/spec/classes/yum_server_spec.rb
@@ -23,7 +23,7 @@ describe 'simp::yum_server' do
   let(:facts){base_facts}
 
   context 'base' do
-    it { should compile.with_all_deps }
-    it { should contain_apache__add_site('yum') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_apache__add_site('yum') }
   end
 end

--- a/spec/classes/yum_spec.rb
+++ b/spec/classes/yum_spec.rb
@@ -29,8 +29,8 @@ describe 'simp::yum' do
     :servers => ['yum1.bar.baz','yum2.bar.baz']
   }}
 
-  it { should compile.with_all_deps }
-  it { should create_yumrepo('simp').with({
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_yumrepo('simp').with({
       :gpgkey => %r(^https?://yum1.bar.baz/yum/SIMP),
       :baseurl => %r(^https?://yum1.bar.baz/yum/SIMP)
     })


### PR DESCRIPTION
This commit synchronizes all common static module assets with current
SIMP module standards.

Also:
- added `metadata.json`, `.puppet-lint.rc`
- updated rspec tests to the new `expect` syntax

SIMP-667 #comment updated `pupmod-simp-simp`
SIMP-753 #close #comment normalized common module assets
