### PR TITLE
(SIMP-1266) Modify create_home_dirs to use ruby-net-ldap

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-* Wed Jul 13 2016 Nick Miller <nick.miller@onyxpoint.com> - 1.2.3-0
+* Wed Jul 20 2016 Nick Markowski <nmarkowski@keywcorp.com> - 1.2.5-0
+- Migrated create_home_dirs from nfs.
+- Modified create_home_dirs to use ruby-net-ldap.
+
+* Wed Jul 13 2016 Nick Miller <nick.miller@onyxpoint.com> - 1.2.4-0
 - Yum repos now default to https with sslverify=false
 
 * Mon Jul 11 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.2.3-0

--- a/manifests/nfs/create_home_dirs.pp
+++ b/manifests/nfs/create_home_dirs.pp
@@ -1,0 +1,105 @@
+# == Class: simp::nfs::create_home_dirs
+#
+# Adds a script to create user home directories for directory server
+# by pulling users from LDAP
+#
+# == Parameters
+#
+# [*uri*]
+#   The uri of the LDAP servers, specified as space-separated list
+#
+# [*user_ou*]
+#   The OU under which users are stored.
+#
+# [*export_dir*]
+#   The location of the home directories being exported.
+#   This location will have to have a puppet managed File resource
+#   associated.  See the nfs::stock::export_home class for an example
+#
+# [*skel_dir*]
+#   The location of sample skeleton files for user directories.
+#   By default this is /etc/skel which is not managed by Puppet,
+#   therefore, no required File resource here
+#
+# [*ldap_scope*]
+#   The search scope to use.
+#   Valid options are 'one', 'sub', and 'base'.
+#   Defaults to 'base' if an invalid option is specified.
+#
+# [*bind_dn*]
+#   The DN to use when binding to the LDAP server
+#
+# [*bind_pw*]
+#   The password to use when binding to the LDAP server
+#
+# [*port*]
+#   The target port on the LDAP server.  If none specified,
+#   defaults to 389 for non-TLS/start_tls connections, and
+#   636 for SSL connections.
+#
+#   Default: $simp::nfs::params::port
+#
+# [*tls*]
+#   Whether or not to enable SSL/TLS for the connection.
+#   $tls = 'ssl'         -> LDAPS on port 636, unless  different *port* specified.
+#                           Uses simple_tls; No validation of the LDAP server's SSL
+#                           certificate is performed.
+#   $tls = 'start_tls'   -> Start TLS on port 389, unless different *port* specified.
+#   $tls = 'none'        -> LDAP on port 389, unless different *port* specified.
+#                           No Encryption.
+#
+#   Default: $simp::nfs::params::tls
+#
+# [*quiet*]
+#   Whether or not to print potentially useful warnings
+#
+# [*syslog_facility*]
+#   The syslog facility at which to log, must be Ruby 'syslog' compatible.
+#
+# [*syslog_priority*]
+#   The syslog priority at which to log, must be Ruby 'syslog' compatible.
+#
+# == Authors
+#
+# * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+#
+class simp::nfs::create_home_dirs (
+  $uri = hiera('ldap::uri'),
+  $base_dn = hiera('ldap::base_dn'),
+  $export_dir = versioncmp(simp_version(),'5') ? { '-1' => '/srv/nfs/home', default => '/var/nfs/home' },
+  $skel_dir = '/etc/skel',
+  $ldap_scope = 'one',
+  $bind_dn = hiera('ldap::bind_dn'),
+  $bind_pw = hiera('ldap::bind_pw'),
+  $port = $simp::nfs::params::port,
+  $tls = $simp::nfs::params::tls,
+  $quiet = true,
+  $syslog_facility = 'LOG_LOCAL6',
+  $syslog_priority = 'LOG_NOTICE',
+) inherits simp::nfs::params {
+  assert_private()
+
+  validate_absolute_path($export_dir)
+  validate_absolute_path($skel_dir)
+  validate_array_member($ldap_scope, ['one','sub','base'])
+  validate_port($port)
+  validate_array_member($tls, ['ssl','start_tls','none'])
+  validate_bool($quiet)
+
+  package { 'rubygem-net-ldap':
+    ensure => 'latest'
+  }
+
+  file { '/etc/cron.hourly/create_home_directories.rb':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0500',
+    content => template('simp/create_home_directories.rb.erb'),
+    notify  => [ Exec['/etc/cron.hourly/create_home_directories.rb'] ],
+    require => Package['rubygem-net-ldap'],
+  }
+
+  exec { '/etc/cron.hourly/create_home_directories.rb':
+    refreshonly => true,
+  }
+}

--- a/manifests/nfs/export_home.pp
+++ b/manifests/nfs/export_home.pp
@@ -53,16 +53,17 @@ class simp::nfs::export_home (
   $sec = 'none:sys',
   $create_home_dirs = false
 ) {
+  validate_net_list($client_nets)
+  validate_bool($create_home_dirs)
+
   include 'nfs'
   include 'nfs::idmapd'
-
   # NOTE: You must set nfs::server::client_ips in hiera for this to function properly.
   include 'nfs::server'
 
   if $create_home_dirs {
-    include 'nfs::server::create_home_dirs'
+    include 'simp::nfs::create_home_dirs'
   }
-
 
   if ! $::nfs::use_stunnel {
     nfs::server::export { 'nfs4_root':
@@ -108,7 +109,8 @@ class simp::nfs::export_home (
     ensure => 'directory',
     owner  => 'root',
     group  => 'root',
-    mode   => '0755'
+    mode   => '0755',
+    before => $create_home_dirs ? { true => Class['simp::nfs::create_home_dirs'], default => undef }
   }
 
   mount { "${data_dir}/nfs/exports/home":
@@ -122,9 +124,6 @@ class simp::nfs::export_home (
       File["${data_dir}/nfs/home"]
     ]
   }
-
-  validate_net_list($client_nets)
-  validate_bool($create_home_dirs)
 
   compliance_map()
 }

--- a/manifests/nfs/params.pp
+++ b/manifests/nfs/params.pp
@@ -1,0 +1,28 @@
+# == Class: simp::nfs::params ==
+#
+# == Parameters ==
+#
+# [*port*]
+#   The target port on the LDAP server.  If none specified,
+#   defaults to 389 for non-TLS/start_tls connections, and
+#   636 for SSL connections.
+#
+# [*tls*]
+#   Whether or not to enable SSL/TLS for the connection.
+#   $tls = 'ssl'         -> LDAPS on port 636, unless  different *port* specified.
+#                           Uses simple_tls; No validation of the LDAP server's SSL
+#                           certificate is performed.
+#   $tls = 'start_tls'   -> Start TLS on port 389, unless different *port* specified.
+#   $tls = 'none'        -> LDAP on port 389, unless different *port* specified.
+#                           No Encryption.
+#
+class simp::nfs::params {
+  $tls  = 'start_tls'
+  $port = $tls ? {
+    'ssl' => '636',
+    default => '389'
+  }
+
+  validate_port($port)
+  validate_array_member($tls, ['ssl','start_tls','none'])
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-simp",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "author":  "simp",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -50,5 +50,5 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type:      foss
-  vagrant_memsize: 256
+  vagrant_memsize: 2048
   # vb_gui: true

--- a/spec/classes/nfs/create_home_dirs_spec.rb
+++ b/spec/classes/nfs/create_home_dirs_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'simp::nfs::create_home_dirs' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:pre_condition) { 'include "nfs"' }
+        let(:facts) { facts }
+
+        it { is_expected.to create_class('simp::nfs::create_home_dirs') }
+
+        context 'base' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('simp::nfs::create_home_dirs') }
+          it { is_expected.to contain_class('nfs') }
+
+          it { is_expected.to contain_package('rubygem-net-ldap') }
+          it { is_expected.to create_file('/etc/cron.hourly/create_home_directories.rb') }
+        end
+      end
+    end
+  end
+end

--- a/templates/create_home_directories.rb.erb
+++ b/templates/create_home_directories.rb.erb
@@ -1,0 +1,178 @@
+#!/usr/bin/ruby
+<%
+  SCOPE_MAPPING = {
+    'one' => 'Net::LDAP::SearchScope_SingleLevel',
+    'sub' => 'Net::LDAP::SearchScope_WholeSubtree',
+    'default' => 'Net::LDAP::SearchScope_BaseObject'
+  }
+
+  SCOPE_MAPPING[@ldap_scope] ? t_scope = SCOPE_MAPPING[@ldap_scope] : t_scope = SCOPE_MAPPING
+-%>
+require 'rubygems'
+require 'fileutils'
+require 'net/ldap'
+require 'timeout'
+require 'socket'
+require 'syslog'
+
+File.umask(0122)
+
+ldap_params = Hash.new
+
+servers = (["<%= @uri.map { |x| x = x.split("://").last }.join(',') %>"])
+server = nil
+userou = 'ou=People,<%= @base_dn %>'
+export_dir = '<%= @export_dir %>'
+skel_dir = '<%= @skel_dir %>'
+dn = '<%= @bind_dn.gsub(/'/, "\\\\'") %>'
+pw = '<%= @bind_pw.gsub(/'/, "\\\\'") %>'
+tls = '<%= @tls %>'
+quiet = <%= @quiet %>
+syslog_facility = Syslog::<%= @syslog_facility %>
+syslog_priority = Syslog::<%= @syslog_priority %>
+tmout = 5
+
+begin
+  Syslog.open('home_directories', Syslog::LOG_PID, syslog_facility)
+rescue
+  $stderr.puts("Error: Could not open connection to syslog, writing to stdout!")
+  quiet = false
+end
+
+# If called from the console, we probably want to see everything.
+if $stdin.isatty then
+  quiet = false
+end
+
+# Return value
+$retval = 0
+
+# Did we get an argument? If so, it's probably from incrond!
+
+cmdline = Hash.new
+ARGV.each_index do |i|
+  if ARGV[i+1] == '=' then
+    cmdline[ARGV[i]] = ARGV[i+2]
+  elsif ARGV[i] =~ /(.*)=(.*)/ then
+    cmdline[$1] = $2
+  else
+    cmdline[ARGV[i]] = nil
+  end
+end
+
+# Search through the servers and find one that works, die otherwise.
+# Create a connection to LDAP and bind it
+conn = nil
+servers.each do |svr|
+  begin
+    Timeout::timeout(tmout) do
+      begin
+        s = TCPSocket.new(svr,<%= @port %>)
+        s.close
+      rescue Errno::ECONNREFUSED, Effno::EHOSTUNREACH
+        raise Exception
+      end
+
+      # Attempt to bind with svr
+      # See https://github.com/ruby-ldap/ruby-net-ldap/ for configuration options.
+      # NOTE: Binding with the host will automatically cease once the code block
+      # is executed; only open() will create a persistent connection which requires
+      # closing.
+      conn_opts = {:host => svr, :port => <%= @port %>, :auth => {:method => :simple, :username => dn, :password => pw}}
+      if tls == 'ssl' then
+        conn_opts[:encryption] = :simple_tls
+      elsif tls ==  'start_tls'
+        conn_opts[:encryption] = :start_tls
+      end
+      conn = Net::LDAP.new(conn_opts)
+      conn.bind
+
+    end
+  rescue Exception => e
+    msg = [
+      "Warning: Got exception '#{e}' of type '#{e.class}' while",
+      "trying to connect to #{svr}"
+    ]
+    if e.class == Net::LDAP::ResultStrings and e.to_s == 'Invalid Credentials' then
+      msg << "  * This may be because the keys on this system are not trusted by #{svr}."
+    end
+    if not quiet then
+      $stderr.puts(msg.join("\n"))
+    end
+
+    Syslog.err(msg.join("\n"))
+
+    conn = nil
+    next
+  end
+
+  server = svr
+  break
+end
+
+begin
+  # Use a successfully bound connection (above) to grab all uid/gid pairs
+  # and save to a results hash.
+  results = Hash.new
+  uid = nil
+  gid = nil
+  conn and conn.search(
+    :base => userou,
+    :filter => '(objectClass=*)',
+    :scope => <%= t_scope %>,
+    :return_result => true,
+    :attributes => ['uid', 'gidNumber']
+  ) do |entry|
+    entry.each do |attr, value|
+      attr = attr.to_s.strip
+      uid = value if attr == 'uid'
+      gid = value if attr == 'gidnumber'
+    end
+    if not (uid.nil? or gid.nil?) then
+      results[uid] = gid
+    end
+  end
+
+  # Do some preliminary safety checks.
+  if not File.directory?(export_dir) then
+    raise Exception("Export directory not found: #{export_dir}")
+  end
+  if export_dir.eql?('/') then
+    raise Exception('Refusing to modify "/"')
+  end
+
+  # Variables to record what we've added and deleted.
+  current_dirs = (Dir.glob("#{export_dir}/*").map{|x| x = File.basename(x)} - ['ARCHIVED'])
+  new_dirs = (results.keys - current_dirs)
+  to_be_archived = (current_dirs - results.keys)
+
+  # Iterate through the new_dirs and create
+  # and copy skel
+  new_dirs.each do |dir|
+    puts "Creating: #{dir}" if not quiet
+    Syslog.log(syslog_priority, "Creating: #{dir}")
+    FileUtils.mkdir "#{export_dir}/#{dir}", :mode => 0700
+    FileUtils.cp_r "#{skel_dir}/.", "#{export_dir}/#{dir}", :preserve => true
+    FileUtils.chown_R "#{dir}", results[dir], "#{export_dir}/#{dir}"
+  end
+
+# We only want to blow things away if the connection actually succeded.
+  if !conn.nil? then
+    # Check to make sure archive directory exists
+    if not File.directory?("#{export_dir}/ARCHIVED") then
+      FileUtils.mkdir "#{export_dir}/ARCHIVED", :mode => 0750
+    end
+    # Actually move the directory
+    to_be_archived.each do |dir|
+      puts "Archiving: #{dir}" if not quiet
+      Syslog.log(syslog_priority, "Archiving: #{dir}")
+      FileUtils.mv "#{export_dir}/#{dir}", "#{export_dir}/ARCHIVED/#{dir}_#{Time.now.strftime('%Y_%m_%d_%H%M%S')}"
+    end
+  end
+rescue Exception => err
+  $stderr.puts("Error: #{err.message}")
+  Syslog.err("Error: #{err.message}")
+  exit 1
+end
+
+exit $retval


### PR DESCRIPTION
Migrated create_home_dirs class from the nfs module.  Converted
the create_home_dirs template from ruby-ldap to ruby-net-ldap.

SIMP-1266 #close
SIMP-1270 #comment move create_home_dirs
SIMP-1240 #comment update create_home_dirs
