### PR TITLE
(SIMP-3144) simp::base_apps uses simp_options global that doesn't exist

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon May 09 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 4.0.1.0
+- Use the correct simp_options global catalyst for base_apps::ensure
+
 * Mon Apr 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 4.0.1.0
 - Set the poklit administrator group
 - Merged base_services into base_apps, leaving a shim in base_services

--- a/manifests/base_apps.pp
+++ b/manifests/base_apps.pp
@@ -24,7 +24,7 @@
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class simp::base_apps (
-  Simp::PackageEnsure       $ensure               = simplib::lookup('simp_options::ensure', { 'default_value' => 'installed' }),
+  Simp::PackageEnsure       $ensure               = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
   Optional[Array[String,1]] $extra_apps           = undef,
   Boolean                   $manage_elinks_config = true
 ) {


### PR DESCRIPTION
simp::base_apps is using 'simp_options::ensure' instead of
'simp_options::package_ensure'

SIMP-3144 #close