### PR TITLE
(SIMP-3483) SSSD not working in CentOS 6.9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Jul 31 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.1.1-0
+- call simp::nsswitch in simp and simp-lite scenario instead of just nsswitch
+  to set nsswitch according to simp_options instead of just the nsswitch defaults.
+
 * Thu Jul 20 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 4.1.1-0
 - Refactor classification lists to be RedHat specific to support other target
   platforms

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -5,7 +5,7 @@ lookup_options:
       strategy: deep
       # Disable this for now.
       #knockout_prefix: --
-      sort_merge_arrays: true
+      sort_merged_arrays: true
   simp::classes:
     merge:
       strategy: unique
@@ -16,13 +16,13 @@ lookup_options:
       strategy: deep
       # Disable this for now.
       #knockout_prefix: --
-      sort_merge_arrays: true
+      sort_merged_arrays: true
   simp::server::classes:
     merge:
       strategy: deep
       # Disable this for now.
       #knockout_prefix: --
-      sort_merge_arrays: true
+      sort_merged_arrays: true
 
 simp::server::scenario_map:
   none: []

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -31,7 +31,6 @@ simp::scenario_map:
     - incron
     - useradd
     - resolv
-    - nsswitch
     - issue
     - tuned
     - swap
@@ -45,6 +44,7 @@ simp::scenario_map:
     - simp::yum::schedule
     - simp::kmod_blacklist
     - simp::mountpoints
+    - simp::nsswitch
     - simp::sysctl
     - ssh
     - sudosh
@@ -63,7 +63,6 @@ simp::scenario_map:
     - incron
     - useradd
     - resolv
-    - nsswitch
     - issue
     - tuned
     - swap
@@ -77,6 +76,7 @@ simp::scenario_map:
     - simp::yum::schedule
     - simp::kmod_blacklist
     - simp::mountpoints
+    - simp::nsswitch
     - simp::sysctl
     - ssh
     - sudosh
@@ -99,7 +99,6 @@ simp::scenario_map:
     - incron
     - useradd
     - resolv
-    - nsswitch
     - issue
     - tuned
     - swap
@@ -113,6 +112,7 @@ simp::scenario_map:
     - simp::yum::schedule
     - simp::kmod_blacklist
     - simp::mountpoints
+    - simp::nsswitch
     - simp::sysctl
     - ssh
     - sudosh
@@ -130,7 +130,6 @@ simp::server::data:
   - cron
   - incron
   - issue
-  - nsswitch
   - ntpd
   - pam::access
   - resolv
@@ -145,6 +144,7 @@ simp::server::data:
   - simp::base_services
   - simp::kmod_blacklist
   - simp::mountpoints
+  - simp::nsswitch
   - simp::sysctl
   - '--simp::scenario::base'
   - '--auditd'


### PR DESCRIPTION
  -changed module from nsswitch to simp::nsswitch in
   scenarions simp and simp_lite so nsswitch
   would be configured correctly according to simp_options.

SIMP-3483 #close