### PR TITLE
(SIMP-4597) Fix Perms on ctrl-alt-del-capture file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Apr 02 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.4.2-0
+- changed permission on ctrl-alt-del-capture.service to prevent "no effect"
+  errors in system logs.
+
 * Thu Mar 29 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.4.1-0
 - Ensure that a file exists on EL 6 if portreserve is enabled so that the
   portreserve service does not flap

--- a/manifests/ctrl_alt_del.pp
+++ b/manifests/ctrl_alt_del.pp
@@ -62,7 +62,7 @@ class simp::ctrl_alt_del (
           ensure  => 'file',
           owner   => 'root',
           group   => 'root',
-          mode    => '0640',
+          mode    => '0644',
           content => template("${module_name}/etc/systemd/system/ctrl-alt-del-capture.service.erb")
         }
       }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",


### PR DESCRIPTION
  - change perms set on service file to prevent annoying errors.

SIMP-4625 #close
SIMP-4597 #comment ctrl-alt-del-capture fix applied