### PR TITLE
(SIMP-2003) Fixed the acceptance tests

### DIFF
--- a/spec/acceptance/suites/default/01_mcollective_spec.rb
+++ b/spec/acceptance/suites/default/01_mcollective_spec.rb
@@ -3,6 +3,20 @@ require 'spec_helper_acceptance'
 test_name 'simp::mcollective class'
 
 describe 'simp::mcollective class' do
+  before(:context) do
+    hosts.each do |host|
+      interfaces = fact_on(host, 'interfaces').strip.split(',')
+      interfaces.delete_if do |x|
+        x =~ /^lo/
+      end
+
+      interfaces.each do |iface|
+        if fact_on(host, "ipaddress_#{iface}").strip.empty?
+          on(host, "ifup #{iface}", :accept_all_exit_codes => true)
+        end
+      end
+    end
+  end
 
   let(:servers){ hosts_with_role( hosts, 'mco_server' ) }
   let(:clients){ hosts_with_role( hosts, 'mco_client' ) }

--- a/spec/acceptance/suites/default/03_nfs_spec.rb
+++ b/spec/acceptance/suites/default/03_nfs_spec.rb
@@ -3,6 +3,20 @@ require 'spec_helper_acceptance'
 test_name 'simp nfs stock classes'
 
 describe 'simp nfs stock classes' do
+  before(:context) do
+    hosts.each do |host|
+      interfaces = fact_on(host, 'interfaces').strip.split(',')
+      interfaces.delete_if do |x|
+        x =~ /^lo/
+      end
+
+      interfaces.each do |iface|
+        if fact_on(host, "ipaddress_#{iface}").strip.empty?
+          on(host, "ifup #{iface}", :accept_all_exit_codes => true)
+        end
+      end
+    end
+  end
 
   let(:servers) { hosts_with_role( hosts, 'nfs_server' ) }
   let(:clients) { hosts_with_role( hosts, 'client' ) }

--- a/spec/acceptance/suites/default/04_rsyslog_spec.rb
+++ b/spec/acceptance/suites/default/04_rsyslog_spec.rb
@@ -3,6 +3,20 @@ require 'spec_helper_acceptance'
 test_name 'simp rsyslog stock classes'
 
 describe 'simp rsyslog stock classes' do
+  before(:context) do
+    hosts.each do |host|
+      interfaces = fact_on(host, 'interfaces').strip.split(',')
+      interfaces.delete_if do |x|
+        x =~ /^lo/
+      end
+
+      interfaces.each do |iface|
+        if fact_on(host, "ipaddress_#{iface}").strip.empty?
+          on(host, "ifup #{iface}", :accept_all_exit_codes => true)
+        end
+      end
+    end
+  end
 
   let(:servers) { hosts_with_role( hosts, 'rsyslog_server' ) }
 


### PR DESCRIPTION
The acceptance tests were failing both because the network interfaces
were not being re-enabled and because the SELinux contexts were not
being set properly in the YUM test.

The MCO test is still failing due to our MCO module not handling the AIO
package properly but that's not a problem with running the tests
inherently and will need additional work.

SIMP-2003 #comment Fixed acceptance tests