### PR TITLE
(SIMP-3613) simp: Pin concat to 3.0.0 in .fixtures.yml

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -25,7 +25,9 @@ fixtures:
     autofs: https://github.com/simp/pupmod-simp-autofs
     chkrootkit: https://github.com/simp/pupmod-simp-chkrootkit
     clamav: https://github.com/simp/pupmod-simp-clamav
-    concat: https://github.com/simp/puppetlabs-concat
+    concat:
+      repo: https://github.com/simp/puppetlabs-concat
+      ref: 3.0.0
     cron: https://github.com/simp/pupmod-simp-cron
     datacat: https://github.com/simp/puppet-datacat
     dhcp: https://github.com/simp/pupmod-simp-dhcp

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -26,6 +26,7 @@ fixtures:
     chkrootkit: https://github.com/simp/pupmod-simp-chkrootkit
     clamav: https://github.com/simp/pupmod-simp-clamav
     concat:
+      # master is at 4.0.1, but we are bound to < 4.0.0 in our metadata.json
       repo: https://github.com/simp/puppetlabs-concat
       ref: 3.0.0
     cron: https://github.com/simp/pupmod-simp-cron


### PR DESCRIPTION
This project is one of the few that does NOT work with concat 4.0.1,
which is the version on the master of puppetlabs-concat.