### PR TITLE
(SIMP-4482) Set ownership and permissions of puppet/puppetdb.conf

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,6 +139,7 @@ pup5.3-validation:
   <<: *cache_bundler
   <<: *setup_bundler_env
   <<: *validation_checks
+  allow_failure: true
 
 pup5.3-unit:
   stage: unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,9 @@ jobs:
         - bundle exec rake pkg:compare_latest_tag
         - bundle exec rake pkg:create_tag_changelog
         - bundle exec puppet module build
+
     - stage: spec
-      rvm: 2.1.9
+      rvm: 2.4.1
       env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec
@@ -71,7 +72,7 @@ jobs:
         - bundle exec rake spec
 
     - stage: deploy
-      rvm: 2.1.9
+      rvm: 2.4.1
       script:
         - true
       before_deploy:
@@ -91,5 +92,5 @@ jobs:
             secure: "NR5lPHTfp142XIW5nowolBMFitPaaXpLiO9IvNXU3u00cZCOQmdU8fKWZPqKcUf8izV8EK9p5KCOSd956XxwrCyuwNEq6Z26WAydU6MN8qMKW7ucfm+xcURWQPKQ19MX5pNSaLOXemFvva2kuZF1rkwCYoSHJeBXDfLusBau56b9cIbX8BxNfkqPVzbNu1LioQkXTJ8Qt0u/hmRZy4593E6O5I6Hblh2lPKugNv+LpsUqwCGll1hvnTu0SJJEPZBYlKuC34qfsnqErT+eSOjLNGhxkPy3JVfwP4GRQbw2rFWNMzaPC/i6LGuB9GMPuUNjJHpZyl2+k33f9vFwfZiWoqIwJTRQTnXsbSa/amgtlaFX//43n9NMMPrI9WryoiYHTWQGiDxNuzqN6qjtthUlNfPBovsaqSsmcW9XELhsMxoo/t1G6LQWqEiCq5FB/bsnEig24CJeRELHL42A3bii+VWiBl/kgMEd/ju3J0VIqbLKIJcPQWhcomW5YGMf8Q9+FNZPyA4i3ebwwehh+etfND6+d3DOeXE84ZGLtJppELRwbgvJO/JWE/qxCdNSO4Nh3No+rRqXal3IESQBkfawuQoLIMBod7MCrRzo5d4J1asyoFJU+FMLRYjCcgaMUudUNViux6g86Cfav9rTDmhs7zdIZxaCOSNgLv9gfNu6AY="
           on:
             tags: true
-            rvm: 2.1.9
+            rvm: 2.4.1
             condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Fri Mar 09 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.4.0-0
+- Set the ownership and permissions of puppet/puppetdb.conf in
+  simp::puppetdb, instead of allowing them to be set to those of
+  the process running puppet, if the file needs to be created.
+  This is part of the fix to the failure of SIMP to bootstrap on a
+  system on which root's umask has already been restricted to 077.
+
 * Mon Feb 26 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.4.0-0
 - Remove management of the 'root' user's groups in the User resource
   - Works around https://tickets.puppetlabs.com/browse/PUP-8470

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -132,6 +132,11 @@ class simp::puppetdb (
     # and permissions.  To ensure the file is usable, no matter what the
     # umask of is of the process creating it, set the ownership and
     # permissions here.
+    #
+    # This smells like an upstream issue, and other have agreed
+    # https://tickets.puppetlabs.com/browse/MODULES-5391
+    # If puppetlabs/puppetdb gets updated, watch out for duplicate
+    # declaration errors for this file resource.
     file { "${::puppetdb::master::puppetdb_conf::puppet_confdir}/puppetdb.conf":
       ensure  => present,
       owner  => 'root',

--- a/spec/fixtures/hieradata/simp_puppetdb_manage_config_false.yaml
+++ b/spec/fixtures/hieradata/simp_puppetdb_manage_config_false.yaml
@@ -4,3 +4,7 @@
 # management of the puppet service by pupmod::master::base and
 # puppetdb::master::config.
 puppetdb::master::config::restart_puppet: false
+
+# This setting means the user has decided to manage puppetdb config
+# outside of puppetdb::master::config.
+puppetdb::master::config::manage_config: false


### PR DESCRIPTION
Set the ownership and permissions of puppet/puppetdb.conf in
simp::puppetdb, instead of allowing them to be set to those of
the process running puppet, if the file needs to be created.
This is part of the fix to the failure of SIMP to bootstrap on a
system on which root's umask has already been restricted to 077.

SIMP-4482 #comment pupmod-simp-simp fix for puppet/puppetdb.conf