### PR TITLE
(SIMP-1043) Updated default kickstart_server options.

### DIFF
--- a/build/pupmod-simp.spec
+++ b/build/pupmod-simp.spec
@@ -1,6 +1,6 @@
 Summary: SIMP Puppet Module
 Name: pupmod-simp
-Version: 1.2.1
+Version: 1.2.2
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -87,6 +87,10 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Wed May 11 2016 Nick Markowski <nmarkowski@keywcorp.com> - 1.2.2-0
+- Added a hook to control SSLVerifyClient in ks.conf.  Defaults
+  to 'optional'.
+
 * Wed Apr 13 2016 Kendall Moore <kendall.moore@onyxpoint.com> - 1.2.1-0
 - Svckill now ignores quotaon and messagebus in RHEL/CentOS 7
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-simp",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author":  "simp",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/templates/etc/httpd/conf.d/ks.conf.erb
+++ b/templates/etc/httpd/conf.d/ks.conf.erb
@@ -16,4 +16,7 @@ Alias /ks /var/www/ks
 <%= t_allowroot %>
 <% end -%>
     Allow from <%= @domain %>
+    <IfModule ssl_module>
+      SSLVerifyClient <%= @sslverifyclient %>
+    </IfModule>
 </Location>


### PR DESCRIPTION
- Added a hook to control SSLVerifyClient in ks.conf.
- Defaults to optional.

SIMP-1043 #comment httpd optional verifyclient