### PR TITLE
(SIMP-2958) Version simp::yum API, abstract

### DIFF
--- a/manifests/yum/api_v1.pp
+++ b/manifests/yum/api_v1.pp
@@ -1,0 +1,59 @@
+# API v1 abstraction for simp::yum
+class simp::yum::api_v1 inherits ::simp::yum {
+  assert_private()
+
+  $_simp_repo_enable = $enable_simp_repos ? { true => 1, default => 0 }
+  $_os_repo_enable   = $enable_os_repos ?   { true => 1, default => 0 }
+
+  if $enable_auto_updates == true {
+    include '::simp::yum::schedule'
+  }
+  else {
+    cron { 'simp_yum_update': ensure => 'absent' }
+  }
+
+  if empty($os_gpg_url) {
+    $_temp_os_gpg_url = $facts['os']['name'] ? {
+      'RedHat' => "https://YUM_SERVER/yum/${facts['os']['name']}/${facts['os']['release']['major']}/${facts['architecture']}/RPM-GPG-KEY-redhat-release",
+      default  => "https://YUM_SERVER/yum/${facts['os']['name']}/${facts['os']['release']['major']}/${facts['architecture']}/RPM-GPG-KEY-${facts['os']['name']}-${facts['os']['release']['major']}"
+    }
+
+    $_os_gpg_url = simp_yumrepo_mangle($_temp_os_gpg_url, $servers)
+  }
+  else {
+    $_os_gpg_url = simp_yumrepo_mangle($os_gpg_url, $servers)
+  }
+
+  if empty($simp_gpg_url) {
+    $_simp_gpg_url = simp_yumrepo_gpgkeys('https://YUM_SERVER/yum/SIMP', $servers)
+  }
+  else {
+    $_simp_gpg_url = simp_yumrepo_mangle($simp_gpg_url, $servers)
+  }
+
+  yumrepo { 'os_updates':
+    baseurl         => simp_yumrepo_mangle($os_update_url, $servers),
+    descr           => "All ${facts['os']['name']} ${facts['os']['release']['major']} ${facts['architecture']} base packages and updates",
+    enabled         => $_os_repo_enable,
+    enablegroups    => 0,
+    gpgcheck        => 1,
+    gpgkey          => join(split($_os_gpg_url,"\n"),"\n   "),
+    sslverify       => 0,
+    keepalive       => 0,
+    metadata_expire => 3600,
+    tag             => 'firstrun'
+  }
+
+  yumrepo { 'simp':
+    baseurl         => simp_yumrepo_mangle($simp_update_url, $servers),
+    descr           => 'SIMP Packages',
+    enabled         => $_simp_repo_enable,
+    enablegroups    => 0,
+    gpgcheck        => 1,
+    gpgkey          => join(split($_simp_gpg_url,"\n"),"\n   "),
+    sslverify       => 0,
+    keepalive       => 0,
+    metadata_expire => 3600,
+    tag             => 'firstrun'
+  }
+}

--- a/spec/classes/yum_spec.rb
+++ b/spec/classes/yum_spec.rb
@@ -7,6 +7,18 @@ describe 'simp::yum' do
         facts
       end
 
+      context 'when `$api_version` is set' do
+        context 'to a value in the `>=1.0.0 <2.0.0` range' do
+          let(:params) { { api_version: '1.0.0'} }
+          it { is_expected.to compile.with_all_deps }
+        end
+
+        context 'to a value in the `>=2.0.0 <3.0.0` range' do
+          let(:params) { { api_version: '2.0.0'} }
+          it { is_expected.to raise_error(Puppet::Error) }
+        end
+      end
+
       context 'with default parameters' do
         it { is_expected.to compile.with_all_deps }
         it 'creates the SIMP Yumrepo' do


### PR DESCRIPTION
The `simp::yum` API needs to be revamped, but we cannot break it just
yet. To enable a non-breaking interface redesign, this commit abstracts
most of the implementation into a sub-classed selected via a new
`api_version` parameter.

SIMP-2958 #close