### PR TITLE
(SIMP-3055) Set polkit administrator group

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -26,6 +26,7 @@ fixtures:
     cron: https://github.com/simp/pupmod-simp-cron
     datacat: https://github.com/simp/puppet-datacat
     dhcp: https://github.com/simp/pupmod-simp-dhcp
+    file_concat: https://github.com/simp/puppet-lib-file_concat
     fips: https://github.com/simp/pupmod-simp-fips
     freeradius: https://github.com/simp/pupmod-simp-freeradius
     haveged:
@@ -53,12 +54,12 @@ fixtures:
     oddjob: https://github.com/simp/pupmod-simp-oddjob
     pam: https://github.com/simp/pupmod-simp-pam
     pki: https://github.com/simp/pupmod-simp-pki
+    polkit: https://github.com/simp/pupmod-simp-polkit
     postfix: https://github.com/simp/pupmod-simp-postfix
     postgresql: https://github.com/simp/puppetlabs-postgresql
     puppetdb:
       repo: https://github.com/simp/puppetlabs-puppetdb
       branch: simp-master
-    file_concat: https://github.com/simp/puppet-lib-file_concat
     pupmod: https://github.com/simp/pupmod-simp-pupmod
     resolv: https://github.com/simp/pupmod-simp-resolv
     rsync: https://github.com/simp/pupmod-simp-rsync

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Apr 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 4.0.1.0
+- Set the poklit administrator group
+
 * Thu Apr 06 2017 Nick Markowski <nmarkowski@keywcorp.com> - 4.0.0-0
 - Updated apache rsync hosts_allow to $trusted_nets. The previous value
   of 127.0.0.1 would not allow apache to rsync if stunnel was disabled.

--- a/metadata.json
+++ b/metadata.json
@@ -94,6 +94,10 @@
       "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
+      "name": "simp/polkit",
+      "version_requirement": ">= 6.1.0 < 7.0.0"
+    },
+    {
       "name": "simp/postfix",
       "version_requirement": ">= 5.0.0 < 6.0.0"
     },

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/spec/classes/admin_spec.rb
+++ b/spec/classes/admin_spec.rb
@@ -13,8 +13,79 @@ describe 'simp::admin' do
 
         context 'with default parameters' do
           it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('simp::admin') }
+          it { is_expected.to create_class('simp::sudoers') }
           it { is_expected.to create_sudo__alias__user('admins') }
           it { is_expected.to create_sudo__alias__user('auditors') }
+          it { is_expected.to create_sudo__user_specification('admin_global').with({
+            :user_list => ['%administrators'],
+            :cmnd      => ['/usr/bin/sudosh'],
+            :passwd    => false
+          }) }
+          it { is_expected.to create_sudo__user_specification('auditors').with({
+            :user_list => ['%security'],
+            :cmnd      => ['AUDIT'],
+            :passwd    => false
+          }) }
+          if facts[:os][:release][:major].to_i >= 7
+            it { is_expected.to create_polkit__authorization__rule('Set administrators group to a policykit administrator').with({
+              :ensure => 'present',
+              :priority => 10,
+              :content => <<-EOF
+polkit.addAdminRule(function(action, subject) {
+  return ["unix-group:administrators"];
+});
+              EOF
+            }) }
+          end
+        end
+
+        context 'with admin and auditor settings' do
+          let(:params) {{
+              :admin_group               => 'devs',
+              :passwordless_admin_sudo   => false,
+              :auditor_group             => 'auditors',
+              :passwordless_auditor_sudo => false,
+              :force_logged_shell        => false
+          }}
+          it { is_expected.to create_sudo__user_specification('admin_global').with({
+            :user_list => ['%devs'],
+            :cmnd      => ['ALL'],
+            :passwd    => true
+          }) }
+          it { is_expected.to create_sudo__user_specification('auditors').with({
+            :user_list => ['%auditors'],
+            :cmnd      => ['AUDIT'],
+            :passwd    => true
+          }) }
+        end
+
+        context 'polkit settings' do
+          if facts[:os][:release][:major].to_i >= 7
+            it { is_expected.to create_polkit__authorization__rule('Set administrators group to a policykit administrator').with({
+              :ensure => 'present',
+              :priority => 10,
+              :content => /unix-group:administrators/
+            }) }
+          end
+
+          context 'with set_polkit_admin_group => false' do
+            let(:params) {{ :set_polkit_admin_group => false }}
+            it { is_expected.to create_polkit__authorization__rule('Set administrators group to a policykit administrator').with({
+              :ensure => 'absent',
+            }) }
+          end
+
+          context 'with admin_group => coolkids' do
+            let(:params) {{ :admin_group => 'coolkids' }}
+            if facts[:os][:release][:major].to_i >= 7
+              it { is_expected.to create_polkit__authorization__rule('Set coolkids group to a policykit administrator').with({
+                :ensure => 'present',
+                :priority => 10,
+                :content => /unix-group:coolkids/
+              }) }
+            end
+          end
         end
 
       end


### PR DESCRIPTION
This commit will add `simp::admin::admin_group` as a polkit
administrator.

SIMP-3055 #close