### PR TITLE
(SIMP-3613) simp: Update to concat 3.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 4.1.1-0
+- Update concat version in metadata.json
+- Add concat dependency to build/rpm_metadata/requires
+
 * Mon Jul 31 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.1.1-0
 - call simp::nsswitch in simp and simp-lite scenario instead of just nsswitch
   to set nsswitch according to simp_options instead of just the nsswitch defaults.

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -3,6 +3,8 @@ Requires: pupmod-herculesteam-augeasproviders_puppet < 3.0.0-0
 Requires: pupmod-herculesteam-augeasproviders_puppet >= 2.1.0-0
 Requires: pupmod-herculesteam-augeasproviders_sysctl < 3.0.0-0
 Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.2.0-0
+Requires: pupmod-puppetlabs-concat < 4.0.0-0
+Requires: pupmod-puppetlabs-concat >= 2.2.0-0
 Requires: pupmod-puppetlabs-inifile < 2.0.0-0
 Requires: pupmod-puppetlabs-inifile >= 1.6.0-0
 Requires: pupmod-puppetlabs-postgresql < 5.0.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "version_requirement": ">= 2.2.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/inifile",


### PR DESCRIPTION
- concat 3.0.0 is fully backward compatible with 2.x.
- Update concat version in metadata.json
- Add concat dependency to build/rpm_metadata/requires