### PR TITLE
(SIMP-2238) Create profile using kmod module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -66,6 +66,7 @@ fixtures:
     java_ks:
       repo: https://github.com/simp/puppetlabs-java_ks
       branch: simp-master
+    kmod: https://github.com/simp/puppet-kmod.git
     krb5: https://github.com/simp/pupmod-simp-krb5
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     mcollective:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Dec 05 2016 Nick Miller <nick.miller@onyxpoint.com> - 2.0.1-0
+- Added simp::kmod_blacklist profile to manage the kernel blacklist using puppet-kmod
+  - config migrated from simplib
+
 * Thu Dec 02 2016 Nick Markowski <nmarkowski@keywcorp.com> - 2.0.1-0
 - Removed pupmod-simp-sysctl in favor of augeas-sysctl
 

--- a/manifests/kmod_blacklist.pp
+++ b/manifests/kmod_blacklist.pp
@@ -1,0 +1,48 @@
+# This class provides a default set of blacklist entries per the SCAP
+# Security Guide.
+#
+# @param enable_defaults Boolean
+#   Enable to use the default blacklist, otherwise just the custom_blacklist will be used.
+#
+# @param default_blacklist Array[String]
+#   List of kernel modules to be included by default
+#
+# @param custom_blacklist Array[String]
+#   Other kernel modules to be blacklisted
+#
+class simp::kmod_blacklist (
+  Boolean $enable_defaults = true,
+  Array[String] $default_blacklist = [
+    'bluetooth',
+    'cramfs',
+    'dccp',
+    'dccp_ipv4',
+    'dccp_ipv6',
+    'freevxfs',
+    'hfs',
+    'hfsplus',
+    'ieee1394',
+    'jffs2',
+    'net-pf-31',
+    'rds',
+    'sctp',
+    'squashfs',
+    'tipc',
+    'udf',
+    'usb-storage'
+  ],
+  Array[String] $custom_blacklist = []
+) {
+
+  if $enable_defaults {
+    $blacklist = $custom_blacklist + $default_blacklist
+  }
+  else {
+    $blacklist = $custom_blacklist
+  }
+
+  $blacklist.each |String $mod| {
+    kmod::blacklist { $mod: }
+  }
+
+}

--- a/manifests/kmod_blacklist.pp
+++ b/manifests/kmod_blacklist.pp
@@ -4,7 +4,7 @@
 # @param enable_defaults Boolean
 #   Enable to use the default blacklist, otherwise just the custom_blacklist will be used.
 #
-# @param default_blacklist Array[String]
+# @param blacklist Array[String]
 #   List of kernel modules to be included by default
 #
 # @param custom_blacklist Array[String]
@@ -12,7 +12,7 @@
 #
 class simp::kmod_blacklist (
   Boolean $enable_defaults = true,
-  Array[String] $default_blacklist = [
+  Array[String] $blacklist = [
     'bluetooth',
     'cramfs',
     'dccp',
@@ -35,13 +35,13 @@ class simp::kmod_blacklist (
 ) {
 
   if $enable_defaults {
-    $blacklist = $custom_blacklist + $default_blacklist
+    $_blacklist = $custom_blacklist + $blacklist
   }
   else {
-    $blacklist = $custom_blacklist
+    $_blacklist = $custom_blacklist
   }
 
-  $blacklist.each |String $mod| {
+  $_blacklist.each |String $mod| {
     kmod::blacklist { $mod: }
   }
 

--- a/spec/classes/kmod_blacklist_spec.rb
+++ b/spec/classes/kmod_blacklist_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'simp::kmod_blacklist' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts['augeasversion'] = '1.4.0'
+          facts
+        end
+
+        let(:stock_blacklist) {
+          ['bluetooth', 'cramfs', 'dccp', 'dccp_ipv4',
+           'dccp_ipv6', 'freevxfs', 'hfs', 'hfsplus',
+           'ieee1394', 'jffs2', 'net-pf-31', 'rds', 'sctp',
+           'squashfs', 'tipc', 'udf', 'usb-storage']
+        }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp::kmod_blacklist') }
+
+        context 'with default parameters' do
+          it 'should blacklist all the default kmods' do
+            stock_blacklist.each do |mod|
+              is_expected.to create_kmod__blacklist(mod)
+            end
+          end
+        end
+
+        context 'with custom kmods' do
+          let(:custom_list) { ['nfs','fuse'] }
+          let(:params) {{ :custom_blacklist => custom_list }}
+          it 'should include all the kmods in the blacklist' do
+            (stock_blacklist + custom_list).each do |mod|
+              is_expected.to create_kmod__blacklist(mod)
+            end
+          end
+        end
+
+        context 'with the default list disabled' do
+          let(:custom_list) { ['nfs','fuse'] }
+          let(:params) {{
+            :enable_defaults  => false,
+            :custom_blacklist => custom_list
+          }}
+          it 'should include only the custom the kmods in the blacklist' do
+            custom_list.each do |mod|
+              is_expected.to create_kmod__blacklist(mod)
+            end
+          end
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to remove the module_blacklist class from simplib, we forked
the camptocamp/puppet-kmod module. This commit adds a profile to include
the settings that were previously in the manifest from simplib.

SIMP-2238 #close
SIMP-1679 #comment created profile for kmod blacklist settings