### PR TITLE
(SIMP-3826) pupmod-simp-simp: Fix version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,8 +9,7 @@
 
 .setup_bundler_env: &setup_bundler_env
   before_script:
-    # For FIPS compatibility
-    - gem install bundler -v '~> 1.14.0'
+    - gem install bundler 
     - rm -f Gemfile.lock
     - bundle install --no-binstubs --path .vendor "${FLAGS[@]}"
 
@@ -42,7 +41,7 @@ puppet-syntax:
   <<: *syntax_checks
 
 # Puppet 4
-unit-test-ruby-2.1.9:
+unit-ruby-2.1.9:
   stage: unit
   tags:
     - docker
@@ -52,7 +51,7 @@ unit-test-ruby-2.1.9:
   <<: *spec_tests
 
 # Puppet 5
-unit-test-ruby-2.4.1:
+unit-ruby-2.4.1:
   stage: unit
   tags:
     - docker
@@ -74,29 +73,7 @@ puppet4.7-syntax:
   <<: *setup_bundler_env
   <<: *syntax_checks
 
-unit-test-puppet4.7-ruby-2.1:
-  stage: unit
-  tags:
-    - docker
-  image: ruby:2.1
-  variables:
-    PUPPET_VERSION: '4.7'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *spec_tests
-
-puppet4.7-syntax:
-  stage: syntax
-  tags:
-    - docker
-  image: ruby:2.1
-  variables:
-    PUPPET_VERSION: '4.7'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *syntax_checks
-
-unit-test-puppet4.7-ruby-2.1:
+unit-puppet4.7-ruby-2.1:
   stage: unit
   tags:
     - docker
@@ -118,7 +95,7 @@ puppet5-syntax:
   <<: *setup_bundler_env
   <<: *syntax_checks
 
-unit-test-puppet5-ruby-2.4:
+unit-puppet5-ruby-2.4:
   stage: unit
   tags:
     - docker
@@ -128,12 +105,59 @@ unit-test-puppet5-ruby-2.4:
   <<: *cache_bundler
   <<: *setup_bundler_env
   <<: *spec_tests
+  allow_failure: true
 
-acceptance-test:
+acceptance-base_apps:
   stage: acceptance
   tags:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
   script:
-    - bundle exec rake beaker:suites
+    - bundle exec rake beaker:suites[base_apps]
+
+acceptance-default:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  script:
+    - bundle exec rake beaker:suites[default]
+
+acceptance-no_simp_server:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  script:
+    - bundle exec rake beaker:suites[no_simp_server]
+
+acceptance-one_shot_scenario:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  script:
+    - bundle exec rake beaker:suites[scenario_one_shot]
+
+acceptance-poss_scenario:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  script:
+    - bundle exec rake beaker:suites[scenario_poss]
+
+acceptance-remote_access_scenario:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  script:
+    - bundle exec rake beaker:suites[scenario_remote_access]
+  allow_failure: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,48 +8,86 @@
 # PE 2017.2   4.10  2.1.9  TBD
 ---
 language: ruby
-sudo: false
 cache: bundler
-before_script:
-  - bundle update
+sudo: false
+
 bundler_args: --without development system_tests --path .vendor
-before_install: rm Gemfile.lock || true
-script:
-  - bundle exec rake test
+
 notifications:
   email: false
-rvm:
-  - 2.1.9
-env:
-  global:
-    - STRICT_VARIABLES=yes
-  matrix:
-    - PUPPET_VERSION="~> 4.8.2" FORGE_PUBLISH=true
-    - PUPPET_VERSION="~> 4.10.0"
-    - PUPPET_VERSION="~> 4.9.2"
-    - PUPPET_VERSION="~> 4.7.0"
-matrix:
-  fast_finish: true
 
-before_deploy:
-  - 'bundle exec rake metadata_lint'
-  - 'bundle exec rake clobber'
-  - 'bundle exec rake spec_clean'
-  - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-  - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
-deploy:
-  - provider: puppetforge
-    user: simp
-    password:
-        secure: "NR5lPHTfp142XIW5nowolBMFitPaaXpLiO9IvNXU3u00cZCOQmdU8fKWZPqKcUf8izV8EK9p5KCOSd956XxwrCyuwNEq6Z26WAydU6MN8qMKW7ucfm+xcURWQPKQ19MX5pNSaLOXemFvva2kuZF1rkwCYoSHJeBXDfLusBau56b9cIbX8BxNfkqPVzbNu1LioQkXTJ8Qt0u/hmRZy4593E6O5I6Hblh2lPKugNv+LpsUqwCGll1hvnTu0SJJEPZBYlKuC34qfsnqErT+eSOjLNGhxkPy3JVfwP4GRQbw2rFWNMzaPC/i6LGuB9GMPuUNjJHpZyl2+k33f9vFwfZiWoqIwJTRQTnXsbSa/amgtlaFX//43n9NMMPrI9WryoiYHTWQGiDxNuzqN6qjtthUlNfPBovsaqSsmcW9XELhsMxoo/t1G6LQWqEiCq5FB/bsnEig24CJeRELHL42A3bii+VWiBl/kgMEd/ju3J0VIqbLKIJcPQWhcomW5YGMf8Q9+FNZPyA4i3ebwwehh+etfND6+d3DOeXE84ZGLtJppELRwbgvJO/JWE/qxCdNSO4Nh3No+rRqXal3IESQBkfawuQoLIMBod7MCrRzo5d4J1asyoFJU+FMLRYjCcgaMUudUNViux6g86Cfav9rTDmhs7zdIZxaCOSNgLv9gfNu6AY="
-    on:
-      tags: true
+addons:
+  apt:
+    packages:
+      - rpm
+
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  allow_failures:
+    - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+
+  include:
+    - stage: check
       rvm: 2.1.9
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
-  - provider: releases
-    api_key:
-        secure: "Xu84X+7tUMAzO2qCw53d2Gq2tcg99+oTqAuIuSlB0gDxQL7lkWcjPWPf3CE9jmgu4C4fw56R4ZX2oYW3m0+mtcPCKDoJAFKwFswMImDbdYcfTLCr4Hn3I+yxqjw7ls6Zlr7XL4o9mfWbZhM/1eF2iWdDdcBzMhlzHxe7eD0J+K/N0VSWgJTRFhHercyUsOgr2aXZz0CwQPU4zHzd2uZaTGUUoX9nK9nSb6Ro64sefzaviUBuLJjt9T2v6YuKibXHKwXYCgpHG3anwOwS/SuGPMszOoGuR0KtGCF6McLtAOtsHYGn4CXL3CbB03rYYZ4TRHX7Av9qGwS79LcY+bDVEnCs5Hebim14W0t4N+rk5hB7uglvYP/X/BeBp40SvEzhNiT/o2k80Q+toUN17avyjBm5knvRmlzFBSXT8aI75FDv8/LJ5Mdq+N6c3QrUoGOayNWtjeabC0alGLC9mAPLyiR47SeniumrkndLkRPqw8iWqDoe7jSPTbeK4T5IebqhwWg8bCXDUCA6iMNHOXzy74enRuoPXUVl+zM64d5ISwHDN8O59TZrqU6MSzPeYWm+hCeB+MhuulubiNlwLe+UkKQLTh8CqvNBX/6DdWPuYvEDjW/gK644Bh9TcpWH6x0oP8SkihZKSrXBNF3eenYhU4ph7kwkxxX86HE24aasU7c="
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
+      script:
+        - bundle exec rake check:dot_underscore
+        - bundle exec rake check:test_file
+        - bundle exec rake pkg:check_version
+        - bundle exec rake metadata_lint
+        - bundle exec rake compare_latest_tag
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.8.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: deploy
+      rvm: 2.1.9
+      script:
+        - true
+      before_deploy:
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+      deploy:
+        - provider: releases
+          api_key:
+            secure: "Xu84X+7tUMAzO2qCw53d2Gq2tcg99+oTqAuIuSlB0gDxQL7lkWcjPWPf3CE9jmgu4C4fw56R4ZX2oYW3m0+mtcPCKDoJAFKwFswMImDbdYcfTLCr4Hn3I+yxqjw7ls6Zlr7XL4o9mfWbZhM/1eF2iWdDdcBzMhlzHxe7eD0J+K/N0VSWgJTRFhHercyUsOgr2aXZz0CwQPU4zHzd2uZaTGUUoX9nK9nSb6Ro64sefzaviUBuLJjt9T2v6YuKibXHKwXYCgpHG3anwOwS/SuGPMszOoGuR0KtGCF6McLtAOtsHYGn4CXL3CbB03rYYZ4TRHX7Av9qGwS79LcY+bDVEnCs5Hebim14W0t4N+rk5hB7uglvYP/X/BeBp40SvEzhNiT/o2k80Q+toUN17avyjBm5knvRmlzFBSXT8aI75FDv8/LJ5Mdq+N6c3QrUoGOayNWtjeabC0alGLC9mAPLyiR47SeniumrkndLkRPqw8iWqDoe7jSPTbeK4T5IebqhwWg8bCXDUCA6iMNHOXzy74enRuoPXUVl+zM64d5ISwHDN8O59TZrqU6MSzPeYWm+hCeB+MhuulubiNlwLe+UkKQLTh8CqvNBX/6DdWPuYvEDjW/gK644Bh9TcpWH6x0oP8SkihZKSrXBNF3eenYhU4ph7kwkxxX86HE24aasU7c="
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: puppetforge
+          user: simp
+          password:
+            secure: "NR5lPHTfp142XIW5nowolBMFitPaaXpLiO9IvNXU3u00cZCOQmdU8fKWZPqKcUf8izV8EK9p5KCOSd956XxwrCyuwNEq6Z26WAydU6MN8qMKW7ucfm+xcURWQPKQ19MX5pNSaLOXemFvva2kuZF1rkwCYoSHJeBXDfLusBau56b9cIbX8BxNfkqPVzbNu1LioQkXTJ8Qt0u/hmRZy4593E6O5I6Hblh2lPKugNv+LpsUqwCGll1hvnTu0SJJEPZBYlKuC34qfsnqErT+eSOjLNGhxkPy3JVfwP4GRQbw2rFWNMzaPC/i6LGuB9GMPuUNjJHpZyl2+k33f9vFwfZiWoqIwJTRQTnXsbSa/amgtlaFX//43n9NMMPrI9WryoiYHTWQGiDxNuzqN6qjtthUlNfPBovsaqSsmcW9XELhsMxoo/t1G6LQWqEiCq5FB/bsnEig24CJeRELHL42A3bii+VWiBl/kgMEd/ju3J0VIqbLKIJcPQWhcomW5YGMf8Q9+FNZPyA4i3ebwwehh+etfND6+d3DOeXE84ZGLtJppELRwbgvJO/JWE/qxCdNSO4Nh3No+rRqXal3IESQBkfawuQoLIMBod7MCrRzo5d4J1asyoFJU+FMLRYjCcgaMUudUNViux6g86Cfav9rTDmhs7zdIZxaCOSNgLv9gfNu6AY="
+          on:
+            tags: true
+            rvm: 2.1.9
+            condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Wed Oct 04 2017 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.2.0-0
+- Fail compilation for a subset of SIMP capabilities, if they are
+  used on unsupported operating systems.
+
+* Wed Oct 04 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.0-0
+- Add an acceptance test for the 'poss' scenario using Oracle EL6
+
 * Wed Aug 23 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 4.1.1-0
 - change simp::server::classes's lookup_options to be 'unique'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/scenario_poss/metadata.yml
+++ b/spec/acceptance/suites/scenario_poss/metadata.yml
@@ -1,3 +1,3 @@
 ---
-'name': 'One Shot Scenario'
+'name': 'Poss Scenario on Oracle EL6'
 'default_run': true


### PR DESCRIPTION
Update version in prep for tag and release.

Also, to facilitate the testing required for release:
- Allow same test failures in gitlab as in travis.
- Split out gitlab acceptance tests so they run on
  separate runners.
- Add acceptance tests that are not in the default
  suite but are important.
- Shorten job names, so more of the name displays on
  the gitlab pipeline graph.

SIMP-3826 #comment pupmod-simp-simp version update