### PR TITLE
(SIMP-4505) Fix admin_clean_puppet_certs sudo bug

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@
 .cache_bundler: &cache_bundler
   cache:
     untracked: true
-    # An attempt at caching between runs (ala Travis CI)
+    # A broad attempt at caching between runs (ala Travis CI)
     key: "${CI_PROJECT_NAMESPACE}__bundler"
     paths:
       - '.vendor'
@@ -22,11 +22,16 @@
 
 .setup_bundler_env: &setup_bundler_env
   before_script:
-    - '(find .vendor | wc -l) || :'
-    - bundle check || gem install bundler --no-rdoc --no-ri
-    - rm -f Gemfile.lock
-    - rm -rf pkg/
-    - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
+    - 'echo Files in cache: $(find .vendor | wc -l) || :'
+    - 'export GEM_HOME=.vendor/gem_install'
+    - 'export BUNDLE_CACHE_PATH=.vendor/bundler'
+    - 'declare GEM_BUNDLER_VER=(-v ''~> ${BUNDLER_VERSION:-1.16.0}'')'
+    - declare GEM_INSTALL=(gem install --no-document)
+    - declare BUNDLER_INSTALL=(bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}")
+    - gem list -ie "${GEM_BUNDLE_VER[@]}" --silent bundler || "${GEM_INSTALL[@]}" --local "${GEM_BUNDLE_VER[@]}" bundler || "${GEM_INSTALL[@]}" "${GEM_BUNDLE_VER[@]}" bundler
+    - 'rm -rf pkg/ || :'
+    - bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL[@]}" --local || "${BUNDLER_INSTALL[@]}")
+
 
 .validation_checks: &validation_checks
   script:
@@ -52,7 +57,7 @@ stages:
 # Puppet 4.7 for PE 2016.4 LTS Support (EOL: 2018-10-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
 # --------------------------------------
-pup4.7-validation:
+pup4_7-validation:
   stage: validation
   tags:
     - docker
@@ -63,7 +68,7 @@ pup4.7-validation:
   <<: *setup_bundler_env
   <<: *validation_checks
 
-pup4.7-unit:
+pup4_7-unit:
   stage: unit
   tags:
     - docker
@@ -77,7 +82,7 @@ pup4.7-unit:
 
 # Puppet 4.8 for SIMP 6.0 + 6.1 support
 # --------------------------------------
-pup4.8-validation:
+pup4_8-validation:
   stage: validation
   tags:
     - docker
@@ -88,7 +93,7 @@ pup4.8-validation:
   <<: *setup_bundler_env
   <<: *validation_checks
 
-pup4.8-unit:
+pup4_8-unit:
   stage: unit
   tags:
     - docker
@@ -103,7 +108,7 @@ pup4.8-unit:
 # Puppet 4.10 for PE 2017.2 support (EOL:2018-02-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
 # --------------------------------------
-pup4.10-validation:
+pup4_10-validation:
   stage: validation
   tags:
     - docker
@@ -114,7 +119,7 @@ pup4.10-validation:
   <<: *setup_bundler_env
   <<: *validation_checks
 
-pup4.10-unit:
+pup4_10-unit:
   stage: unit
   tags:
     - docker
@@ -129,7 +134,7 @@ pup4.10-unit:
 # Puppet 5.3 for PE 2017.3 support (EOL: 2018-07)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
 # --------------------------------------
-pup5.3-validation:
+pup5_3-validation:
   stage: validation
   tags:
     - docker
@@ -141,7 +146,7 @@ pup5.3-validation:
   <<: *validation_checks
   allow_failure: true
 
-pup5.3-unit:
+pup5_3-unit:
   stage: unit
   tags:
     - docker
@@ -156,7 +161,7 @@ pup5.3-unit:
 
 # Keep an eye on the latest puppet 5
 # ----------------------------------
-pup5.latest-validation:
+pup5_latest-validation:
   stage: validation
   tags:
     - docker
@@ -168,7 +173,7 @@ pup5.latest-validation:
   <<: *validation_checks
   allow_failure: true
 
-pup5.latest-unit:
+pup5_latest-unit:
   stage: unit
   tags:
     - docker
@@ -190,6 +195,8 @@ base_apps:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
   script:
     - bundle exec rake beaker:suites[base_apps]
 
@@ -199,6 +206,8 @@ default:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
   script:
     - bundle exec rake beaker:suites[default]
 
@@ -208,6 +217,8 @@ default-puppet5:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
   script:
     - bundle exec rake beaker:suites[default,puppet5]
   allow_failure: true
@@ -218,6 +229,8 @@ no_simp_server:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
   script:
     - bundle exec rake beaker:suites[no_simp_server]
 
@@ -227,6 +240,8 @@ one_shot_scenario:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
   script:
     - bundle exec rake beaker:suites[scenario_one_shot]
 
@@ -236,6 +251,8 @@ poss_scenario:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
   script:
     - bundle exec rake beaker:suites[scenario_poss]
 
@@ -245,6 +262,8 @@ remote_access_scenario:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
   script:
     - bundle exec rake beaker:suites[scenario_remote_access]
   allow_failure: true

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Wed Mar 14 2018 Nick Miller <nick.miller@onyxpoint.com> - 4.4.0-0
+- Fixed a bug where if the `puppet_settings` fact did not exist, users in the
+  `%administrators` group could `rm -rf` any path
+- The value in the hash was also corrected to
+  `$facts['puppet_settings']['main']['ssldir']`
+
 * Fri Mar 09 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.4.0-0
 - Set the ownership and permissions of puppet/puppetdb.conf in
   simp::puppetdb, instead of allowing them to be set to those of

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -19,18 +19,20 @@ describe 'simp' do
 
       context "on #{os}" do
         let(:facts) do
-            os_facts[:puppet_vardir] = '/opt/puppetlabs/puppet/cache'
-            os_facts[:puppet_settings] = {
+          os_facts[:puppet_vardir] = '/opt/puppetlabs/puppet/cache'
+          os_facts[:puppet_settings] = {
+            'main' => {
               'ssldir' => '/opt/puppetlabs/puppet/vardir',
-              'agent' => {
-                'server' => 'puppet.bar.baz'
-              }
+            },
+            'agent' => {
+              'server' => 'puppet.bar.baz'
             }
-            os_facts[:server_facts] = {
-              :servername => 'puppet.bar.baz',
-              :serverip   => '1.2.3.4'
-            }
-            os_facts
+          }
+          os_facts[:server_facts] = {
+            :servername => 'puppet.bar.baz',
+            :serverip   => '1.2.3.4'
+          }
+          os_facts
         end
 
         context 'with default parameters (scenario defaults to simp)' do
@@ -135,7 +137,9 @@ describe 'simp' do
           facts[:augeasversion] = '1.2.3'
           facts[:puppet_vardir] = '/opt/puppetlabs/puppet/cache'
           facts[:puppet_settings] = {
-            'ssldir' => '/opt/puppetlabs/puppet/vardir',
+            'main' => {
+              'ssldir' => '/opt/puppetlabs/puppet/vardir',
+            },
             'agent' => {
               'server' => 'puppet.bar.baz'
             }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -5,7 +5,14 @@ describe 'simp::server' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         let(:facts) do
-          facts[:puppet_settings] = { :ssldir => '/opt/puppet/somewhere/ssl' }
+          facts[:puppet_settings] = {
+            'main' => {
+              'ssldir' => '/opt/puppetlabs/puppet/vardir',
+            },
+            'agent' => {
+              'server' => 'puppet.bar.baz'
+            }
+          }
           facts[:augeasversion] = '1.4.0'
           facts[:openssh_version] = '5.7'
           facts

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -152,3 +152,8 @@ Dir.glob("#{RSpec.configuration.module_path}/*").each do |dir|
     fail "ERROR: The module '#{dir}' is not installed. Tests cannot continue."
   end
 end
+
+if ENV['PUPPET_DEBUG']
+  Puppet::Util::Log.level = :debug
+  Puppet::Util::Log.newdestination(:console)
+end


### PR DESCRIPTION
- Fixed a bug where if the `puppet_settings` fact did not exist, users
  in the `%administrators` group could `rm -rf` any path
- The value in the hash was also corrected to
  `$facts['puppet_settings']['main']['ssldir']`

SIMP-4441 #close