### PR TITLE
(SIMP-2485) Remove ipv6 catalyst

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 * Tue Jan 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 2.0.1-0
 - Removing including of simp::server::* classes from the simp::server
   class in favor of including them in the class list in hiera.
-
-* Wed Jan 18 2017 Nick Miller <nick.miller@onyxpoint.com> - 2.0.1-0
 - Removed any dangling references or dependencies on ganglia or snmpd
+- Rearranged logic in sysctl and removed the ipv6 catalyst. ipv6 will now be
+  unmanaged by default.
 
 * Thu Jan 05 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.0.1-0
 - Added a 'simp::ctrl_alt_del' class for managing the behavior of giving a

--- a/manifests/base_apps.pp
+++ b/manifests/base_apps.pp
@@ -28,7 +28,6 @@ class simp::base_apps (
     'dos2unix',
     'elinks',
     'hunspell',
-    'lslk',
     'lsof',
     'man',
     'man-pages',

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -140,7 +140,7 @@ class simp::sysctl (
   Boolean              $core_dumps                                     = false,
   Stdlib::AbsolutePath $core_dump_dir                                  = '/var/core',
   Boolean              $pam                                            = simplib::lookup('simp_options::pam', { 'default_value' => false }),
-  Boolean              $ipv6                                           = simplib::lookup('simp_options::ipv6', { 'default_value' => false })
+  Optional[Boolean]    $ipv6                                           = undef
 ) {
 
   validate_sysctl_value('kernel.core_pattern',$kernel__core_pattern)
@@ -233,26 +233,26 @@ class simp::sysctl (
         sysctl { 'kernel.exec-shield': value => $kernel__exec_shield }
       }
 
-      if $ipv6 {
-        sysctl { 'net.ipv6.conf.all.disable_ipv6': value => 0 }
-          ->
-        sysctl {
-          'net.ipv6.conf.all.accept_redirects'         : value => $net__ipv6__conf__all__accept_redirects;
-          'net.ipv6.conf.all.autoconf'                 : value => $net__ipv6__conf__all__autoconf;
-          'net.ipv6.conf.all.forwarding'               : value => $net__ipv6__conf__all__forwarding;
-          'net.ipv6.conf.default.accept_ra'            : value => $net__ipv6__conf__default__accept_ra;
-          'net.ipv6.conf.default.accept_ra_defrtr'     : value => $net__ipv6__conf__default__accept_ra_defrtr;
-          'net.ipv6.conf.default.accept_ra_pinfo'      : value => $net__ipv6__conf__default__accept_ra_pinfo;
-          'net.ipv6.conf.default.accept_ra_rtr_pref'   : value => $net__ipv6__conf__default__accept_ra_rtr_pref;
-          'net.ipv6.conf.default.accept_redirects'     : value => $net__ipv6__conf__default__accept_redirects;
-          'net.ipv6.conf.default.autoconf'             : value => $net__ipv6__conf__default__autoconf;
-          'net.ipv6.conf.default.dad_transmits'        : value => $net__ipv6__conf__default__dad_transmits;
-          'net.ipv6.conf.default.max_addresses'        : value => $net__ipv6__conf__default__max_addresses;
-          'net.ipv6.conf.default.router_solicitations' : value => $net__ipv6__conf__default__router_solicitations;
+      if $ipv6 !~ Undef {
+        $_ipv6 = $ipv6 ? { true => 0, false => 1 }
+        sysctl { 'net.ipv6.conf.all.disable_ipv6': value => $_ipv6 }
+        if $ipv6 {
+          sysctl {
+            default                                      : require => Sysctl['net.ipv6.conf.all.disable_ipv6'];
+            'net.ipv6.conf.all.accept_redirects'         : value => $net__ipv6__conf__all__accept_redirects;
+            'net.ipv6.conf.all.autoconf'                 : value => $net__ipv6__conf__all__autoconf;
+            'net.ipv6.conf.all.forwarding'               : value => $net__ipv6__conf__all__forwarding;
+            'net.ipv6.conf.default.accept_ra'            : value => $net__ipv6__conf__default__accept_ra;
+            'net.ipv6.conf.default.accept_ra_defrtr'     : value => $net__ipv6__conf__default__accept_ra_defrtr;
+            'net.ipv6.conf.default.accept_ra_pinfo'      : value => $net__ipv6__conf__default__accept_ra_pinfo;
+            'net.ipv6.conf.default.accept_ra_rtr_pref'   : value => $net__ipv6__conf__default__accept_ra_rtr_pref;
+            'net.ipv6.conf.default.accept_redirects'     : value => $net__ipv6__conf__default__accept_redirects;
+            'net.ipv6.conf.default.autoconf'             : value => $net__ipv6__conf__default__autoconf;
+            'net.ipv6.conf.default.dad_transmits'        : value => $net__ipv6__conf__default__dad_transmits;
+            'net.ipv6.conf.default.max_addresses'        : value => $net__ipv6__conf__default__max_addresses;
+            'net.ipv6.conf.default.router_solicitations' : value => $net__ipv6__conf__default__router_solicitations;
+          }
         }
-      }
-      else {
-        sysctl { 'net.ipv6.conf.all.disable_ipv6': value => 1 }
       }
     }
     default : {

--- a/spec/classes/sysctl_spec.rb
+++ b/spec/classes/sysctl_spec.rb
@@ -12,12 +12,19 @@ describe 'simp::sysctl' do
         it { is_expected.to create_class('simp::sysctl') }
         it { is_expected.not_to create_file('/var/core').that_comes_before('Sysctl[kernel.core_pattern]') }
         it { is_expected.not_to create_file('/var/core').that_comes_before('Sysctl[kernel.core_uses_pid]') }
-        it { is_expected.to create_sysctl('net.ipv6.conf.all.disable_ipv6').with(:value => 1 ) }
+        it { is_expected.not_to create_sysctl('net.ipv6.conf.all.disable_ipv6').with(:value => 1 ) }
       end
 
-      context "with ipv6 = true" do
+      context "with ipv6 => true" do
         let(:params) {{ :ipv6 => true }}
         it { is_expected.to create_sysctl('net.ipv6.conf.all.disable_ipv6').with(:value => 0 ) }
+        it { is_expected.to create_sysctl('net.ipv6.conf.all.accept_redirects').with(:value => 0 ) }
+      end
+
+      context "with ipv6 => false" do
+        let(:params) {{ :ipv6 => false }}
+        it { is_expected.to create_sysctl('net.ipv6.conf.all.disable_ipv6').with(:value => 1 ) }
+        it { is_expected.not_to create_sysctl('net.ipv6.conf.all.accept_redirects') }
       end
 
       context "kernel__core_pattern with absolute path" do


### PR DESCRIPTION
- Rearranged logic in sysctl and removed the ipv6 catalyst. ipv6 will
  now be unmanaged by default.

SIMP-2485 #close