### PR TITLE
(SIMP-3893) Correct default for `min_id` to 500

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Oct 19 2017  Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.2.2-0
+- Lowered default value of parameter simp::sssd::client::min_id to 500
+
 * Fri Oct 06 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.1-0
 - Added simp/timezone to the module dependency list
 

--- a/manifests/sssd/client.pp
+++ b/manifests/sssd/client.pp
@@ -47,7 +47,7 @@ class simp::sssd::client (
   Boolean $ssh               = true,
   Boolean $enumerate_users   = false,
   Boolean $cache_credentials = true,
-  Integer $min_id            = 1000
+  Integer $min_id            = 500
 ){
 
   simplib::assert_metadata( $module_name )

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",


### PR DESCRIPTION
SSSD was filtering out the `administrators` group (GID 700) because
sssd.conf's default min_id was set to value of 1000, causing several
hard-to-diagnose problems for various users.  This patch fixes the
problem by dropping the minimum GID to 500.

SIMP-3893 #close