### PR TITLE
(SIMP-4048) pupmod-simp-simp: Set net.ipv6.conf.all.accept_source_route

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Nov 07 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 4.2.3-0
+- Small test fixes to allow acceptance tests to run on servers in FIPS mode
+
 * Thu Oct 19 2017  Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.2.2-0
 - Lowered default value of parameter simp::sssd::client::min_id to 500
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
-* Tue Nov 07 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 4.2.3-0
+* Mon Nov 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 4.3.0-0
+- In simp::sysctl, add parameters for net.ipv6.conf.all.accept_source_route
+  and net.ipv6.conf.default.accept_source_route and set them to 0 by
+  default.  This satisfies STIG CCI-0000366.
 - Small test fixes to allow acceptance tests to run on servers in FIPS mode
 
 * Thu Oct 19 2017  Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.2.2-0

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -60,6 +60,7 @@
 # @param net__ipv4__tcp_max_syn_backlog
 # @param net__ipv4__tcp_syncookies
 # @param net__ipv6__conf__all__accept_redirects
+# @param net__ipv6__conf__all__accept_source_route
 # @param net__ipv6__conf__all__autoconf
 # @param net__ipv6__conf__all__forwarding
 # @param net__ipv6__conf__default__accept_ra
@@ -67,6 +68,7 @@
 # @param net__ipv6__conf__default__accept_ra_pinfo
 # @param net__ipv6__conf__default__accept_ra_rtr_pref
 # @param net__ipv6__conf__default__accept_redirects
+# @param net__ipv6__conf__default__accept_source_route
 # @param net__ipv6__conf__default__autoconf
 # @param net__ipv6__conf__default__dad_transmits
 # @param net__ipv6__conf__default__max_addresses
@@ -127,6 +129,7 @@ class simp::sysctl (
   Integer[1]           $net__ipv4__tcp_max_syn_backlog                 = 4096,
   Integer[0,1]         $net__ipv4__tcp_syncookies                      = 1,          # CCE-27053-8
   Integer[0,1]         $net__ipv6__conf__all__accept_redirects         = 0,
+  Integer[0,1]         $net__ipv6__conf__all__accept_source_route      = 0,          # CCI-000366 (STIG)
   Integer[0,1]         $net__ipv6__conf__all__autoconf                 = 0,
   Integer[0,1]         $net__ipv6__conf__all__forwarding               = 0,
   Integer[0,1]         $net__ipv6__conf__default__accept_ra            = 0,          # CCE-27164-3
@@ -134,6 +137,7 @@ class simp::sysctl (
   Integer[0,1]         $net__ipv6__conf__default__accept_ra_pinfo      = 0,          # SSG network_ipv6_limit_requests (No CCEs available at this time)
   Integer[0,1]         $net__ipv6__conf__default__accept_ra_rtr_pref   = 0,          # SSG network_ipv6_limit_requests (No CCEs available at this time)
   Integer[0,1]         $net__ipv6__conf__default__accept_redirects     = 0,          # CCE-27166-8
+  Integer[0,1]         $net__ipv6__conf__default__accept_source_route  = 0,
   Integer[0,1]         $net__ipv6__conf__default__autoconf             = 0,          # SSG network_ipv6_limit_requests (No CCEs available at this time)
   Integer[0,1]         $net__ipv6__conf__default__dad_transmits        = 0,          # SSG network_ipv6_limit_requests (No CCEs available at this time)
   Integer[0]           $net__ipv6__conf__default__max_addresses        = 1,          # SSG network_ipv6_limit_requests (No CCEs available at this time)
@@ -248,6 +252,7 @@ class simp::sysctl (
       if $facts['ipv6_enabled'] and ( $_disable_ipv6 == 0 ) {
         sysctl {
           'net.ipv6.conf.all.accept_redirects'         : value => $net__ipv6__conf__all__accept_redirects;
+          'net.ipv6.conf.all.accept_source_route'      : value => $net__ipv6__conf__all__accept_source_route;
           'net.ipv6.conf.all.autoconf'                 : value => $net__ipv6__conf__all__autoconf;
           'net.ipv6.conf.all.forwarding'               : value => $net__ipv6__conf__all__forwarding;
           'net.ipv6.conf.default.accept_ra'            : value => $net__ipv6__conf__default__accept_ra;
@@ -255,6 +260,7 @@ class simp::sysctl (
           'net.ipv6.conf.default.accept_ra_pinfo'      : value => $net__ipv6__conf__default__accept_ra_pinfo;
           'net.ipv6.conf.default.accept_ra_rtr_pref'   : value => $net__ipv6__conf__default__accept_ra_rtr_pref;
           'net.ipv6.conf.default.accept_redirects'     : value => $net__ipv6__conf__default__accept_redirects;
+          'net.ipv6.conf.default.accept_source_route'  : value => $net__ipv6__conf__default__accept_source_route;
           'net.ipv6.conf.default.autoconf'             : value => $net__ipv6__conf__default__autoconf;
           'net.ipv6.conf.default.dad_transmits'        : value => $net__ipv6__conf__default__dad_transmits;
           'net.ipv6.conf.default.max_addresses'        : value => $net__ipv6__conf__default__max_addresses;

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/spec/classes/sysctl_spec.rb
+++ b/spec/classes/sysctl_spec.rb
@@ -13,6 +13,8 @@ describe 'simp::sysctl' do
         it { is_expected.not_to create_file('/var/core').that_comes_before('Sysctl[kernel.core_pattern]') }
         it { is_expected.not_to create_file('/var/core').that_comes_before('Sysctl[kernel.core_uses_pid]') }
         it { is_expected.not_to create_sysctl('net.ipv6.conf.all.disable_ipv6').with(:value => 1 ) }
+        it { is_expected.not_to create_sysctl('net.ipv6.conf.all.accept_source_route').with(:value => 0 ) }
+        it { is_expected.not_to create_sysctl('net.ipv6.conf.default.accept_source_route').with(:value => 0 ) }
       end
 
       context "with ipv6 => true" do
@@ -23,12 +25,16 @@ describe 'simp::sysctl' do
 
         it { is_expected.to create_sysctl('net.ipv6.conf.all.disable_ipv6').with(:value => 0 ) }
         it { is_expected.to create_sysctl('net.ipv6.conf.all.accept_redirects').with(:value => 0 ) }
+        it { is_expected.to create_sysctl('net.ipv6.conf.all.accept_source_route').with(:value => 0 ) }
+        it { is_expected.to create_sysctl('net.ipv6.conf.default.accept_source_route').with(:value => 0 ) }
       end
 
       context "with ipv6 => false" do
         let(:params) {{ :ipv6 => false }}
         it { is_expected.to create_sysctl('net.ipv6.conf.all.disable_ipv6').with(:value => 1 ) }
         it { is_expected.not_to create_sysctl('net.ipv6.conf.all.accept_redirects') }
+        it { is_expected.not_to create_sysctl('net.ipv6.conf.all.accept_source_route').with(:value => 0 ) }
+        it { is_expected.not_to create_sysctl('net.ipv6.conf.default.accept_source_route').with(:value => 0 ) }
       end
 
       context "kernel__core_pattern with absolute path" do


### PR DESCRIPTION
- In simp::sysctl, add parameters for net.ipv6.conf.all.accept_source_route
  and net.ipv6.conf.default.accept_source_route and set them to 0 by
  default.  This satisfies STIG CCI-0000366.
- Small test fixes to allow acceptance tests to run on servers in FIPS mode

SIMP-3969 #comment pupmod-simp-simp update version for FIPS test fixes
SIMP-4048 #close