### PR TITLE
WIP (SIMP-3062) Hook FakeCA to Puppet Client Certs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Sat Apr 15 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-0
+- Added the ability to hook the FakeCA to the creation of signed Puppet client
+  certificates via incrond for full system automation
+
 * Thu Apr 06 2017 Nick Markowski <nmarkowski@keywcorp.com> - 4.0.0-0
 - Updated apache rsync hosts_allow to $trusted_nets. The previous value
   of 127.0.0.1 would not allow apache to rsync if stunnel was disabled.

--- a/files/usr/local/sbin/simp_fakeca_incron_hook
+++ b/files/usr/local/sbin/simp_fakeca_incron_hook
@@ -1,0 +1,148 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'puppet'
+require 'yaml'
+require 'json'
+require 'fileutils'
+
+action, fqdn = ARGV
+
+USAGE = "Usage: #{$0} <ACTION> <HOST PEM>"
+PUPPET = '/opt/puppetlabs/bin/puppet'
+
+
+if action !~ /^IN_/
+  $stderr.puts "Error: First Argument: `#{action}` is an invalid incrond action"
+  $stderr.puts USAGE
+  exit 1
+end
+
+if fqdn =~ /^(.*)\.pem$/
+  fqdn = $1
+else
+  $stderr.puts "Error: Second Argument: `#{fqdn}` is an invalid `host.fqdn.pem`"
+  $stderr.puts USAGE
+  exit 1
+end
+
+if action == 'IN_CREATE'
+  domain = fqdn.split('.')
+  hostname = domain.shift
+  domain = domain.join('.')
+
+  puppet_vardir = %x{#{PUPPET} config --section master print vardir}.strip
+  puppet_factdir = File.join(puppet_vardir, 'yaml', 'facts')
+
+  # This is here because we need to actually compile a catalog for the node to
+  # figure out what environment the host belongs in since it could come from
+  # anywhere.
+  #
+  # This should be safe since the file will be immediately rewritten on the first
+  # real puppet run.
+  unless File.exist?(File.join(puppet_factdir, fqdn + '.yaml'))
+    host_fake_facts = Puppet::Node::Facts.new({
+      'name'   => fqdn,
+      'values' => {
+        'hostname'   => hostname,
+        'domain'     => domain,
+        'fqdn'       => fqdn,
+        'certname'   => fqdn,
+        'clientcert' => fqdn
+      }
+    })
+
+    puppet_user = %x{#{PUPPET} config --section master print user}.strip
+
+    fact_file = File.join(puppet_factdir, fqdn + '.yaml')
+    File.open(fact_file, 'w') do |fh|
+      fh.puts host_fake_facts.to_yaml
+    end
+
+    # Make sure the Puppet server doesn't choke on this
+    FileUtils.chown(puppet_user, nil, fact_file)
+  end
+
+  compilation = []
+  Dir.mktmpdir { |tmpdir|
+    FileUtils.touch('site.pp')
+
+    # Let's figure out where this node lives!
+    compilation = %x{puppet master --manifest=#{tmpdir} --compile #{fqdn} 2> /dev/null}.split("\n")
+  }
+
+  # Strip off any garbage
+  i = 0
+  compilation.each do |line|
+    if line =~ /^\{/
+      break
+    else
+      i = i+1
+    end
+  end
+
+  begin
+    catalog = JSON.parse(compilation[i..-1].join("\n"))
+  rescue JSON::ParseError
+    $stderr.puts "Error: Did not get a valid catalog for '#{fqdn}'"
+    exit 1
+  end
+
+  environment = catalog['environment']
+
+  # Now that the have the environment, we need any DNS Alt names that might
+  # belong to this host.
+
+  host_pki_id = [fqdn]
+
+  host_pemfile = File.join(%x{#{PUPPET} config --section ca print signeddir}.strip, fqdn + '.pem')
+  if File.exist?(host_pemfile)
+    require 'openssl'
+
+    host_cert = OpenSSL::X509::Certificate.new(File.read(host_pemfile))
+
+    host_alt_names = host_cert.extensions.select do |ext|
+      ext.to_s =~ /^subjectAltName/
+    end.first
+
+    if host_alt_names
+      host_alt_names = host_alt_names.value.split(',').map{|x| x = x.split('DNS:').last}
+    end
+
+    host_pki_id = host_pki_id + host_alt_names
+  end
+
+  fakeca = %{/var/simp/environments/#{environment}/FakeCA/gencerts_nopass.sh}
+
+  unless File.exist?(fakeca)
+    $stderr.puts "Error: No FakeCA found at '#{fakeca}'"
+    $stderr.puts "  Are you sure your environment is set up properly?"
+    exit 1
+  end
+
+  fakeca_cmd = %{#{fakeca} auto #{host_pki_id.join(',')}}
+
+  fakeca_cmd_output = %x{#{fakeca_cmd}}
+
+  unless $?.success?
+    $stderr.puts "Error: FakeCA Command `#{fakeca_cmd}` was not successful"
+    $stderr.puts "Command Output:"
+    $stderr.puts fakeca_cmd_output
+    exit 1
+  end
+elsif action == 'IN_DELETE'
+  keydist_path = '/var/simp/environments/simp/site_files/pki_files/files/keydist'
+
+  to_delete = File.join(keydist_path, fqdn)
+  backup_path = File.join(keydist_path, '.incron_backup')
+
+  if File.exist?(to_delete)
+    FileUtils.mkdir_p(backup_path)
+
+    FileUtils.mv(to_delete, File.join(backup_path, fqdn + Time.now.strftime('%Y_%m_%d-%H:%M:%S.%L')))
+  end
+else
+  $stderr.puts "Error: Action '#{action}' was not recognized"
+  exit 1
+end
+
+exit 0

--- a/manifests/server/auto_fakeca.pp
+++ b/manifests/server/auto_fakeca.pp
@@ -8,7 +8,7 @@
 # @author Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #
 class simp::server::auto_fakeca (
-  Boolean $delete_on_removal = true
+  Boolean $delete_on_removal = false
 ) {
   include 'incron'
 

--- a/manifests/server/auto_fakeca.pp
+++ b/manifests/server/auto_fakeca.pp
@@ -1,0 +1,47 @@
+# This class hooks the signing of Puppet clients into the creation of FakeCA
+# certificates for the associated hosts.
+#
+# @param delete_on_removal
+#   Remove the client certificate from the FakeCA when it is removed from the
+#   Puppet CA
+#
+# @author Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+#
+class simp::server::auto_fakeca (
+  Boolean $delete_on_removal = true
+) {
+  include 'incron'
+
+  $_hook_name = 'simp_fakeca_incron_hook'
+  $_incron_hook = "/usr/local/sbin/${_hook_name}"
+
+  file { $_incron_hook:
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0750',
+    source => "puppet:///modules/${module_name}/${_incron_hook}"
+  }
+
+  if $facts['puppet_settings'] {
+    if $facts['puppet_settings']['ca'] {
+      if $facts['puppet_settings']['ca']['signeddir'] {
+        if $delete_on_removal {
+          $_incron_mask = ['IN_CREATE', 'IN_DELETE']
+        }
+        else {
+          $_incron_mask = ['IN_CREATE']
+        }
+
+        incron::system_table { 'hook_fakeca_to_puppet':
+          path    => $facts['puppet_settings']['ca']['signeddir'],
+          mask    => $_incron_mask,
+          command => "${_incron_hook} \$% \$#",
+          require => File[$_incron_hook]
+        }
+      }
+    }
+  }
+  else {
+    warning('The `puppet_settings` fact was not found, `simp::server::auto_fakeca` will have no effect')
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/00_simp_spec.rb
+++ b/spec/acceptance/suites/default/00_simp_spec.rb
@@ -33,6 +33,11 @@ describe 'simp class' do
       let(:options) {
         <<-EOF
 # Mandatory Settings
+
+# Without this, ordering issues may cause the system to become inaccessible
+# after reboot
+simp_options::fips: true
+
 simp_options::dns::servers: ['8.8.8.8']
 simp_options::puppet::server: #{host_fqdn}
 simp_options::puppet::ca: #{host_fqdn}
@@ -60,6 +65,21 @@ simp_options::trusted_nets: ['ALL']
 # Settings to make beaker happy
 ssh::server::conf::permitrootlogin: true
 ssh::server::conf::authorizedkeysfile: .ssh/authorized_keys
+
+# Debugging
+pam::access::users:
+  defaults:
+    origins:
+      - ALL
+    permission: '+'
+  vagrant:
+
+sudo::user_specifications:
+  vagrant_sudosh:
+    user_list: ['vagrant']
+    cmnd: ['/usr/bin/sudosh']
+    runas: root
+    passwd: false
         EOF
       }
 

--- a/spec/classes/server/auto_fakeca_spec.rb
+++ b/spec/classes/server/auto_fakeca_spec.rb
@@ -1,0 +1,44 @@
+# Can't run this until lwe get access to server_facts
+require 'spec_helper'
+
+describe 'simp::server::auto_fakeca' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts[:puppet_settings] = {
+            :ca => {
+              :signeddir => '/var/ca/stuff'
+            }
+          }
+
+          facts
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to create_incron__system_table('hook_fakeca_to_puppet').with({
+            'path'    => facts[:puppet_settings][:ca][:signeddir],
+            'mask'    => ['IN_CREATE', 'IN_DELETE'],
+            'command' => '/usr/local/sbin/simp_fakeca_incron_hook $% $#'
+          })
+        }
+
+        context 'without file deletion' do
+          let(:params){{
+            'delete_on_removal' => false
+          }}
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to create_incron__system_table('hook_fakeca_to_puppet').with({
+              'path'    => facts[:puppet_settings][:ca][:signeddir],
+              'mask'    => ['IN_CREATE'],
+              'command' => '/usr/local/sbin/simp_fakeca_incron_hook $% $#'
+            })
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/server/auto_fakeca_spec.rb
+++ b/spec/classes/server/auto_fakeca_spec.rb
@@ -19,21 +19,21 @@ describe 'simp::server::auto_fakeca' do
         it {
           is_expected.to create_incron__system_table('hook_fakeca_to_puppet').with({
             'path'    => facts[:puppet_settings][:ca][:signeddir],
-            'mask'    => ['IN_CREATE', 'IN_DELETE'],
+            'mask'    => ['IN_CREATE'],
             'command' => '/usr/local/sbin/simp_fakeca_incron_hook $% $#'
           })
         }
 
-        context 'without file deletion' do
+        context 'with file deletion' do
           let(:params){{
-            'delete_on_removal' => false
+            'delete_on_removal' => true
           }}
 
           it { is_expected.to compile.with_all_deps }
           it {
             is_expected.to create_incron__system_table('hook_fakeca_to_puppet').with({
               'path'    => facts[:puppet_settings][:ca][:signeddir],
-              'mask'    => ['IN_CREATE'],
+              'mask'    => ['IN_CREATE', 'IN_DELETE'],
               'command' => '/usr/local/sbin/simp_fakeca_incron_hook $% $#'
             })
           }


### PR DESCRIPTION
This adds an incron job to trigger the creation of a FakeCA certificate
for a newly minted client in the appropriate environment.

You *must* have the associated simp-core commit that makes the FakeCA
thread safe.

SIMP-3062 #close