### PR TITLE
(SIMP-3372) simp - changelog cleanup as prep for tagging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
   simplib::knockout because multiple modules are using the function.
 - A wrapper has been put around simp::knockout for backwards-compatibility
   in our code.
+- Update puppet requirement in metadata.json
 
 * Tue May 30 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-0
 - Updated the simp::kmod_blacklist class to also fully disable the module
@@ -13,13 +14,13 @@
 - Provide the ability to lock module loading if the underlying OS has the
   capability
 
-* Wed May 10 2017 Nick Markowski <nmarkowski@keywcorp.com> - 4.0.2-0
+* Wed May 10 2017 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.0-0
 - Added a 'remote_access' scenario
 
-* Mon May 09 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 4.0.1.0
+* Mon May 09 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 4.1.0-0
 - Use the correct simp_options global catalyst for base_apps::ensure
 
-* Mon Apr 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 4.0.1-0
+* Mon Apr 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 4.1.0-0
 - Set the poklit administrator group
 - Merged base_services into base_apps, leaving a shim in base_services
 


### PR DESCRIPTION
Last tagged version was 4.0.0, so all changes after that are for 4.1.0.