### PR TITLE
(SIMP-1586) Fix beaker reference in Gemfile

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Sep 29 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.2.8-0
+- Fixed beaker reference in Gemfile.
+
 * Tue Aug 09 2016 Nick Markowski <nmarkowski@keywcorp.com> - 1.2.7-0
 - Fixed an invalid data type in simp::nfs::export_home.
 

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ end
 group :system_tests do
   #gem 'beaker'
   # Need this for SELinux workarounds until the PR gets accepted
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker', :ref => 'BKR-896'
+  gem 'beaker'
   gem 'beaker-rspec'
   gem 'simp-beaker-helpers', '>= 1.0.5'
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,13 +1,16 @@
 {
-  "name":    "simp-simp",
-  "version": "1.2.7",
-  "author":  "simp",
+  "name": "simp-simp",
+  "version": "1.2.8",
+  "author": "simp",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-simp",
+  "source": "https://github.com/simp/pupmod-simp-simp",
   "project_page": "https://github.com/simp/pupmod-simp-simp",
-  "issues_url":   "https://simp/project.atlassian.net",
-  "tags": [ "simp", "profiles"],
+  "issues_url": "https://simp/project.atlassian.net",
+  "tags": [
+    "simp",
+    "profiles"
+  ],
   "dependencies": [
     {
       "name": "simp/aide",


### PR DESCRIPTION
The Gemfile still referred to the BKR-896 branch of
https://github.com/trevor-vaughan/beaker, which has since been merged
into the upstream project.  This commit modifies the Gemfile to point to
the correct upstream location.

SIMP-1586 #close