### PR TITLE
(SIMP-1684) Remove pupmod-simp-sysctl

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -102,7 +102,6 @@ fixtures:
     sudo: https://github.com/simp/pupmod-simp-sudo
     sudosh: https://github.com/simp/pupmod-simp-sudosh
     svckill: https://github.com/simp/pupmod-simp-svckill
-    sysctl: https://github.com/simp/pupmod-simp-sysctl
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
     tftpboot: https://github.com/simp/pupmod-simp-tftpboot
     upstart: https://github.com/simp/pupmod-simp-upstart

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Dec 02 2016 Nick Markowski <nmarkowski@keywcorp.com> - 2.0.1-0
+- Removed pupmod-simp-sysctl in favor of augeas-sysctl
+
 * Thu Nov 29 2016 Nicholas Hughes Nick Markowski <nmarkowski@keywcorp.com> - 2.0.0-0
 - Introduced rsyslog rule orders so messages hit 'stop' rules before they
   reach 'catch-alls'.  By doing so, log duplication is prevented.

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -62,8 +62,8 @@ Requires: pupmod-simp-sudosh >= 5.0.0-0
 Requires: pupmod-simp-sudosh < 6.0.0-0
 Requires: pupmod-simp-svckill >= 2.0.0-0
 Requires: pupmod-simp-svckill < 3.0.0-0
-Requires: pupmod-simp-sysctl >= 5.0.0-0
-Requires: pupmod-simp-sysctl < 6.0.0-0
+Requires: pupmod-herculesteam-augeasproviders_sysctl < 3.0.0-0
+Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.1.0-0
 Requires: pupmod-simp-tcpwrappers >= 5.0.0-0
 Requires: pupmod-simp-tcpwrappers < 6.0.0-0
 Requires: pupmod-simp-tftpboot >= 5.0.0-0

--- a/manifests/rsyslog/stock/log_server.pp
+++ b/manifests/rsyslog/stock/log_server.pp
@@ -175,8 +175,8 @@ class simp::rsyslog::stock::log_server (
     }
     if $use_default_dhcpd_rules {
       rsyslog::rule::local { '0_default_dhcpd':
-        rule      => 'if ($programname == \'dhcpd\') then',
-        dyna_file => 'dhcpd_template',
+        rule            => 'if ($programname == \'dhcpd\') then',
+        dyna_file       => 'dhcpd_template',
         stop_processing => true
       }
     }
@@ -234,22 +234,22 @@ class simp::rsyslog::stock::log_server (
     }
     if $use_default_message_rules {
       rsyslog::rule::local { '9_default_message':
-        rule      => '*.info;mail.none;authpriv.none;cron.none;local6.none;local5.none',
-        dyna_file => 'messages_template',
+        rule            => '*.info;mail.none;authpriv.none;cron.none;local6.none;local5.none',
+        dyna_file       => 'messages_template',
         stop_processing => true
       }
     }
     if $use_default_mail_rules {
       rsyslog::rule::local { '0_default_mail':
-        rule      => 'mail.*',
-        dyna_file => 'maillog_template',
+        rule            => 'mail.*',
+        dyna_file       => 'maillog_template',
         stop_processing => true
       }
     }
     if $use_default_cron_rules {
       rsyslog::rule::local { '0_default_cron':
-        rule      => 'cron.*',
-        dyna_file => 'cron_template',
+        rule            => 'cron.*',
+        dyna_file       => 'cron_template',
         stop_processing => true
       }
     }
@@ -261,15 +261,15 @@ class simp::rsyslog::stock::log_server (
     }
     if $use_default_spool_rules {
       rsyslog::rule::local { '0_default_spool':
-        rule      => 'if ($syslogfacility-text == \'uucp\' or ($syslogfacility-text == \'news\' and $syslogpriority-text == \'crit\')) then',
-        dyna_file => 'spooler_template',
+        rule            => 'if ($syslogfacility-text == \'uucp\' or ($syslogfacility-text == \'news\' and $syslogpriority-text == \'crit\')) then',
+        dyna_file       => 'spooler_template',
         stop_processing => true
       }
     }
     if $use_default_boot_rules {
       rsyslog::rule::local { '0_default_boot':
-        rule      => 'local7.*',
-        dyna_file => 'boot_template',
+        rule            => 'local7.*',
+        dyna_file       => 'boot_template',
         stop_processing => true
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",


### PR DESCRIPTION
Replaced sysctl::value with augeas 'sysctl' native type.

SIMP-1684 #comment done in simp-simp
SIMP-2247 #close