### PR TITLE
(SIMP-4579) simp: prelink acceptance tests fail in FIPS mode

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -211,6 +211,18 @@ default:
   script:
     - bundle exec rake beaker:suites[default]
 
+default-fips:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
+    BEAKER_fips: 'yes'
+  script:
+    - bundle exec rake beaker:suites[default]
+
 default-puppet5:
   stage: acceptance
   tags:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
+* Tue Mar 27 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.4.0-0
+- In simp::prelink, ensure prelinking is disabled when the server is
+  in FIPS mode, as FIPS is incompatible with prelinking.
+
 * Fri Mar 16 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.4.0-0
-- updated metadata.json to include trlinkin/nsswitch
+- Updated metadata.json to include trlinkin/nsswitch
 
 * Wed Mar 14 2018 Nick Miller <nick.miller@onyxpoint.com> - 4.4.0-0
 - Fixed a bug where if the `puppet_settings` fact did not exist, users in the

--- a/manifests/prelink.pp
+++ b/manifests/prelink.pp
@@ -1,19 +1,22 @@
 # Manage prelinking
 #
 # @param enable
-#   Whether to enable prelinking.
+#   Whether to enable prelinking.  Prelinking can only be enabled if
+#   the server is *NOT* in FIPS mode.
 #
-#   * When ``$enable`` is ``true``, ensures the prelink package
-#     is installed and prelinking has been enabled.
+#   * When ``$enable`` is ``true`` and ``$facts['fips_enabled']`` is
+#     ``false``, ensures the prelink package is installed and
+#     prelinking has been enabled.
 #
-#   * When ``$enable`` is ``false``, ensures the prelink package
-#     is not installed, undoing any existing prelinking, if needed.
-#     This satisfies the SCAP Security Guide's OVAL check
+#   * When ``$enable`` is ``false`` or ``$facts['fips_enabled']`` is
+#     ``true``, ensures the prelink package is not installed, undoing
+#     any existing prelinking, if needed.  This satisfies the SCAP
+#     Security Guide's OVAL check
 #     xccdf_org.ssgproject.content_rule_disable_prelink.
 #
 # @param ensure
 #   The ``$ensure`` status of the prelink package, when ``$enable``
-#   is ``true``.
+#   is ``true`` and ``$facts['fips_enabled']`` is ``false``.
 #
 # @author https://github.com/simp/pupmod-simp-simp/graphs/contributors
 #
@@ -23,7 +26,7 @@ class simp::prelink (
 ) {
   simplib::assert_metadata( $module_name )
 
-  if $enable {
+  if ( $enable and ! $facts['fips_enabled'] ) {
     package { 'prelink': ensure => $ensure }
 
     shellvar { 'enable prelink':

--- a/spec/classes/prelink_spec.rb
+++ b/spec/classes/prelink_spec.rb
@@ -16,15 +16,15 @@ describe 'simp::prelink' do
 
         context 'when prelink is installed and disabled' do
           let(:facts) do
-            os_facts.merge( {:prelink => { :enabled => false } } )
+            os_facts.merge( { :prelink => { :enabled => false } } )
           end
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('simp::prelink') }
           it {
             is_expected.to contain_exec('remove prelinking').with( {
-              :command     => '/etc/cron.daily/prelink',
-              :before      =>'Package[prelink]'
+              :command => '/etc/cron.daily/prelink',
+              :before  =>'Package[prelink]'
             } )
           }
 
@@ -33,7 +33,12 @@ describe 'simp::prelink' do
 
         context 'when prelink is installed and enabled' do
           let(:facts) do
-            os_facts.merge( {:prelink => { :enabled => true } } )
+            os_facts.merge( {
+              :prelink      => { :enabled => true },
+              # if prelink is on, FIPS cannot be enabled, because the
+              # system would be broken in that configuration
+              :fips_enabled => false
+            } )
           end
 
           it { is_expected.to compile.with_all_deps }
@@ -57,27 +62,49 @@ describe 'simp::prelink' do
 
           it { is_expected.to contain_package('prelink').with_ensure('absent') }
         end
-
       end
 
       context 'when enable=true' do
-        let(:facts) do
-          os_facts
+        context 'when FIPS mode is not enabled' do
+          let(:facts) do
+            os_facts.merge( { :fips_enabled => false } )
+          end
+
+          let(:params) {{ :enable => true }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('simp::prelink') }
+          it { is_expected.to contain_package('prelink').that_comes_before('Shellvar[enable prelink]') }
+          it {
+            is_expected.to contain_shellvar('enable prelink').with( {
+              :ensure   => 'present',
+              :target   => '/etc/sysconfig/prelink',
+              :variable => 'PRELINKING',
+              :value    => 'yes'
+            } )
+           }
         end
 
-        let(:params) {{ :enable => true }}
+        context 'when FIPS mode is enabled and prelink is installed' do
+          let(:facts) do
+            os_facts.merge( {
+              :prelink      => { :enabled => false },
+              :fips_enabled => true
+            } )
+          end
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_class('simp::prelink') }
-        it { is_expected.to contain_package('prelink').that_comes_before('Shellvar[enable prelink]') }
-        it {
-          is_expected.to contain_shellvar('enable prelink').with( {
-            :ensure   => 'present',
-            :target   => '/etc/sysconfig/prelink',
-            :variable => 'PRELINKING',
-            :value    => 'yes'
-          } )
-         }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('simp::prelink') }
+          it {
+            is_expected.to contain_exec('remove prelinking').with( {
+              :command => '/etc/cron.daily/prelink',
+              :before  =>'Package[prelink]'
+            } )
+          }
+
+          it { is_expected.to contain_package('prelink').with_ensure('absent') }
+        end
+
       end
     end
   end


### PR DESCRIPTION
The prelink acceptance tests were failing when the server was in
FIPS mode because FIPS and prelink are incompatible!  So, to
prevent an uninformed user from making this mistake, updated
simp::prelink to ensure prelinking is disabled when the server
is in FIPS mode.

SIMP-4579 #close