### PR TITLE
(SIMP-2495) Remove class includes from simp::server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Jan 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 2.0.1-0
+- Removing including of simp::server::* classes from the simp::server
+  class in favor of including them in the class list in hiera.
+
 * Wed Jan 18 2017 Nick Miller <nick.miller@onyxpoint.com> - 2.0.1-0
 - Removed any dangling references or dependencies on ganglia or snmpd
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -26,16 +26,8 @@
 #
 class simp::server (
   Boolean $allow_simp_user     = false,
-  Boolean $enable_rsync_shares = true,
-  Boolean $enable_kickstart    = true,
-  Boolean $enable_ldap         = true,
-  Boolean $enable_yum          = true,
   Boolean $pam                 = simplib::lookup('simp_options::pam', { 'default_value' => false })
 ) {
-  if $enable_rsync_shares { include '::simp::server::rsync_shares' }
-  if $enable_kickstart { include '::simp::server::kickstart' }
-  if $enable_ldap { include '::simp::server::ldap' }
-  if $enable_yum { include '::simp::server::yum' }
 
   if $allow_simp_user {
     if $pam {

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -35,7 +35,6 @@ describe 'simp::server' do
         context 'with default parameters' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('simp::server') }
-          it { is_expected.to create_class('simp::server::rsync_shares') }
           it { is_expected.not_to create_pam__access__rule('allow_simp') }
           it { is_expected.not_to create_sudo__user_specification('default_simp') }
         end
@@ -48,20 +47,10 @@ describe 'simp::server' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('simp::server') }
-          it { is_expected.to create_class('simp::server::rsync_shares') }
           it { is_expected.to create_pam__access__rule('allow_simp') }
           it { is_expected.to create_sudo__user_specification('default_simp') }
         end
 
-        context 'without rsync shares' do
-          let(:params){{
-            :enable_rsync_shares => false
-          }}
-
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_class('simp::server') }
-          it { is_expected.to_not create_class('simp::server::rsync_shares') }
-        end
       end
     end
   end


### PR DESCRIPTION
Removing including of simp::server::* classes from the simp::server
class in favor of including them in the class list in hiera.

SIMP-2495 #close