### PR TITLE
(SIMP-3302) Move simp::knockout functionality into simplib

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Fri Jun 09 2017 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.0-0
+- Due to lack of support for knockout_prefix for arrays in older versions
+  of Puppet, simp::knockout functionality has been moved to
+  simplib::knockout because multiple modules are using the function.
+- A wrapper has been put around simp::knockout for backwards-compatibility
+  in our code.
+
 * Tue May 30 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-0
 - Updated the simp::kmod_blacklist class to also fully disable the module
   loading

--- a/functions/knockout.pp
+++ b/functions/knockout.pp
@@ -1,28 +1,6 @@
-# uses the knockout prefix of '--' to remove elements from an array.
-# @param array The array to knockout
-# @return [Array] Resulting array.
-# @example Using knockout
-#   array = [
-#     'ssh',
-#     'sudo',
-#     '--ssh',
-#   ]
-#   result = simp::knockout(array)
+# Deprecated knockout function, see simplib::knockout
 #
-#   result => [
-#              'sudo'
-#             ]
 function simp::knockout(Array $array) {
-  $included = $array.filter |$data| {
-    $data !~ /^--/
-  }
-
-  $excluded_filter = $array.filter |$data| {
-    $data =~ /^--/
-  }
-  $excluded = $excluded_filter.map |$data| {
-    delete($data, '--')
-  }
-
-  ($included - $excluded)
+  simplib::knockout($array)
 }
+


### PR DESCRIPTION
- Due to lack of support for knockout_prefix for arrays in older versions
  of Puppet, simp::knockout functionality has been moved to
  simplib::knockout because multiple modules are using the function.
- A wrapper has been put around simp::knockout for backwards-compatibility
  in our code.

SIMP-3302 #added wrapper to simp::knockout