### PR TITLE
(SIMP-893) Fixed nfs_server default in the home_client class.

### DIFF
--- a/build/pupmod-simp.spec
+++ b/build/pupmod-simp.spec
@@ -1,7 +1,7 @@
 Summary: SIMP Puppet Module
 Name: pupmod-simp
 Version: 1.1.0
-Release: 8
+Release: 9
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -85,6 +85,11 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Tue Mar 08 2016 Nick Markowski <nmarkowski@keywcorp.com> - 1.1.0-9
+- Updated a bad default for nfs_server in the home_client class, which
+  otherwise had the potential to render a nil server value, and
+  break automounting.
+
 * Wed Feb 24 2016 Nick Markowski <nmarkowski@keywcorp.com> - 1.1.0-8
 - Updated the mcollective stock class and added appropriate spec and unit
   testing for full functionality test coverage.

--- a/manifests/nfs/home_client.pp
+++ b/manifests/nfs/home_client.pp
@@ -24,7 +24,7 @@
 # * Kendall Moore <mailto:kmoore@keywcorp.com>
 #
 class simp::nfs::home_client (
-  $nfs_server = defined('$::nfs::server') ? { true => $::nfs_server, default => hiera('nfs::server') },
+  $nfs_server = defined('$::nfs_server') ? { true => $::nfs_server, default => hiera('nfs::server') },
   $port = '2049',
   $sec = 'sys',
   $use_autofs = true


### PR DESCRIPTION
Updated a bad default for nfs_server in the home_client class, which
otherwise had the potential to render a nil server value, and
break automounting.

SIMP-893 #close