### PR TITLE
(SIMP-4543) Change log updates (and metadata.json)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 * Fri Mar 16 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.4.0-0
-- updated metadata.json to include trinklin/nsswitch
+- updated metadata.json to include trlinkin/nsswitch
 
 * Wed Mar 14 2018 Nick Miller <nick.miller@onyxpoint.com> - 4.4.0-0
 - Fixed a bug where if the `puppet_settings` fact did not exist, users in the

--- a/metadata.json
+++ b/metadata.json
@@ -134,7 +134,7 @@
       "version_requirement": ">= 4.0.0 < 5.0.0"
     },
     {
-      "name": "trinklin/nsswitch",
+      "name": "trlinkin/nsswitch",
       "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],


### PR DESCRIPTION
- The name for nsswitch module was spelled wrong.

SIMP-4543 #comment updates for pupmod-simp-simp