### PR TITLE
(SIMP-3626) simp::server::classes array has incorrect merge defaults

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* Wed Aug 23 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 4.1.1-0
+- change simp::server::classes's lookup_options to be 'unique'
 
 * Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 4.1.1-0
 - Update concat version in metadata.json

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -17,7 +17,7 @@ lookup_options:
       #knockout_prefix: --
   simp::server::classes:
     merge:
-      strategy: deep
+      strategy: unique
       # Disable this for now.
       #knockout_prefix: --
 


### PR DESCRIPTION
the simp::server::classes array has incorrect merge defaults, which break hiera's auto-casting by turning it into a hash erroneously

SIMP-3626 #close