### PR TITLE
(SIMP-2578) Updated rsync stunnel logic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Feb 06 2017 Nick Markowski <nmarkowski@keywcorp.com> - 2.0.1-0
+- Modified rsync stunnel logic to add a connection to the rsync server
+  only if the machine is *not* the rsync server.
+
 * Wed Jan 18 2017 Nick Miller <nick.miller@onyxpoint.com> - 2.0.1-0
 - Removing including of simp::server::* classes from the simp::server
   class in favor of including them in the class list in hiera.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -167,9 +167,11 @@ class simp (
       $_rsync_stunnel_svr = $rsync_stunnel
     }
 
-    stunnel::connection { 'rsync':
-      connect => ["${_rsync_stunnel_svr}:8730"],
-      accept  => '127.0.0.1:873'
+    if !host_is_me($_rsync_stunnel_svr) {
+      stunnel::connection { 'rsync':
+        connect => ["${_rsync_stunnel_svr}:8730"],
+        accept  => '127.0.0.1:873'
+      }
     }
   }
 }


### PR DESCRIPTION
- Modified rsync stunnel logic to add a connection to the rsync server
  only if the machine is *not* the rsync server.

SIMP-2578 #close