### PR TITLE
SIMP-3512 changes to pupmod-simp-simp for puppet supported tags

### DIFF
--- a/manifests/rc_local.pp
+++ b/manifests/rc_local.pp
@@ -52,7 +52,7 @@ class simp::rc_local (
   }
 
   file { '/etc/rc.d/rc.local':
-    ensure  => 'present',
+    ensure  => 'file',
     owner   => 'root',
     group   => 'root',
     mode    => '0770',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -43,7 +43,12 @@ class simp::server (
 ) {
 
   if $scenario_map.has_key($scenario) {
-    include simp::knockout(union($scenario_map[$scenario], $classes))
+    include simp::knockout(
+      union(
+        $scenario_map[$scenario],
+        $classes,
+      )
+    )
   } else {
     fail("ERROR - Invalid scenario '${scenario}' for the given scenario map.")
   }

--- a/manifests/server/kickstart/runpuppet.pp
+++ b/manifests/server/kickstart/runpuppet.pp
@@ -74,7 +74,7 @@ class simp::server::kickstart::runpuppet (
   }
 
   file { $location:
-    ensure  => 'present',
+    ensure  => 'file',
     owner   => 'root',
     group   => 'apache',
     mode    => '0640',

--- a/manifests/server/yum.pp
+++ b/manifests/server/yum.pp
@@ -33,5 +33,7 @@ class simp::server::yum (
     }
   }
 
-  package { 'createrepo': ensure => 'latest' }
+  package { 'createrepo':
+    ensure => 'latest',
+  }
 }

--- a/manifests/sssd/client.pp
+++ b/manifests/sssd/client.pp
@@ -51,7 +51,6 @@ class simp::sssd::client (
 ){
   if $ldap_domain or $local_domain {
     include '::sssd'
-
     include '::sssd::service::nss'
     include '::sssd::service::pam'
 

--- a/manifests/yum/repo/internet_simp_dependencies.pp
+++ b/manifests/yum/repo/internet_simp_dependencies.pp
@@ -7,7 +7,7 @@
 #   * Defaults to the version of the **puppet server**
 #
 class simp::yum::repo::internet_simp_dependencies (
-  Variant[String,Undef] $simp_release_slug = undef,
+  Optional[String] $simp_release_slug = undef,
 ){
   $_release_slug = simp::yum::repo::sanitize_simp_release_slug( $simp_release_slug )
 


### PR DESCRIPTION
Specific items addressed in this PR:
* several syntax changes, such as multi-lining code blocks
* using correct keywords removed use of the 'inherits' keyword, which should only be used with the old params pattern
* remove variables from private classes, instead refer to the toplevel class
* comments welcome, still testing.

In the future, we need to address the use of 'include' instead of 'require' in many classes of this module. Currently many 'include' statements cannot be replaced by 'require' without creating cyclical dependencies, which may speak to a larger problem with defined types.

SIMP-3512 #close