### PR TITLE
(SIMP-2436) Control ctrl-alt-del behavior

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Jan 05 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.0.1-0
+- Added a 'simp::ctrl_alt_del' class for managing the behavior of giving a
+  system the three finger death punch
+
 * Mon Dec 05 2016 Nick Miller <nick.miller@onyxpoint.com> - 2.0.1-0
 - Added simp::kmod_blacklist profile to manage the kernel blacklist using puppet-kmod
   - config migrated from simplib

--- a/files/etc/systemd/system/ctrl-alt-del.target
+++ b/files/etc/systemd/system/ctrl-alt-del.target
@@ -1,5 +1,5 @@
 [Unit]
-Description=Ctrl-Alt-Delete Capture
+Description=Ctrl-Alt-Delete Capture - Managed by Puppet
 Documentation=man:systemd.special(7)
 DefaultDependencies=no
 Wants=ctrl-alt-del-capture.service

--- a/files/etc/systemd/system/ctrl-alt-del.target
+++ b/files/etc/systemd/system/ctrl-alt-del.target
@@ -1,0 +1,6 @@
+[Unit]
+Description=Ctrl-Alt-Delete Capture
+Documentation=man:systemd.special(7)
+DefaultDependencies=no
+Wants=ctrl-alt-del-capture.service
+AllowIsolate=no

--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -90,25 +90,25 @@ class simp::admin (
     if $logged_shell == 'sudosh' {
       include '::sudosh'
 
-      $_shell_cmd = '/usr/bin/sudosh'
+      $_shell_cmd = ['/usr/bin/sudosh']
     }
   }
   else {
-    $_shell_cmd = 'ALL'
+    $_shell_cmd = ['ALL']
   }
 
   sudo::user_specification { 'admin_global':
-    user_list => "%${admin_group}",
+    user_list => ["%${admin_group}"],
     host_list => [$facts['fqdn']],
     runas     => 'ALL',
-    cmnd      => [$_shell_cmd],
+    cmnd      => $_shell_cmd,
     passwd    => !$passwordless_admin_sudo
   }
 
   # The following two are especially important if you're using sudosh.
   # They allow you to recover from destroying the certs in your environment.
   sudo::user_specification { 'admin_run_puppet':
-    user_list => "%${admin_group}",
+    user_list => ["%${admin_group}"],
     host_list => [$facts['fqdn']],
     runas     => 'root',
     cmnd      => ['/usr/sbin/puppet', '/opt/puppetlabs/bin/puppet'],
@@ -116,18 +116,18 @@ class simp::admin (
   }
 
   sudo::user_specification { 'admin_clean_puppet_certs':
-    user_list => "%${admin_group}",
+    user_list => ["%${admin_group}"],
     host_list => [$facts['fqdn']],
     runas     => 'root',
-    cmnd      => "/bin/rm -rf ${facts['puppet_settings']['ssldir']}",
+    cmnd      => ["/bin/rm -rf ${facts['puppet_settings']['ssldir']}"],
     passwd    => !$passwordless_admin_sudo
   }
 
   sudo::user_specification { 'auditors':
-    user_list => "%${auditor_group}",
+    user_list => ["%${auditor_group}"],
     host_list => [$facts['fqdn']],
     runas     => 'root',
-    cmnd      => 'AUDIT',
+    cmnd      => ['AUDIT'],
     passwd    => !$passwordless_auditor_sudo
   }
 }

--- a/manifests/ctrl_alt_del.pp
+++ b/manifests/ctrl_alt_del.pp
@@ -1,0 +1,110 @@
+# Manage the state of pressing ``ctrl-alt-del``
+#
+# @param enable
+#   Allow ``ctrl-alt-del`` to restart the system
+#
+# @param log
+#   Instead of just disabling the command, set the system up to write a log
+#   entry when the key combination is pressed
+#
+# @param log_users
+#   Record all logged in users in the log message
+#
+# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+#
+class simp::ctrl_alt_del (
+  Boolean                   $enable    = false,
+  Boolean                   $log       = true,
+  Boolean                   $log_users = true,
+  Simplib::Syslog::Facility $facility  = 'local6',
+  Simplib::Syslog::Severity $severity  = 'warning'
+) {
+
+  if 'systemd' in $facts['init_systems'] {
+    $_logger = '/bin/echo -n'
+  }
+  else {
+    $_logger = "/bin/logger -p ${facility}.${severity}"
+  }
+
+  if $log {
+    if $log_users {
+      $_log_cmnd = "/bin/sh -c \"${_logger} 'Ctrl-Alt-Del detected - Logged in users:' `/usr/bin/who | /bin/cut -f1 -d' ' | /bin/sort -u | /usr/bin/tr '\\n' ' '`\""
+    }
+    else {
+      $_log_cmnd = "/bin/sh -c \"${_logger} 'Ctrl-Alt-Del detected'\""
+    }
+  }
+
+  if 'systemd' in $facts['init_systems'] {
+    if $enable {
+      file { '/etc/systemd/system/ctrl-alt-del.target': ensure => 'absent' }
+      file { '/etc/systemd/system/ctrl-alt-del-capture.service': ensure => 'absent' }
+    }
+    else {
+      if $log {
+        file { '/etc/systemd/system/ctrl-alt-del.target':
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0644',
+          content => file("${module_name}/etc/systemd/system/ctrl-alt-del.target")
+        }
+
+        file { '/etc/systemd/system/ctrl-alt-del-capture.service':
+          ensure  => 'file',
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0640',
+          content => template("${module_name}/etc/systemd/system/ctrl-alt-del-capture.service.erb")
+        }
+      }
+      else {
+        file { '/etc/systemd/system/ctrl-alt-del.target':
+          ensure => 'symlink',
+          target => '/dev/null',
+          force  => true
+        }
+
+        file { '/etc/systemd/system/ctrl-alt-del-capture.service': ensure => 'absent' }
+      }
+
+      File['/etc/systemd/system/ctrl-alt-del.target'] ~> Exec['ctrl_alt_del_systemd_reexec']
+      File['/etc/systemd/system/ctrl-alt-del-capture.service'] ~> Exec['ctrl_alt_del_systemd_reexec']
+    }
+
+    exec { 'ctrl_alt_del_systemd_reexec':
+      refreshonly => true,
+      command     => '/bin/systemctl daemon-reexec'
+    }
+  }
+  elsif 'upstart' in $facts['init_systems'] {
+    include '::upstart'
+
+    if $enable {
+      upstart::job { 'control-alt-delete':
+        main_process => '/sbin/shutdown -r now "Control-Alt-Delete pressed"',
+        start_on     => 'control-alt-delete',
+        description  => 'Logs that Ctrl-Alt-Del was pressed without rebooting the system.'
+      }
+    }
+    else {
+      if $log {
+        upstart::job { 'control-alt-delete':
+          main_process => $_log_cmnd,
+          start_on     => 'control-alt-delete',
+          description  => 'Logs that Ctrl-Alt-Del was pressed without rebooting the system.'
+        }
+      }
+      else {
+        upstart::job { 'control-alt-delete':
+          main_process => '/bin/true',
+          start_on     => 'control-alt-delete',
+          description  => 'Logs that Ctrl-Alt-Del was pressed without rebooting the system.'
+        }
+      }
+    }
+  }
+  else {
+    fail('Could not find a supported init system')
+  }
+}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -49,7 +49,7 @@ class simp::server (
     }
 
     sudo::user_specification { 'default_simp':
-      user_list => 'simp',
+      user_list => ['simp'],
       runas     => 'root',
       cmnd      => ['/bin/su root', '/bin/su - root']
     }

--- a/spec/classes/ctrl_alt_del_spec.rb
+++ b/spec/classes/ctrl_alt_del_spec.rb
@@ -1,0 +1,126 @@
+require 'spec_helper'
+
+describe 'simp::ctrl_alt_del' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+
+        shared_examples_for "a systemd system" do
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to create_class('simp::ctrl_alt_del') }
+
+          it { is_expected.to create_file('/etc/systemd/system/ctrl-alt-del.target') }
+          it {
+            is_expected.to create_file('/etc/systemd/system/ctrl-alt-del-capture.service')
+              .with_content(/SyslogFacility=local6/)
+          }
+          it {
+            is_expected.to create_file('/etc/systemd/system/ctrl-alt-del-capture.service')
+              .with_content(/SyslogLevel=warning/)
+          }
+        end
+
+        shared_examples_for "an upstart system" do
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to create_class('simp::ctrl_alt_del') }
+          it { is_expected.to create_class('upstart') }
+
+          it { is_expected.to create_upstart__job('control-alt-delete').with_start_on('control-alt-delete') }
+        end
+
+        if facts[:init_systems].include?('systemd')
+          it_behaves_like 'a systemd system'
+
+          it {
+            is_expected.to create_file('/etc/systemd/system/ctrl-alt-del-capture.service')
+              .with_content(
+                %r{ExecStart=/bin/sh -c "/bin/echo -n 'Ctrl-Alt-Del detected - Logged in users:' `/usr/bin/who | /bin/cut -f1 -d' ' | /bin/sort -u | /usr/bin/tr '\\n' ' '`"\n}
+              )
+          }
+
+          context 'when not logging users' do
+            let(:params){{
+              :log_users => false
+            }}
+
+            it_behaves_like 'a systemd system'
+
+            it {
+              is_expected.to create_file('/etc/systemd/system/ctrl-alt-del-capture.service')
+                .with_content(
+                  %r{ExecStart=/bin/sh -c "/bin/echo -n 'Ctrl-Alt-Del detected'"\n}
+                )
+            }
+          end
+
+          context 'when not logging' do
+            let(:params){{
+              :log => false
+            }}
+
+            it { is_expected.to compile.with_all_deps }
+
+            it { is_expected.to create_file('/etc/systemd/system/ctrl-alt-del.target').with_target('/dev/null') }
+            it { is_expected.to create_file('/etc/systemd/system/ctrl-alt-del-capture.service').with_ensure('absent') }
+          end
+
+          context 'when allowing ctrl-alt-del' do
+            let(:params){{
+              :enable => true
+            }}
+
+            it { is_expected.to compile.with_all_deps }
+
+            it { is_expected.to create_file('/etc/systemd/system/ctrl-alt-del.target').with_ensure('absent') }
+            it { is_expected.to create_file('/etc/systemd/system/ctrl-alt-del-capture.service').with_ensure('absent') }
+          end
+        elsif facts[:init_systems].include?('upstart')
+          it_behaves_like 'an upstart system'
+
+          it { is_expected.to create_upstart__job('control-alt-delete').with_main_process(
+            %{/bin/sh -c "/bin/logger -p local6.warning 'Ctrl-Alt-Del detected - Logged in users:' `/usr/bin/who | /bin/cut -f1 -d' ' | /bin/sort -u | /usr/bin/tr '\\n' ' '`"}
+          )}
+
+          context 'when not logging users' do
+            let(:params){{
+              :log_users => false
+            }}
+
+            it_behaves_like 'an upstart system'
+
+            it { is_expected.to create_upstart__job('control-alt-delete').with_main_process(%{/bin/sh -c "/bin/logger -p local6.warning 'Ctrl-Alt-Del detected'"}) }
+          end
+
+          context 'when not logging' do
+            let(:params){{
+              :log => false
+            }}
+
+            it_behaves_like 'an upstart system'
+
+            it { is_expected.to create_upstart__job('control-alt-delete').with_main_process('/bin/true') }
+          end
+
+          context 'when allowing ctrl-alt-del' do
+            let(:params){{
+              :enable => true
+            }}
+
+            it_behaves_like 'an upstart system'
+
+            it { is_expected.to create_upstart__job('control-alt-delete').with_main_process('/sbin/shutdown -r now "Control-Alt-Delete pressed"') }
+          end
+        else
+          it {
+            expect {
+              is_expected.to compile.with_all_deps
+            }.to raise_error(/not find supported init/)
+          }
+        end
+      end
+    end
+  end
+end

--- a/templates/etc/systemd/system/ctrl-alt-del-capture.service.erb
+++ b/templates/etc/systemd/system/ctrl-alt-del-capture.service.erb
@@ -1,0 +1,13 @@
+[Unit]
+Description=Log calls to Ctrl-Alt-Delete
+
+[Service]
+Type=simple
+StandardOutput=syslog
+SyslogIdentifier=ctrl-alt-del
+SyslogFacility=<%= @facility %>
+SyslogLevel=<%= @severity %>
+ExecStart=<%= @_log_cmnd %>
+
+[Install]
+WantedBy=ctrl-alt-del.target

--- a/templates/etc/systemd/system/ctrl-alt-del-capture.service.erb
+++ b/templates/etc/systemd/system/ctrl-alt-del-capture.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description=Log calls to Ctrl-Alt-Delete
+Description=Log calls to Ctrl-Alt-Delete - Managed by Puppet
 
 [Service]
 Type=simple


### PR DESCRIPTION
This conflicts with the old 'upstart' class but provides full control
over the behavior of ctrl-alt-del in both systemd and upstart

SIMP-2436 #close