### PR TITLE
(SIMP-2682) Fix filebucketing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,11 @@
-* Mon Feb 06 2017 Nick Markowski <nmarkowski@keywcorp.com> - 2.0.1-0
+* Tue Feb 14 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.0.0-0
+- Ensure that the filebucket is appropriately set for both local and remote use
+
+* Mon Feb 06 2017 Nick Markowski <nmarkowski@keywcorp.com> - 3.0.0-0
 - Modified rsync stunnel logic to add a connection to the rsync server
   only if the machine is *not* the rsync server.
 
-* Wed Jan 18 2017 Nick Miller <nick.miller@onyxpoint.com> - 2.0.1-0
+* Wed Jan 18 2017 Nick Miller <nick.miller@onyxpoint.com> - 3.0.0-0
 - Removing including of simp::server::* classes from the simp::server
   class in favor of including them in the class list in hiera.
 - Removed any dangling references or dependencies on ganglia or snmpd
@@ -11,7 +14,7 @@
 - Beefed up simp::server class to include more default classes
 - Made $rsync_stunnel enabled by default
 
-* Thu Jan 05 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.0.1-0
+* Thu Jan 05 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.0.0-0
 - Added a 'simp::ctrl_alt_del' class for managing the behavior of giving a
   system the three finger death punch
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,7 +97,7 @@ class simp (
   Boolean                         $puppet_server_hosts_entry  = true,
   Boolean                         $enable_filebucketing       = false,
   String                          $filebucket_name            = 'simp',
-  Optional[Simplib::Host]      $filebucket_server          = undef,
+  Optional[Simplib::Host]         $filebucket_server          = undef,
   Stdlib::Absolutepath            $filebucket_path            = "${facts['puppet_vardir']}/simp/filebucket",
   Boolean                         $use_sudoers_aliases        = true,
   Simp::Runlevel                  $runlevel                   = 3,
@@ -105,10 +105,10 @@ class simp (
   Boolean                         $manage_root_metadata       = true,
   Boolean                         $manage_root_perms          = true,
   Boolean                         $manage_rc_local            = true,
-  Boolean                         $pam                        = simplib::lookup('simp_options::pam', { 'default_value' => false }),
-  Boolean                         $fips                       = simplib::lookup('simp_options::fips', { 'default_value' => false }),
-  Boolean                         $ldap                       = simplib::lookup('simp_options::ldap', { 'default_value' => false }),
-  Boolean                         $sssd                       = simplib::lookup('simp_options::sssd', { 'default_value' => true }),
+  Boolean                         $pam                        = simplib::lookup('simp_options::pam', { 'default_value'   => false }),
+  Boolean                         $fips                       = simplib::lookup('simp_options::fips', { 'default_value'  => false }),
+  Boolean                         $ldap                       = simplib::lookup('simp_options::ldap', { 'default_value'  => false }),
+  Boolean                         $sssd                       = simplib::lookup('simp_options::sssd', { 'default_value'  => true }),
   Boolean                         $stock_sssd                 = true
 ) {
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,11 +13,29 @@ describe 'simp' do
           facts
         end
 
-        context 'with default parameters' do
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_file('/opt/puppetlabs/puppet/cache/simp') }
-          it { is_expected.to create_host('puppet.bar.baz').with_ip('1.2.3.4') }
-          it { is_expected.to create_stunnel__connection('rsync') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_file('/opt/puppetlabs/puppet/cache/simp') }
+        it { is_expected.to create_host('puppet.bar.baz').with_ip('1.2.3.4') }
+        it { is_expected.to create_stunnel__connection('rsync') }
+        it { is_expected.to_not create_filebucket('simp') }
+
+        context 'with filebucketing' do
+          context 'with local path' do
+            let(:params) {{ :enable_filebucketing => true }}
+
+            it { is_expected.to create_file('/etc/rc.d/rc.local').with_backup('simp') }
+            it { is_expected.to create_filebucket('simp').with_path("#{facts[:puppet_vardir]}/simp/filebucket") }
+          end
+
+          context 'with remote server' do
+            let(:params) {{
+              :enable_filebucketing => true,
+              :filebucket_server    => 'my.puppet.server'
+            }}
+
+            it { is_expected.to create_file('/etc/rc.d/rc.local').with_backup('simp') }
+            it { is_expected.to create_filebucket('simp').with_server(params[:filebucket_server]) }
+          end
         end
 
         context 'rsync_stunnel logic' do


### PR DESCRIPTION
This change ensures that filebucketing, if enabled, will either send to
a remote server or will place files in a separate directory on the
local system.

The system now also defaults to disabling filebucketing

SIMP-2682 #close