### PR TITLE
(SIMP-2742) Clarify sysctl's ipv6 local variables

### DIFF
--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -233,9 +233,9 @@ class simp::sysctl (
         sysctl { 'kernel.exec-shield': value => $kernel__exec_shield }
       }
 
-      if $ipv6 !~ Undef {
-        $_ipv6 = $ipv6 ? { true => 0, false => 1 }
-        sysctl { 'net.ipv6.conf.all.disable_ipv6': value => $_ipv6 }
+      unless $ipv6.is_a(Undef) {
+        $_disable_ipv6 = $ipv6 ? { true => 0, false => 1 }
+        sysctl { 'net.ipv6.conf.all.disable_ipv6': value => $_disable_ipv6 }
         if $ipv6 {
           sysctl {
             default                                      : require => Sysctl['net.ipv6.conf.all.disable_ipv6'];


### PR DESCRIPTION
Prior to this `simp::sysctl` used a local variable, `$_ipv6`, which held
the value to `net.ipv6.conf.all.disable_ipv6`.  That was confusing,
because the value is whether or not to disable IPv6, the inverse of
expected meaning.  This commit changes the name of the local variable to
`$_disable_ipv6`.

SIMP-2742 #close