### PR TITLE
(SIMP-3969) pupmod: Acceptance test fixes for FIPS

### DIFF
--- a/spec/acceptance/suites/default/00_simp_spec.rb
+++ b/spec/acceptance/suites/default/00_simp_spec.rb
@@ -57,7 +57,7 @@ useradd::securetty:
       # These boxes have no root password by default...
       it 'should set the root password' do
         on(host, "sed -i 's/enforce_for_root//g' /etc/pam.d/*")
-        on(host, 'echo "root:password" | chpasswd')
+        on(host, 'echo "root:password" | chpasswd --crypt-method SHA256')
       end
 
       it 'should set up needed repositories' do

--- a/spec/acceptance/suites/scenario_one_shot/00_simp_spec.rb
+++ b/spec/acceptance/suites/scenario_one_shot/00_simp_spec.rb
@@ -109,7 +109,7 @@ useradd::securetty:
     # These boxes have no root password by default...
     it 'should set the root password' do
       on(host, "sed -i 's/enforce_for_root//g' /etc/pam.d/*")
-      on(host, 'echo "root:password" | chpasswd')
+      on(host, 'echo "root:password" | chpasswd --crypt-method SHA256')
     end
 
     it 'should bootstrap in a few runs' do

--- a/spec/acceptance/suites/scenario_poss/00_simp_spec.rb
+++ b/spec/acceptance/suites/scenario_poss/00_simp_spec.rb
@@ -34,7 +34,7 @@ simp::scenario: poss
     # These boxes have no root password by default...
     it 'should set the root password' do
       on(host, "sed -i 's/enforce_for_root//g' /etc/pam.d/*")
-      on(host, 'echo "root:password" | chpasswd')
+      on(host, 'echo "root:password" | chpasswd --crypt-method SHA256')
     end
 
     it 'should run puppet' do


### PR DESCRIPTION
Fixes to allow acceptance tests to run on servers in FIPS mode.

SIMP-3969 #comment pupmod acceptance test fixes for FIPS