### PR TITLE
WIP: (SIMP-2839) Add test for installing via r10k

### DIFF
--- a/spec/acceptance/suites/r10k/01_simp_server_spec.rb
+++ b/spec/acceptance/suites/r10k/01_simp_server_spec.rb
@@ -1,0 +1,172 @@
+require 'spec_helper_acceptance'
+
+test_name 'puppetserver via r10k'
+
+describe 'install environment via r10k and puppetserver' do
+
+  masters     = hosts_with_role(hosts, 'master')
+  agents      = hosts_with_role(hosts, 'agent')
+  master_fqdn = fact_on(master, 'fqdn')
+  master_manifest = <<-EOF
+    # Set up a puppetserver
+    # class { 'pupmod': firewall => true, }
+    class { 'pupmod::master':
+      firewall     => true,
+      trusted_nets => ['ALL'],
+    }
+    # pupmod::master::autosign { '*': entry => '*' }
+    exec { 'set autosign':
+      command => '/opt/puppetlabs/bin/puppet config --section master set autosign true',
+      unless  => '/opt/puppetlabs/bin/puppet config --section master print autosign | grep true'
+    }
+
+    # Maintain connection to the VM
+    pam::access::rule { 'vagrant_all':
+      users      => ['vagrant'],
+      permission => '+',
+      origins    => ['ALL'],
+    }
+    sudo::user_specification { 'vagrant':
+      user_list => ['vagrant'],
+      cmnd      => ['ALL'],
+      passwd    => false,
+    }
+    sshd_config { 'PermitRootLogin'    : value => 'yes' }
+    sshd_config { 'AuthorizedKeysFile' : value => '.ssh/authorized_keys' }
+    include 'tcpwrappers'
+    include 'iptables'
+    tcpwrappers::allow { 'sshd': pattern => 'ALL' }
+    iptables::listen::tcp_stateful { 'allow_ssh':
+      trusted_nets => ['ALL'],
+      dports       => 22
+    }
+  EOF
+
+  hosts.each do |host|
+    it 'should set the root password' do
+      on(host, "sed -i 's/enforce_for_root//g' /etc/pam.d/*")
+      on(host, 'echo password | passwd root --stdin')
+    end
+    it 'should set up needed repositories' do
+      host.install_package('epel-release')
+      on(host, 'curl -s https://packagecloud.io/install/repositories/simp-project/6_X_Dependencies/script.rpm.sh | bash')
+    end
+  end
+
+  context 'master' do
+    masters.each do |master|
+      it 'should apply set up a puppetserver' do
+        apply_manifest_on(master, master_manifest, :accept_all_exit_codes => true)
+        apply_manifest_on(master, master_manifest, :accept_all_exit_codes => true)
+        master.reboot
+        apply_manifest_on(master, master_manifest, :catch_failures => true)
+      end
+      it 'should be idempotent' do
+        apply_manifest_on(master, master_manifest, :catch_changes => true )
+      end
+    end
+  end
+
+  context 'install r10k and modules' do
+    it 'should install the r10k gem' do
+      master.install_package('git')
+      on(master, 'puppet resource package r10k ensure=present provider=puppet_gem')
+    end
+    it 'scp a Puppetfile to $codedir' do
+      scp_to(master, 'spec/acceptance/suites/r10k/files/Puppetfile', '/etc/puppetlabs/code/environments/production/Puppetfile')
+    end
+    it 'should install the Puppetfile' do
+      on(master, 'cd /etc/puppetlabs/code/environments/production; /opt/puppetlabs/puppet/bin/r10k puppetfile install')
+      on(master, 'chown -R root.puppet /etc/puppetlabs/code/environments/production/modules')
+      on(master, 'chmod -R g+rX /etc/puppetlabs/code/environments/production/modules')
+    end
+
+  end
+
+  context 'classify nodes' do
+    site_pp = <<-EOF
+      node default {
+        include 'simp'
+      }
+      node /puppet/ {
+        include 'simp'
+        include 'simp::server'
+        include 'pupmod'
+        include 'pupmod::master'
+      }
+    EOF
+    common_yaml = <<-EOF
+      # Options
+      simp_options::dns::servers: ['8.8.8.8']
+      simp_options::puppet::server: #{master_fqdn}
+      simp_options::puppet::ca: #{master_fqdn}
+      simp_options::ntpd::servers: ['time.nist.gov']
+      simp_options::ldap::bind_pw: 's00per sekr3t!'
+      simp_options::ldap::bind_hash: '{SSHA}foobarbaz!!!!'
+      simp_options::ldap::sync_pw: 's00per sekr3t!'
+      simp_options::ldap::sync_hash: '{SSHA}foobarbaz!!!!'
+      simp_options::ldap::root_hash: '{SSHA}foobarbaz!!!!'
+      simp_options::auditd: true
+      simp_options::haveged: true
+      simp_options::pam: true
+      simp_options::logrotate: true
+      simp_options::selinux: true
+      simp_options::tcpwrappers: true
+
+      # simp_options::log_servers: ['#{master_fqdn}']
+      sssd::domains: ['LOCAL']
+      simp::yum::servers: ['#{master_fqdn}']
+
+      # Settings required for acceptance test, some may be required
+      simp::scenario: simp
+      simp_options::clamav: false
+      simp_options::pki: true
+      simp_options::pki::source: '/etc/pki/simp-testing/pki'
+      simp_options::trusted_nets: ['ALL']
+      simp::yum::os_update_url: http://mirror.centos.org/centos/$releasever/os/$basearch/
+      simp::yum::enable_simp_repos: false
+      simp::scenario::base::puppet_server_hosts_entry: false
+
+      # Settings to make beaker happy
+      sudo::user_specifications:
+        vagrant_all:
+          user_list: ['vagrant']
+          cmnd: ['ALL']
+          passwd: false
+      pam::access::users:
+        defaults:
+          origins:
+            - ALL
+          permission: '+'
+        vagrant:
+      ssh::server::conf::permitrootlogin: true
+      ssh::server::conf::authorizedkeysfile: .ssh/authorized_keys
+    EOF
+    on(master, 'mkdir -p /etc/puppetlabs/code/environments/production/{hieradata,manifests}')
+    scp_to(master, 'spec/acceptance/suites/r10k/files/hiera.yaml', '/etc/puppetlabs/puppet/hiera.yaml')
+    create_remote_file(master, '/etc/puppetlabs/code/environments/production/manifests/site.pp', site_pp)
+    create_remote_file(master, '/etc/puppetlabs/code/environments/production/hieradata/default.yaml', common_yaml)
+    on(master, 'chown -R root.puppet /etc/puppetlabs/code/environments/production/{hieradata,manifests}')
+    on(master, 'chmod -R g+rX /etc/puppetlabs/code/environments/production/{hieradata,manifests}')
+    on(master, 'puppet resource service puppetserver ensure=running')
+  end
+
+  context 'agents' do
+    agents.each do |agent|
+      it 'should run the agent' do
+        # require 'pry';binding.pry if fact_on(agent, 'hostname') == 'agent'
+        on(agent, "puppet agent -t --ca_port 8141 --server #{master_fqdn}", :acceptable_exit_codes => [0,2,4,6])
+        sleep(30)
+        on(agent, "puppet agent -t --ca_port 8141 --server #{master_fqdn}", :acceptable_exit_codes => [0,2,4,6])
+        agent.reboot
+        sleep(180)
+        on(agent, "puppet agent -t --ca_port 8141 --server #{master_fqdn}", :acceptable_exit_codes => [0,2])
+      end
+      it 'should be idempotent' do
+        sleep(30)
+        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0])
+      end
+    end
+  end
+
+end

--- a/spec/acceptance/suites/r10k/02_simp_server_rsync_spec.rb
+++ b/spec/acceptance/suites/r10k/02_simp_server_rsync_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper_acceptance'
+
+test_name 'simp::server::rsync_shares'
+
+describe 'install rsync from GitHub (not rpm) and test simp::server::rsync_shares' do
+  pending('TODO')
+end

--- a/spec/acceptance/suites/r10k/02_simp_server_rsync_spec.rb
+++ b/spec/acceptance/suites/r10k/02_simp_server_rsync_spec.rb
@@ -1,7 +1,126 @@
 require 'spec_helper_acceptance'
+require 'json'
 
 test_name 'simp::server::rsync_shares'
 
 describe 'install rsync from GitHub (not rpm) and test simp::server::rsync_shares' do
-  pending('TODO')
+
+  masters     = hosts_with_role(hosts, 'master')
+  agents      = hosts_with_role(hosts, 'agent')
+  master_fqdn = fact_on(master, 'fqdn')
+
+  context 'master' do
+    masters.each do |master|
+      it 'should prepare the rsync server environment' do
+        tmpdir = create_tmpdir_on(master)
+        # master.install_package('selinux-policy-devel')
+
+        script = <<-EOF
+          mkdir -p /var/simp/environments/simp/rsync
+          git clone https://github.com/simp/simp-rsync.git #{tmpdir}
+          rm -rf /var/simp/environments/{simp,production}/rsync
+          mv -f #{tmpdir}/environments/simp/rsync /var/simp/environments/production/
+          ln -s /var/simp/environments/production/rsync/RedHat /var/simp/environments/production/rsync/CentOS
+          chmod u+rwx,g+rX,o+rX /var/simp{,/environments,/environments/production}
+
+          # SELinux fixes
+          # setfacl --restore=/var/simp/environments/production/rsync/.rsync.facl 2>/dev/null
+          # cd #{tmpdir}/build/selinux; make -f /usr/share/selinux/devel/Makefile
+          # cp #{tmpdir}/build/selinux/simp-rsync.pp /usr/share/selinux/packages
+          # semodule -n -i /usr/share/selinux/packages/simp-rsync.pp
+          # load_policy
+          # fixfiles -R simp-rsync restore
+        EOF
+        on(master, script)
+      end
+      it 'should run freshclam' do
+        master.install_package('clamav-update')
+        scp_to(master, 'spec/acceptance/suites/r10k/files/freshclam.conf', '/tmp/freshclam.conf')
+        on(master, 'freshclam -u root --config-file=/tmp/freshclam.conf')
+      end
+
+      it 'classify nodes' do
+        default_yaml = <<-EOF
+          # Options
+          simp_options::dns::servers: ['8.8.8.8']
+          simp_options::puppet::server: #{master_fqdn}
+          simp_options::puppet::ca: #{master_fqdn}
+          simp_options::ntpd::servers: ['time.nist.gov']
+          simp_options::ldap::bind_pw: 's00per sekr3t!'
+          simp_options::ldap::bind_hash: '{SSHA}foobarbaz!!!!'
+          simp_options::ldap::sync_pw: 's00per sekr3t!'
+          simp_options::ldap::sync_hash: '{SSHA}foobarbaz!!!!'
+          simp_options::ldap::root_hash: '{SSHA}foobarbaz!!!!'
+          simp_options::auditd: true
+          simp_options::haveged: true
+          simp_options::fips: false
+          fips::enabled: false # TODO remove when fips pr is merged
+          simp_options::pam: true
+          simp_options::logrotate: true
+          simp_options::selinux: true
+          simp_options::tcpwrappers: true
+          simp_options::stunnel: true
+          simp_options::firewall: true
+
+          # simp_options::log_servers: ['#{master_fqdn}']
+          sssd::domains: ['LOCAL']
+          simp::yum::servers: ['#{master_fqdn}']
+
+          # Settings required for acceptance test, some may be required
+          simp::scenario: simp
+          simp_options::rsync: true
+          simp_options::clamav: true
+          simp_options::pki: true
+          simp_options::pki::source: '/etc/pki/simp-testing/pki'
+          simp_options::trusted_nets: ['10.0.0.0/8']
+          simp::yum::os_update_url: http://mirror.centos.org/centos/$releasever/os/$basearch/
+          simp::yum::enable_simp_repos: false
+          simp::scenario::base::puppet_server_hosts_entry: false
+          simp::scenario::base::rsync_stunnel: #{master_fqdn}
+
+          # Make sure puppet doesn't run (hopefully)
+          pupmod::agent::cron::minute: '0'
+          pupmod::agent::cron::hour: '0'
+          pupmod::agent::cron::weekday: '0'
+          pupmod::agent::cron::month: '1'
+
+          # Settings to make beaker happy
+          sudo::user_specifications:
+            vagrant_all:
+              user_list: ['vagrant']
+              cmnd: ['ALL']
+              passwd: false
+          pam::access::users:
+            defaults:
+              origins:
+                - ALL
+              permission: '+'
+            vagrant:
+          ssh::server::conf::permitrootlogin: true
+          ssh::server::conf::authorizedkeysfile: .ssh/authorized_keys
+        EOF
+        create_remote_file(master, '/etc/puppetlabs/code/environments/production/hieradata/default.yaml', default_yaml)
+      end
+      it 'should configure the system' do
+        on(master, 'puppet agent -t', :acceptable_exit_codes => [0,2,4,6])
+        on(master, 'puppet agent -t', :acceptable_exit_codes => [0,2])
+      end
+      it 'should be idempotent' do
+        on(master, 'puppet agent -t', :acceptable_exit_codes => [0])
+      end
+    end
+  end
+
+  context 'agents' do
+    agents.each do |agent|
+      it 'should configure the system' do
+        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0,2,4,6])
+        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0,2])
+      end
+      it 'should be idempotent' do
+        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0])
+      end
+    end
+  end
+
 end

--- a/spec/acceptance/suites/r10k/03_simp_server_ldap_spec.rb
+++ b/spec/acceptance/suites/r10k/03_simp_server_ldap_spec.rb
@@ -3,20 +3,115 @@ require 'spec_helper_acceptance'
 test_name 'simp::server::ldap'
 
 describe 'use the simp::server::ldap class to create and ldap environment' do
-  pending('TODO')
+  masters     = hosts_with_role(hosts, 'master')
+  agents      = hosts_with_role(hosts, 'agent')
+  master_fqdn = fact_on(master, 'fqdn')
 
-  # masters     = hosts_with_role(hosts, 'master')
-  # agents      = hosts_with_role(hosts, 'agent')
-  # master_fqdn = fact_on(master, 'fqdn')
-  #
-  # context 'master' do
-  #   masters.each do |master|
-  #   end
-  # end
-  #
-  # context 'agents' do
-  #   agents.each do |agent|
-  #   end
-  # end
+  context 'master' do
+    masters.each do |master|
+      it 'classify nodes' do
+        site_pp = <<-EOF
+          node default {
+            include 'simp_options'
+            include 'simp'
+          }
+          node /puppet/ {
+            include 'simp_options'
+            include 'simp'
+            include 'simp::server'
+            include 'simp::server::ldap'
+            include 'simp::server::rsync_shares'
+            include 'pupmod'
+            include 'pupmod::master'
+          }
+        EOF
+        default_yaml = <<-EOF
+          # Options
+          simp_options::dns::servers: ['8.8.8.8']
+          simp_options::puppet::server: #{master_fqdn}
+          simp_options::puppet::ca: #{master_fqdn}
+          simp_options::ntpd::servers: ['time.nist.gov']
+          simp_options::ldap::bind_pw: 's00persekr3t!'
+          simp_options::ldap::bind_hash: '{SSHA}foobarbaz!!!!'
+          simp_options::ldap::sync_pw: 's00persekr3t!'
+          simp_options::ldap::sync_hash: '{SSHA}foobarbaz!!!!'
+          simp_options::ldap::root_hash: '{SSHA}foobarbaz!!!!'
+          simp_openldap::server::conf::rootpw: 's00persekr3t!'
+          # simp_options::ldap::uri: ['ldap://#{master_fqdn}']
+          # simp_options::ldap::uri: #{master_fqdn}
+          simp_options::ldap: true
+          simp_options::sssd: true
+          simp_options::auditd: true
+          simp_options::haveged: true
+          simp_options::fips: false
+          fips::enabled: false # TODO remove when fips pr is merged
+          simp_options::pam: true
+          simp_options::logrotate: true
+          simp_options::selinux: true
+          simp_options::tcpwrappers: true
+          simp_options::stunnel: true
+          simp_options::firewall: true
+
+          # simp_options::log_servers: ['#{master_fqdn}']
+          sssd::domains: ['LOCAL']
+          simp::yum::servers: ['#{master_fqdn}']
+
+          # Settings required for acceptance test, some may be required
+          simp::scenario: simp
+          simp_options::rsync: true
+          simp_options::clamav: true
+          simp_options::pki: true
+          simp_options::pki::source: '/etc/pki/simp-testing/pki'
+          simp_options::trusted_nets: ['10.0.0.0/8']
+          simp::yum::os_update_url: http://mirror.centos.org/centos/$releasever/os/$basearch/
+          simp::yum::enable_simp_repos: false
+          simp::scenario::base::puppet_server_hosts_entry: false
+          simp::scenario::base::rsync_stunnel: #{master_fqdn}
+
+          # Make sure puppet doesn't run (hopefully)
+          pupmod::agent::cron::minute: '0'
+          pupmod::agent::cron::hour: '0'
+          pupmod::agent::cron::weekday: '0'
+          pupmod::agent::cron::month: '1'
+
+          # Settings to make beaker happy
+          sudo::user_specifications:
+            vagrant_all:
+              user_list: ['vagrant']
+              cmnd: ['ALL']
+              passwd: false
+          pam::access::users:
+            defaults:
+              origins:
+                - ALL
+              permission: '+'
+            vagrant:
+          ssh::server::conf::permitrootlogin: true
+          ssh::server::conf::authorizedkeysfile: .ssh/authorized_keys
+        EOF
+        create_remote_file(master, '/etc/puppetlabs/code/environments/production/manifests/site.pp', site_pp)
+        create_remote_file(master, '/etc/puppetlabs/code/environments/production/hieradata/default.yaml', default_yaml)
+      end
+      it 'should configure the system' do
+        on(master, 'puppet agent -t', :acceptable_exit_codes => [0,2,4,6])
+        on(master, 'puppet agent -t', :acceptable_exit_codes => [0,2])
+      end
+      it 'should be idempotent' do
+        on(master, 'puppet agent -t', :acceptable_exit_codes => [0])
+      end
+    end
+  end
+
+  context 'agents' do
+    agents.each do |agent|
+      it 'should configure the system' do
+        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0,2,4,6])
+        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0,2])
+      end
+      it 'should be idempotent' do
+        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0])
+      end
+    end
+  end
 
 end

--- a/spec/acceptance/suites/r10k/03_simp_server_ldap_spec.rb
+++ b/spec/acceptance/suites/r10k/03_simp_server_ldap_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper_acceptance'
+
+test_name 'simp::server::ldap'
+
+describe 'use the simp::server::ldap class to create and ldap environment' do
+  pending('TODO')
+end

--- a/spec/acceptance/suites/r10k/03_simp_server_ldap_spec.rb
+++ b/spec/acceptance/suites/r10k/03_simp_server_ldap_spec.rb
@@ -4,4 +4,19 @@ test_name 'simp::server::ldap'
 
 describe 'use the simp::server::ldap class to create and ldap environment' do
   pending('TODO')
+
+  # masters     = hosts_with_role(hosts, 'master')
+  # agents      = hosts_with_role(hosts, 'agent')
+  # master_fqdn = fact_on(master, 'fqdn')
+  #
+  # context 'master' do
+  #   masters.each do |master|
+  #   end
+  # end
+  #
+  # context 'agents' do
+  #   agents.each do |agent|
+  #   end
+  # end
+
 end

--- a/spec/acceptance/suites/r10k/files/Puppetfile
+++ b/spec/acceptance/suites/r10k/files/Puppetfile
@@ -1,0 +1,426 @@
+# refs recorded for SIMP release 6.0.0
+# vi:syntax=ruby
+
+mod 'bfraser-grafana',
+  :git => 'https://github.com/simp/puppet-grafana',
+  :ref => 'master'
+
+mod 'camptocamp-kmod',
+  :git => 'https://github.com/simp/puppet-kmod.git',
+  :ref => 'master'
+
+mod 'elastic-elasticsearch',
+  :git => 'https://github.com/simp/puppet-elasticsearch',
+  :ref => 'simp-master'
+
+mod 'elastic-logstash',
+  :git => 'https://github.com/simp/puppet-logstash',
+  :ref => 'master'
+
+mod 'electrical-file_concat',
+  :git => 'https://github.com/simp/puppet-lib-file_concat',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders',
+  :git => 'https://github.com/simp/augeasproviders',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders_apache',
+  :git => 'https://github.com/simp/augeasproviders_apache',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders_base',
+  :git => 'https://github.com/simp/augeasproviders_base',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders_core',
+  :git => 'https://github.com/simp/augeasproviders_core',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders_grub',
+  :git => 'https://github.com/simp/augeasproviders_grub',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders_mounttab',
+  :git => 'https://github.com/simp/augeasproviders_mounttab',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders_nagios',
+  :git => 'https://github.com/simp/augeasproviders_nagios',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders_pam',
+  :git => 'https://github.com/simp/augeasproviders_pam',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders_postgresql',
+  :git => 'https://github.com/simp/augeasproviders_postgresql',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders_puppet',
+  :git => 'https://github.com/simp/augeasproviders_puppet',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders_shellvar',
+  :git => 'https://github.com/simp/augeasproviders_shellvar',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders_ssh',
+  :git => 'https://github.com/simp/augeasproviders_ssh',
+  :ref => 'master'
+
+mod 'herculesteam-augeasproviders_sysctl',
+  :git => 'https://github.com/simp/augeasproviders_sysctl',
+  :ref => 'master'
+
+mod 'onyxpoint-gpasswd',
+  :git => 'https://github.com/simp/puppet-gpasswd',
+  :ref => 'simp-master'
+
+mod 'puppetlabs-apache',
+  :git => 'https://github.com/simp/puppetlabs-apache',
+  :ref => 'master'
+
+# We have updated this module for Puppet 4, and submitted changes upstream. We
+# will use the simp-master branch until it is accepted in master.
+mod 'puppetlabs-concat',
+  :git => 'https://github.com/simp/puppetlabs-concat',
+  :ref => 'simp-master'
+
+mod 'puppetlabs-inifile',
+  :git => 'https://github.com/simp/puppetlabs-inifile',
+  :ref => 'master'
+
+mod 'puppetlabs-java',
+  :git => 'https://github.com/simp/puppetlabs-java',
+  :ref => 'master'
+
+mod 'puppetlabs-java_ks',
+  :git => 'https://github.com/simp/puppetlabs-java_ks',
+  :ref => 'master'
+
+mod 'puppetlabs-motd',
+  :git => 'https://github.com/simp/puppetlabs-motd',
+  :ref => 'master'
+
+mod 'puppetlabs-mysql',
+  :git => 'https://github.com/simp/puppetlabs-mysql',
+  :ref => 'master'
+
+mod 'puppetlabs-postgresql',
+  :git => 'https://github.com/simp/puppetlabs-postgresql',
+  :ref => 'master'
+
+mod 'puppetlabs-stdlib',
+  :git => 'https://github.com/simp/puppetlabs-stdlib',
+  :ref => 'master'
+
+mod 'richardc-datacat',
+  :git => 'https://github.com/simp/puppet-datacat',
+  :ref => 'master'
+
+# SIMP has made changes to this module that don't exist upstream
+mod 'saz-timezone',
+  :git => 'https://github.com/simp/puppet-timezone',
+  :ref => 'simp-master'
+
+mod 'simp-acpid',
+  :git => 'https://github.com/simp/pupmod-simp-acpid',
+  :ref => 'master'
+
+mod 'simp-activemq',
+  :git => 'https://github.com/simp/pupmod-simp-activemq',
+  :ref => 'master'
+
+mod 'simp-aide',
+  :git => 'https://github.com/simp/pupmod-simp-aide',
+  :ref => 'master'
+
+mod 'simp-at',
+  :git => 'https://github.com/simp/pupmod-simp-at',
+  :ref => 'master'
+
+mod 'simp-auditd',
+  :git => 'https://github.com/simp/pupmod-simp-auditd',
+  :ref => 'master'
+
+mod 'simp-autofs',
+  :git => 'https://github.com/simp/pupmod-simp-autofs',
+  :ref => 'master'
+
+mod 'simp-chkrootkit',
+  :git => 'https://github.com/simp/pupmod-simp-chkrootkit',
+  :ref => 'master'
+
+mod 'simp-clamav',
+  :git => 'https://github.com/simp/pupmod-simp-clamav',
+  :ref => 'master'
+
+mod 'simp-compliance_markup',
+  :git => 'https://github.com/simp/pupmod-simp-compliance_markup',
+  :ref => 'master'
+
+mod 'simp-cron',
+  :git => 'https://github.com/simp/pupmod-simp-cron',
+  :ref => 'master'
+
+mod 'simp-dhcp',
+  :git => 'https://github.com/simp/pupmod-simp-dhcp',
+  :ref => 'master'
+
+mod 'simp-dirtycow',
+  :git => 'https://github.com/simp/pupmod-simp-dirtycow.git',
+  :ref => 'master'
+
+mod 'simp-fips',
+  :git => 'https://github.com/simp/pupmod-simp-fips',
+  :ref => 'master'
+
+mod 'simp-freeradius',
+  :git => 'https://github.com/simp/pupmod-simp-freeradius',
+  :ref => 'master'
+
+mod 'simp-gdm',
+  :git => 'https://github.com/simp/pupmod-simp-gdm',
+  :ref => 'master'
+
+mod 'simp-gnome',
+  :git => 'https://github.com/simp/pupmod-simp-gnome',
+  :ref => 'master'
+
+# SIMP has made changes to this module that don't exist upstream
+mod 'simp-haveged',
+  :git => 'https://github.com/simp/puppet-haveged',
+  :ref => 'simp-master'
+
+mod 'simp-incron',
+  :git => 'https://github.com/simp/pupmod-simp-incron',
+  :ref => 'master'
+
+mod 'simp-iptables',
+  :git => 'https://github.com/simp/pupmod-simp-iptables',
+  :ref => 'master'
+
+mod 'simp-issue',
+  :git => 'https://github.com/simp/pupmod-simp-issue',
+  :ref => 'master'
+
+mod 'simp-jenkins',
+  :git => 'https://github.com/simp/pupmod-simp-jenkins',
+  :ref => 'master'
+
+  # SIMP has made changes to this module that don't exist upstream
+mod 'simp-journald',
+  :git => 'https://github.com/simp/pupmod-simp-journald.git',
+  :ref => 'simp-master'
+
+mod 'simp-krb5',
+  :git => 'https://github.com/simp/pupmod-simp-krb5',
+  :ref => 'master'
+
+mod 'simp-libreswan',
+  :git => 'https://github.com/simp/pupmod-simp-libreswan',
+  :ref => 'master'
+
+mod 'simp-libvirt',
+  :git => 'https://github.com/simp/pupmod-simp-libvirt',
+  :ref => 'master'
+
+mod 'simp-logrotate',
+  :git => 'https://github.com/simp/pupmod-simp-logrotate',
+  :ref => 'master'
+
+mod 'simp-mcafee',
+  :git => 'https://github.com/simp/pupmod-simp-mcafee',
+  :ref => 'master'
+
+# SIMP has made changes to this module that don't exist upstream
+mod 'simp-mcollective',
+  :git => 'https://github.com/simp/pupmod-simp-mcollective',
+  :ref => 'simp-master'
+
+mod 'simp-mozilla',
+  :git => 'https://github.com/simp/pupmod-simp-mozilla',
+  :ref => 'master'
+
+mod 'simp-named',
+  :git => 'https://github.com/simp/pupmod-simp-named',
+  :ref => 'master'
+
+mod 'simp-network',
+  :git => 'https://github.com/simp/pupmod-simp-network',
+  :ref => 'master'
+
+mod 'simp-nfs',
+  :git => 'https://github.com/simp/pupmod-simp-nfs',
+  :ref => 'master'
+
+mod 'simp-ntpd',
+  :git => 'https://github.com/simp/pupmod-simp-ntpd',
+  :ref => 'master'
+
+mod 'simp-oddjob',
+  :git => 'https://github.com/simp/pupmod-simp-oddjob',
+  :ref => 'master'
+
+mod 'simp-simp_openldap',
+  :git => 'https://github.com/simp/pupmod-simp-simp_openldap',
+  :ref => 'master'
+
+mod 'simp-openscap',
+  :git => 'https://github.com/simp/pupmod-simp-openscap',
+  :ref => 'master'
+
+mod 'simp-pam',
+  :git => 'https://github.com/simp/pupmod-simp-pam',
+  :ref => 'master'
+
+mod 'simp-pki',
+  :git => 'https://github.com/simp/pupmod-simp-pki',
+  :ref => 'master'
+
+mod 'simp-polkit',
+  :git => 'https://github.com/simp/pupmod-simp-polkit',
+  :ref => 'master'
+
+mod 'simp-postfix',
+  :git => 'https://github.com/simp/pupmod-simp-postfix',
+  :ref => 'master'
+
+mod 'simp-pupmod',
+  :git => 'https://github.com/simp/pupmod-simp-pupmod',
+  :ref => 'master'
+
+mod 'simp-puppetdb',
+  :git => 'https://github.com/simp/puppetlabs-puppetdb',
+  :ref => 'simp-master'
+
+mod 'simp-resolv',
+  :git => 'https://github.com/simp/pupmod-simp-resolv',
+  :ref => 'master'
+
+mod 'simp-rsync',
+  :git => 'https://github.com/simp/pupmod-simp-rsync',
+  :ref => 'master'
+
+mod 'simp-rsyslog',
+  :git => 'https://github.com/simp/pupmod-simp-rsyslog',
+  :ref => 'master'
+
+mod 'simp-selinux',
+  :git => 'https://github.com/simp/pupmod-simp-selinux',
+  :ref => 'master'
+
+mod 'simp-simp',
+  :git => 'https://github.com/simp/pupmod-simp-simp',
+  :ref => 'master'
+
+mod 'simp-simpcat',
+  :git => 'https://github.com/simp/pupmod-simp-simpcat',
+  :ref => 'master'
+
+mod 'simp-simp_apache',
+  :git => 'https://github.com/simp/pupmod-simp-apache',
+  :ref => 'master'
+
+mod 'simp-simp_elasticsearch',
+  :git => 'https://github.com/simp/pupmod-simp-simp_elasticsearch',
+  :ref => 'master'
+
+mod 'simp-simp_grafana',
+  :git => 'https://github.com/simp/pupmod-simp-simp_grafana',
+  :ref => 'master'
+
+mod 'simp-simp_logstash',
+  :git => 'https://github.com/simp/pupmod-simp-simp_logstash',
+  :ref => 'master'
+
+mod 'simp-simp_options',
+  :git => 'https://github.com/simp/pupmod-simp-simp_options',
+  :ref => 'master'
+
+mod 'simp-simp_nfs',
+  :git => 'https://github.com/simp/pupmod-simp-simp_nfs',
+  :ref => 'master'
+
+mod 'simp-simp_rsyslog',
+  :git => 'https://github.com/simp/pupmod-simp-simp_rsyslog',
+  :ref => 'master'
+
+mod 'simp-simplib',
+  :git => 'https://github.com/simp/pupmod-simp-simplib',
+  :ref => 'master'
+
+mod 'simp-site',
+  :git => 'https://github.com/simp/pupmod-simp-site',
+  :ref => 'master'
+
+mod 'simp-ssh',
+  :git => 'https://github.com/simp/pupmod-simp-ssh',
+  :ref => 'master'
+
+mod 'simp-sssd',
+  :git => 'https://github.com/simp/pupmod-simp-sssd',
+  :ref => 'master'
+
+mod 'simp-stunnel',
+  :git => 'https://github.com/simp/pupmod-simp-stunnel',
+  :ref => 'master'
+
+mod 'simp-sudo',
+  :git => 'https://github.com/simp/pupmod-simp-sudo',
+  :ref => 'master'
+
+mod 'simp-sudosh',
+  :git => 'https://github.com/simp/pupmod-simp-sudosh',
+  :ref => 'master'
+
+mod 'simp-svckill',
+  :git => 'https://github.com/simp/pupmod-simp-svckill',
+  :ref => 'master'
+
+mod 'simp-swap',
+  :git => 'https://github.com/simp/pupmod-simp-swap',
+  :ref => 'master'
+
+mod 'simp-tcpwrappers',
+  :git => 'https://github.com/simp/pupmod-simp-tcpwrappers',
+  :ref => 'master'
+
+mod 'simp-tftpboot',
+  :git => 'https://github.com/simp/pupmod-simp-tftpboot',
+  :ref => 'master'
+
+mod 'simp-tpm',
+  :git => 'https://github.com/simp/pupmod-simp-tpm',
+  :ref => 'master'
+
+mod 'simp-tuned',
+  :git => 'https://github.com/simp/pupmod-simp-tuned',
+  :ref => 'master'
+
+mod 'simp-upstart',
+  :git => 'https://github.com/simp/pupmod-simp-upstart',
+  :ref => 'master'
+
+mod 'simp-vnc',
+  :git => 'https://github.com/simp/pupmod-simp-vnc',
+  :ref => 'master'
+
+mod 'simp-vsftpd',
+  :git => 'https://github.com/simp/pupmod-simp-vsftpd',
+  :ref => 'master'
+
+mod 'simp-xinetd',
+  :git => 'https://github.com/simp/pupmod-simp-xinetd',
+  :ref => 'master'
+
+mod 'simp-useradd',
+  :git => 'https://github.com/simp/pupmod-simp-useradd',
+  :ref => 'master'
+
+# SIMP has made changes to this module that don't exist upstream
+mod 'trlinkin-nsswitch',
+  :git => 'https://github.com/simp/puppet-nsswitch',
+  :ref => 'simp-master'
+

--- a/spec/acceptance/suites/r10k/files/freshclam.conf
+++ b/spec/acceptance/suites/r10k/files/freshclam.conf
@@ -1,0 +1,46 @@
+DatabaseDirectory /var/simp/environments/production/rsync/Global/clamav
+DatabaseMirror database.clamav.net
+# With this option you can provide custom sources (http:// or file://) for
+# database files. This option can be used multiple times.
+# Default: no custom URLs
+#DatabaseCustomURL http://myserver.com/mysigs.ndb
+#DatabaseCustomURL file:///mnt/nfs/local.hdb
+
+# This option allows you to easily point freshclam to private mirrors.
+# If PrivateMirror is set, freshclam does not attempt to use DNS
+# to determine whether its databases are out-of-date, instead it will
+# use the If-Modified-Since request or directly check the headers of the
+# remote database files. For each database, freshclam first attempts
+# to download the CLD file. If that fails, it tries to download the
+# CVD file. This option overrides DatabaseMirror, DNSDatabaseInfo
+# and ScriptedUpdates. It can be used multiple times to provide
+# fall-back mirrors.
+# Default: disabled
+#PrivateMirror mirror1.mynetwork.com
+#PrivateMirror mirror2.mynetwork.com
+
+# Proxy settings
+# Default: disabled
+#HTTPProxyServer myproxy.com
+#HTTPProxyPort 1234
+#HTTPProxyUsername myusername
+#HTTPProxyPassword mypass
+
+# This option enables support for Google Safe Browsing. When activated for
+# the first time, freshclam will download a new database file (safebrowsing.cvd)
+# which will be automatically loaded by clamd and clamscan during the next
+# reload, provided that the heuristic phishing detection is turned on. This
+# database includes information about websites that may be phishing sites or
+# possible sources of malware. When using this option, it's mandatory to run
+# freshclam at least every 30 minutes.
+# Freshclam uses the ClamAV's mirror infrastructure to distribute the
+# database and its updates but all the contents are provided under Google's
+# terms of use. See http://code.google.com/support/bin/answer.py?answer=70015
+# and http://safebrowsing.clamav.net for more information.
+# Default: disabled
+# SafeBrowsing yes
+
+# This option enables downloading of bytecode.cvd, which includes additional
+# detection mechanisms and improvements to the ClamAV engine.
+# Default: enabled
+Bytecode yes

--- a/spec/acceptance/suites/r10k/files/hiera.yaml
+++ b/spec/acceptance/suites/r10k/files/hiera.yaml
@@ -1,0 +1,29 @@
+---
+# This is the default hiera.yaml file
+# Feel free to modify the hierarchy to suit your needs but please
+# leave the simp* entries in place at the bottom of the list
+:backends:
+  - 'yaml'
+  - 'json'
+:hierarchy:
+  - 'hosts/%{trusted.certname}'
+  - 'hosts/%{facts.fqdn}'
+  - 'hosts/%{facts.hostname}'
+  - 'domains/%{facts.domain}'
+  - '%{facts.os.family}'
+  - '%{facts.os.name}/%{facts.os.release.full}'
+  - '%{facts.os.name}/%{facts.os.release.major}'
+  - '%{facts.os.name}'
+  - 'hostgroups/%{::hostgroup}'
+  - 'default'
+  - 'compliance_profiles/%{::compliance_profile}'
+  - 'simp_config_settings'
+  - 'scenarios/%{::simp_scenario}'
+:logger: 'puppet'
+# When specifying a datadir:
+# # 1) Make sure the directory exists
+# # 2) Make sure the directory reflects the hierarchy
+:yaml:
+  :datadir: '/etc/puppetlabs/code/environments/%{::environment}/hieradata'
+:json:
+  :datadir: '/etc/puppetlabs/code/environments/%{::environment}/hieradata'

--- a/spec/acceptance/suites/r10k/nodesets/default.yml
+++ b/spec/acceptance/suites/r10k/nodesets/default.yml
@@ -1,0 +1,25 @@
+HOSTS:
+  puppet:
+    roles:
+      - server # Mandatory
+      - master
+      - default
+      - simp_server
+      - agent
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: vagrant
+    vagrant_memsize: 4608
+    vagrant_cpus: 2
+  agent:
+    roles:
+      - agent
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type:      aio
+  vagrant_memsize: 256
+  synced_folder: disabled
+  # vb_gui: true


### PR DESCRIPTION
Add basic acceptance test for installing SIMP from r10k and a
Puppetfile. It should set all required settings from simp_options and
other modules.

First, it uses the copied modules from beaker to set up a puppetserver
with SIMP's pupmod module. It then copies the provided Puppetfile to the
master, installs the r10k gem, and runs r10k puppetfile install. It
drops in a barebones site.pp with a few node definitions and then runs
puppet on the master and the agent.

SIMP-2839 #close