### PR TITLE
(SIMP-1004) Puppet 4 cannot enable quotaon or messagebus

### DIFF
--- a/build/pupmod-simp.spec
+++ b/build/pupmod-simp.spec
@@ -1,7 +1,7 @@
 Summary: SIMP Puppet Module
 Name: pupmod-simp
 Version: 1.2.0
-Release: 0
+Release: 1
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -87,6 +87,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Wed Apr 13 2016 Kendall Moore <kendall.moore@onyxpoint.com> - 1.2.0-1
+- Svckill now ignores quotaon and messagebus in RHEL/CentOS 7
+
 * Mon Mar 14 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.2.0-0
 - Moved to Semantic Versioning 2.0
 - Ensure that SSSD is used for systems EL6.7+

--- a/manifests/base_services.pp
+++ b/manifests/base_services.pp
@@ -29,7 +29,14 @@ class simp::base_services {
   case $::operatingsystem {
     'RedHat','CentOS': {
       if $::operatingsystemmajrelease > '6' {
-        service { 'quotaon': enable => true }
+        # For now, these will be commentd out and ignored by svckill
+        # Puppet cannot enable these services because there is no
+        # init.d script or systemd script to do so.
+
+        #        service { 'quotaon': enable => true }
+        #        service { 'messagebus': enable  => true }
+        svckill::ignore { 'quotaon': }
+        svckill::ignore { 'messagebus': }
 
         service { 'mcstransd':
           enable     => true,
@@ -38,7 +45,6 @@ class simp::base_services {
           require    => Package['mcstrans']
         }
 
-        service { 'messagebus': enable  => true }
       }
       else {
         package { 'hal':      ensure => 'latest' }


### PR DESCRIPTION
These services don't have an init.d or systemd script so for now
svckill will just ignore them instead of having Puppet try to
enable them

SIMP-1001 #comment Fixes the pupmod-simp-simp part of this story
SIMP-1001 #close
SIMP-1004 #close
