### PR TITLE
(SIMP-2692) Remove dist gpgkey from simp repo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Feb 01 2017 Nick Miller <nick.miller@onyxpoint.com> - 2.0.1-0
+- Refine list of GPG keys used by simp::yum::server
+
 * Mon Feb 06 2017 Nick Markowski <nmarkowski@keywcorp.com> - 2.0.1-0
 - Modified rsync stunnel logic to add a connection to the rsync server
   only if the machine is *not* the rsync server.

--- a/lib/puppet/parser/functions/simp_yumrepo_gpgkeys.rb
+++ b/lib/puppet/parser/functions/simp_yumrepo_gpgkeys.rb
@@ -22,7 +22,6 @@ module Puppet::Parser::Functions
       'RPM-GPG-KEY-puppet',
       'RPM-GPG-KEY-puppetlabs',
       'RPM-GPG-KEY-SIMP',
-      'RPM-GPG-KEY-EPEL',
       'RPM-GPG-KEY-elasticsearch',
       'RPM-GPG-KEY-grafana'
     ]

--- a/lib/puppet/parser/functions/simp_yumrepo_gpgkeys.rb
+++ b/lib/puppet/parser/functions/simp_yumrepo_gpgkeys.rb
@@ -1,5 +1,4 @@
 module Puppet::Parser::Functions
-
   newfunction(:simp_yumrepo_gpgkeys, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
     Take a URL and a list of YUM servers and return a valid list of
     GPG Keys that pertain to the SIMP load.
@@ -18,47 +17,23 @@ module Puppet::Parser::Functions
       raise Puppet::ParseError, "simp_yumrepo_gpgkeys(): expects the second argument to be an array or string, got #{args[0].inspect} which is of type #{args[0].class}"
     end
 
-    # Common GPG Keys
-    gpg_keys = %w(
-      RPM-GPG-KEY-puppetlabs
-      RPM-GPG-KEY-SIMP
-      RPM-GPG-KEY-EPEL
-      RPM-GPG-KEY-elasticsearch
-      RPM-GPG-KEY-grafana
-    )
+    # Common gpg keys, distributed in simp-gpgkeys
+    gpg_keys = [
+      'RPM-GPG-KEY-puppet',
+      'RPM-GPG-KEY-puppetlabs',
+      'RPM-GPG-KEY-SIMP',
+      'RPM-GPG-KEY-EPEL',
+      'RPM-GPG-KEY-elasticsearch',
+      'RPM-GPG-KEY-grafana'
+    ]
 
-    case "#{Facter.value('operatingsystem')}#{Facter.value('operatingsystemmajrelease')}"
-      when /(RedHat|CentOS)6/
-        gpg_keys += %w(
-          RPM-GPG-KEY-EPEL-6
-        )
-        case "#{Facter.value('operatingsystem')}"
-          when /CentOS/
-            gpg_keys += %w(
-              RPM-GPG-KEY-CentOS-6
-              RPM-GPG-KEY-CentOS-Security-6
-            )
-          when /RedHat/
-            gpg_keys += %w(
-              RPM-GPG-KEY-redhat-release
-            )
-        end
-      when /(RedHat|CentOS)7/
-        gpg_keys += %w(
-          RPM-GPG-KEY-EPEL-7
-        )
-        case "#{Facter.value('operatingsystem')}"
-          when /CentOS/
-            gpg_keys += %w(
-              RPM-GPG-KEY-CentOS-7
-            )
-          when /RedHat/
-            gpg_keys += %w(
-              RPM-GPG-KEY-redhat-release
-            )
-        end
-      else
-        Puppet.warning("#{Facter.value('operatingsystem')} #{Facter.value('operatingsystemmajrelease')}  support not yet complete")
+    os_name    = Facter.value('os')['name']
+    os_maj_rel = Facter.value('os')['release']['major']
+
+    if ['RedHat','CentOS'].include? os_name
+      gpg_keys << 'RPM-GPG-KEY-EPEL-6' if os_maj_rel == '6'
+      gpg_keys << 'RPM-GPG-KEY-EPEL-7' if os_maj_rel == '7'
+      gpg_keys << 'RPM-GPG-KEY-redhat-release' if os_name == 'RedHat'
     end
 
     toret = []
@@ -68,6 +43,5 @@ module Puppet::Parser::Functions
     end
 
     toret.flatten.join("\n    ")
-
   end
 end

--- a/lib/puppet/parser/functions/simp_yumrepo_gpgkeys.rb
+++ b/lib/puppet/parser/functions/simp_yumrepo_gpgkeys.rb
@@ -23,7 +23,8 @@ module Puppet::Parser::Functions
       'RPM-GPG-KEY-puppetlabs',
       'RPM-GPG-KEY-SIMP',
       'RPM-GPG-KEY-elasticsearch',
-      'RPM-GPG-KEY-grafana'
+      'RPM-GPG-KEY-grafana',
+      'RPM-GPG-KEY-PGDG-94'
     ]
 
     os_name    = Facter.value('os')['name']

--- a/spec/classes/yum_spec.rb
+++ b/spec/classes/yum_spec.rb
@@ -5,33 +5,21 @@ describe 'simp::yum' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         let(:facts) do
-          if ['RedHat','CentOS'].include?(facts[:operatingsystem]) && facts[:operatingsystemmajrelease].to_s < '7'
-            facts[:apache_version] = '2.2'
-            facts[:grub_version] = '0.9'
-            facts[:init_systems] = ['rc','sysv','upstart']
-          else
-            facts[:apache_version] = '2.4'
-            facts[:grub_version] = '2.0~beta'
-            facts[:init_systems] = ['rc','sysv','systemd']
-          end
-
-          facts[:selinux_current_mode] = 'enforcing'
-
           facts
         end
 
+        # it { require 'pry';binding.pry }
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_yumrepo('simp').with({
-            :gpgkey => %r(^https://yum.bar.baz/yum/SIMP),
+            :gpgkey  => %r(^https://yum.bar.baz/yum/SIMP),
             :baseurl => %r(^https://yum.bar.baz/yum/SIMP)
-          })
-        }
-        if facts[:operatingsystemmajrelease].to_s == '6' and facts[:operatingsystem] == 'CentOS'
+        }) }
+
+        if facts[:os][:release][:major].to_s == '6' and facts[:os][:name] == 'CentOS'
           it { is_expected.to create_yumrepo('os_updates').with({
-              :gpgkey => %r(^https://yum.bar.baz/yum/CentOS/6/x86_64/RPM-GPG-KEY-CentOS-6),
+              :gpgkey  => %r(^https://yum.bar.baz/yum/CentOS/6/x86_64/RPM-GPG-KEY-CentOS-6),
               :baseurl => %r(^https://yum.bar.baz/yum/CentOS/6/x86_64/Updates)
-            })
-          }
+          }) }
         end
       end
     end

--- a/spec/functions/simp_yumrepo_gpgkeys_spec.rb
+++ b/spec/functions/simp_yumrepo_gpgkeys_spec.rb
@@ -86,7 +86,10 @@ describe 'simp_yumrepo_gpgkeys' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         before :each do
-          Facter.stubs(:value).with('os').returns facts[:os]
+          # SIMP's provided facts use symbols as keys, which are not accessible
+          # in Puppet. See SIMP-2696
+          structured_os = { 'name' => facts[:os][:name].to_s, 'release' => { 'major' => facts[:os][:release][:major].to_s } }
+          Facter.stubs(:value).with('os').returns structured_os
         end
 
         let(:facts) { facts }

--- a/spec/functions/simp_yumrepo_gpgkeys_spec.rb
+++ b/spec/functions/simp_yumrepo_gpgkeys_spec.rb
@@ -12,49 +12,49 @@ describe 'simp_yumrepo_gpgkeys' do
 
   let(:url) { 'https://YUM_SERVER/yum/SIMP' }
   let(:servers) { ['1.1.1.1', '2.2.2.2'] }
-  let(:expected_output) {
-    { 'centos-6-x86_64' =>
-      "https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
+  let(:expected_output) {{
+    'centos-6-x86_64' =>
+      "https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
+      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6\n" +
-      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-6\n" +
-      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-Security-6\n" +
+      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
-      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6\n" +
-      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-6\n" +
-      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-Security-6",
+      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6",
 
-      'centos-7-x86_64' =>
-      "https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
+    'centos-7-x86_64' =>
+      "https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
+      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7\n" +
-      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-7\n" +
+      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
-      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7\n" +
-      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-7",
+      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7",
 
-      'redhat-6-x86_64' =>
-      "https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
+    'redhat-6-x86_64' =>
+      "https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
+      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-redhat-release\n" +
+      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
@@ -63,14 +63,16 @@ describe 'simp_yumrepo_gpgkeys' do
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-redhat-release",
 
-      'redhat-7-x86_64' =>
-      "https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
+    'redhat-7-x86_64' =>
+      "https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
+      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-redhat-release\n" +
+      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
@@ -78,17 +80,13 @@ describe 'simp_yumrepo_gpgkeys' do
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-redhat-release"
-
-    }
-
-  }
+  }}
 
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         before :each do
-          Facter.stubs(:value).with('operatingsystem').returns facts[:operatingsystem]
-          Facter.stubs(:value).with('operatingsystemmajrelease').returns facts[:operatingsystemmajrelease]
+          Facter.stubs(:value).with('os').returns facts[:os]
         end
 
         let(:facts) { facts }

--- a/spec/functions/simp_yumrepo_gpgkeys_spec.rb
+++ b/spec/functions/simp_yumrepo_gpgkeys_spec.rb
@@ -17,14 +17,12 @@ describe 'simp_yumrepo_gpgkeys' do
       "https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
-      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
-      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6",
@@ -33,14 +31,12 @@ describe 'simp_yumrepo_gpgkeys' do
       "https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
-      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
-      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7",
@@ -49,7 +45,6 @@ describe 'simp_yumrepo_gpgkeys' do
       "https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
-      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6\n" +
@@ -57,7 +52,6 @@ describe 'simp_yumrepo_gpgkeys' do
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
-      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6\n" +
@@ -67,7 +61,6 @@ describe 'simp_yumrepo_gpgkeys' do
       "https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
-      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7\n" +
@@ -75,7 +68,6 @@ describe 'simp_yumrepo_gpgkeys' do
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
-      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7\n" +

--- a/spec/functions/simp_yumrepo_gpgkeys_spec.rb
+++ b/spec/functions/simp_yumrepo_gpgkeys_spec.rb
@@ -19,12 +19,14 @@ describe 'simp_yumrepo_gpgkeys' do
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
+      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-94\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
+      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-94\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6",
 
     'centos-7-x86_64' =>
@@ -33,12 +35,14 @@ describe 'simp_yumrepo_gpgkeys' do
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
+      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-94\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
+      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-94\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7",
 
     'redhat-6-x86_64' =>
@@ -47,6 +51,7 @@ describe 'simp_yumrepo_gpgkeys' do
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
+      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-94\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-redhat-release\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
@@ -54,6 +59,7 @@ describe 'simp_yumrepo_gpgkeys' do
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
+      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-94\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-6\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-redhat-release",
 
@@ -63,6 +69,7 @@ describe 'simp_yumrepo_gpgkeys' do
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
+      "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-94\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7\n" +
       "    https://1.1.1.1/yum/SIMP/GPGKEYS/RPM-GPG-KEY-redhat-release\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet\n" +
@@ -70,6 +77,7 @@ describe 'simp_yumrepo_gpgkeys' do
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana\n" +
+      "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-94\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-7\n" +
       "    https://2.2.2.2/yum/SIMP/GPGKEYS/RPM-GPG-KEY-redhat-release"
   }}


### PR DESCRIPTION
Previously, the simp repo on clients would have the distribution gpg
keys available. This is incorrect.

This commit also adds the new puppet gpg key and removes the old EPEL 5 key.

SIMP-2692 #close
SIMP-2690 #comment puppet gpg key added to simp/simp