### PR TITLE
(SIMP-2469) Move clamav and mcafee to top

### DIFF
--- a/manifests/server/rsync_shares.pp
+++ b/manifests/server/rsync_shares.pp
@@ -87,13 +87,13 @@ class simp::server::rsync_shares (
 
       rsync::server::section { "mcafee_${_env}":
         comment     => "McAfee DAT files for Environment ${_env}",
-        path        => "${rsync_base}/${_env}/${_rsync_subdir}/mcafee",
+        path        => "${rsync_base}/${_env}/mcafee",
         hosts_allow => $_trusted_nets
       }
 
       rsync::server::section { "clamav_${_env}":
         comment     => "ClamAV Virus Database Updates for Environment ${_env}",
-        path        => "${rsync_base}/${_env}/${_rsync_subdir}/clamav",
+        path        => "${rsync_base}/${_env}/clamav",
         hosts_allow => $_trusted_nets
       }
 


### PR DESCRIPTION
This moved the clamav and mcafee virus definitions to the top level of
the rsync environment since they will be shared across all of the
clients.

SIMP-2469 #comment Move clamav and mcafee defs to top