### PR TITLE
(SIMP-2427) Update to use simp_openldap

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -103,7 +103,7 @@ fixtures:
     simpcat: https://github.com/simp/pupmod-simp-concat
     simplib: https://github.com/simp/pupmod-simp-simplib
     simp_apache: https://github.com/simp/pupmod-simp-apache
-    #simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap
+    simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     ssh: https://github.com/simp/pupmod-simp-ssh
     stdlib: https://github.com/simp/puppetlabs-stdlib
@@ -121,4 +121,3 @@ fixtures:
     xinetd: https://github.com/simp/pupmod-simp-xinetd
   symlinks:
     simp: "#{source_dir}"
-    simp_openldap: "#{source_dir}/../simp_openldap"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -87,7 +87,6 @@ fixtures:
       branch: simp-master
     ntpd: https://github.com/simp/pupmod-simp-ntpd
     oddjob: https://github.com/simp/pupmod-simp-oddjob
-    openldap: https://github.com/simp/pupmod-simp-openldap
     pam: https://github.com/simp/pupmod-simp-pam
     pki: https://github.com/simp/pupmod-simp-pki
     postfix: https://github.com/simp/pupmod-simp-postfix
@@ -104,6 +103,7 @@ fixtures:
     simpcat: https://github.com/simp/pupmod-simp-concat
     simplib: https://github.com/simp/pupmod-simp-simplib
     simp_apache: https://github.com/simp/pupmod-simp-apache
+    #simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     ssh: https://github.com/simp/pupmod-simp-ssh
     stdlib: https://github.com/simp/puppetlabs-stdlib
@@ -121,3 +121,4 @@ fixtures:
     xinetd: https://github.com/simp/pupmod-simp-xinetd
   symlinks:
     simp: "#{source_dir}"
+    simp_openldap: "#{source_dir}/../simp_openldap"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
-#  PE/SIMP versions
-#  app    pup  ruby
-# 2015.2  4.3  2.1.7
-# 2015.3  4.3  2.1.8
-# 2016.1  4.4  2.1.9
-# 2016.2  4.5  2.1.9
-# S6.0.0  4.7  2.1.9
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2015.2   4.2   2.1.7  2017-03-17
+# PE 2015.3   4.3   2.1.8  2017-03-17
+# PE 2016.1   4.4   2.1.9  2017-03-17 (yes: all three EOL on the same day!)
+# PE 2016.2   4.5   2.1.9  2017-04-30
+# PE 2016.4   4.7   2.1.9  TBD (LTS)
+# PE 2016.5   4.8   2.1.9  TBD
+# SIMP6.0.0   4.8   2.1.9  TBD
 ---
 language: ruby
 sudo: false
@@ -24,17 +27,17 @@ env:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+    - PUPPET_VERSION="~> 4.8.1"
     - PUPPET_VERSION="~> 4.7.0"
     - PUPPET_VERSION="~> 4.5.0"
-    - PUPPET_VERSION="~> 3.8.0"
     - PUPPET_VERSION="~> 4.4.0"
     - PUPPET_VERSION="~> 4.3.0"
-    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
   fast_finish: true
   allow_failures:
+    - env: PUPPET_VERSION="~> 4.7.0"
     - env: PUPPET_VERSION="~> 4.5.0"
-    - env: PUPPET_VERSION="~> 3.8.0"
     - env: PUPPET_VERSION="~> 4.4.0"
     - env: PUPPET_VERSION="~> 4.3.0"
-    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.2.0"

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -31,8 +31,8 @@ Requires: pupmod-simp-named < 7.0.0-0
 Requires: pupmod-simp-named >= 6.0.0-0
 Requires: pupmod-simp-ntpd < 7.0.0-0
 Requires: pupmod-simp-ntpd >= 6.0.0-0
-Requires: pupmod-simp-openldap < 7.0.0-0
-Requires: pupmod-simp-openldap >= 6.0.0-0
+Requires: pupmod-simp-simp_openldap < 7.0.0-0
+Requires: pupmod-simp-simp_openldap >= 6.0.0-0
 Requires: pupmod-simp-pam < 7.0.0-0
 Requires: pupmod-simp-pam >= 6.0.0-0
 Requires: pupmod-simp-pki < 7.0.0-0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,7 +136,7 @@ class simp (
   }
 
   if $ldap {
-    include '::openldap::client'
+    include '::simp_openldap::client'
 
   }
 

--- a/manifests/server/ldap.pp
+++ b/manifests/server/ldap.pp
@@ -9,12 +9,12 @@
 #   ldap::master will be used as the master server.
 #
 #   If you want to use values other than the defaults as provided with
-#   openldap::server::syncrepl. Leave this as 'false', include this
-#   class and call openldap::server::syncrepl with your values as
+#   simp_openldap::server::syncrepl. Leave this as 'false', include this
+#   class and call simp_openldap::server::syncrepl with your values as
 #   appropriate.
 #
 # @param rid
-#   The RID of the system. See openldap::server::syncrepl for
+#   The RID of the system. See simp_openldap::server::syncrepl for
 #   additional information.
 #
 # @param bind_dn
@@ -41,26 +41,26 @@ class simp::server::ldap (
 ){
 
   # Order matters with these top two!
-  include '::openldap'
-  include '::openldap::server'
-  include '::openldap::slapo::ppolicy'
-  include '::openldap::slapo::syncprov'
-  if $enable_lastbind { include '::openldap::slapo::lastbind' }
+  include '::simp_openldap'
+  include '::simp_openldap::server'
+  include '::simp_openldap::slapo::ppolicy'
+  include '::simp_openldap::slapo::syncprov'
+  if $enable_lastbind { include '::simp_openldap::slapo::lastbind' }
 
   $s_rid = to_string($rid)
   if $is_slave {
-    openldap::server::syncrepl { $s_rid: }
+    simp_openldap::server::syncrepl { $s_rid: }
   }
 
   if !empty($bind_dn) {
-    openldap::server::limits { 'Host_Bind_DN_Unlimited_Query':
+    simp_openldap::server::limits { 'Host_Bind_DN_Unlimited_Query':
       who    => $bind_dn,
       limits => ['size.soft=unlimited','size.hard=unlimited','size.prtotal=unlimited']
     }
   }
 
   if !empty($sync_dn) {
-    openldap::server::limits { 'LDAP_Sync_DN_Unlimited_Query':
+    simp_openldap::server::limits { 'LDAP_Sync_DN_Unlimited_Query':
       who    => $sync_dn,
       limits => ['size.soft=unlimited','size.hard=unlimited','size.prtotal=unlimited']
     }

--- a/metadata.json
+++ b/metadata.json
@@ -81,7 +81,7 @@
       "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
-      "name": "simp/openldap",
+      "name": "simp/simp_openldap",
       "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {

--- a/spec/classes/server/ldap_spec.rb
+++ b/spec/classes/server/ldap_spec.rb
@@ -26,14 +26,14 @@ describe 'simp::server::ldap' do
           let(:params){{ :is_slave => true }}
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_openldap__server__syncrepl('111') }
+          it { is_expected.to create_simp_openldap__server__syncrepl('111') }
         end
 
         context 'use_lastbind' do
           let(:params){{ :enable_lastbind => true }}
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_class('openldap::slapo::lastbind') }
+          it { is_expected.to create_class('simp_openldap::slapo::lastbind') }
         end
       end
     end


### PR DESCRIPTION
Migrated all 'openldap' calls to 'simp_openldap' to prep for the future
backend change.

SIMP-2427 #comment Updated the 'simp' module