### PR TITLE
(SIMP-1593)Add ES and Grafana GPG keys to yum conf

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Oct 3 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 1.2.9-0
+- Added Elasticsearch and Grafana Keys to yum config
+
 * Thu Sep 29 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.2.8-0
 - Fixed beaker reference in Gemfile.
 

--- a/lib/puppet/parser/functions/simp_yumrepo_gpgkeys.rb
+++ b/lib/puppet/parser/functions/simp_yumrepo_gpgkeys.rb
@@ -23,6 +23,8 @@ module Puppet::Parser::Functions
       RPM-GPG-KEY-puppetlabs
       RPM-GPG-KEY-SIMP
       RPM-GPG-KEY-EPEL
+      RPM-GPG-KEY-elasticsearch
+      RPM-GPG-KEY-grafana
     )
 
     case "#{Facter.value('operatingsystem')}#{Facter.value('operatingsystemmajrelease')}"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "author": "simp",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",


### PR DESCRIPTION
Elasticsearch and Grafana would not install because the
GPG keys were missing from the SIMP repo yum config file.

SIMP-1593 #comment
