### PR TITLE
(SIMP-2987) Updated apache rysnc hosts_allow

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Apr 06 2017 Nick Markowski <nmarkowski@keywcorp.com> - 4.0.0-0
+- Updated apache rsync hosts_allow to $trusted_nets. The previous value
+  of 127.0.0.1 would not allow apache to rsync if stunnel was disabled.
+
 * Mon Apr 03 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.0.0-0
 - Updated the YUM configuration so that no repos are set up by default and it
   is simple to connect to the public repos for SIMP.

--- a/manifests/server/rsync_shares.pp
+++ b/manifests/server/rsync_shares.pp
@@ -115,7 +115,7 @@ class simp::server::rsync_shares (
             auth_users     => ["apache_rsync_${_env}_${_os}"],
             comment        => "Apache configurations for Environment ${_env} on ${_os}",
             path           => "${rsync_base}/${_env}/rsync/${_os_id}/Global/apache",
-            hosts_allow    => ['127.0.0.1'],
+            hosts_allow    => $_trusted_nets,
             outgoing_chmod => 'o-rwx'
           }
         }


### PR DESCRIPTION
- Updated apache rsync hosts_allow to $trusted_nets. The previous value
  of 127.0.0.1 would not allow apache to rsync if stunnel was disabled.

SIMP-2987 #close