### PR TITLE
(SIMP-4819) Set hostname in runpuppet

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Mon Apr 16 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.4.2-0
+- In the runpuppet init script used to bootstrap kickstarted clients,
+  for EL7, persist the hostname retrieved by DHCP as a static hostname.
+  This prevents problems that can arise on EL7 when the DHCP lease
+  expires in the middle of the client bootstrap puppet runs.
+
 * Mon Apr 02 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.4.2-0
 - changed permission on ctrl-alt-del-capture.service to prevent "no effect"
   errors in system logs.

--- a/manifests/server/kickstart/runpuppet.pp
+++ b/manifests/server/kickstart/runpuppet.pp
@@ -40,7 +40,9 @@
 #   certificate is not presented.
 #
 # @param fips
-#   If true, set puppet keylength to 2048, else 4096.
+#   If true, set puppet keylength to 2048, else 4096.  This non-compliant
+#   setting is to work around problems with older versions of Ruby.  It
+#   will be fixed, when Puppet fully supports FIPS mode.
 #
 class simp::server::kickstart::runpuppet (
   Boolean                     $fips                    = simplib::lookup('simp_options::fips', { 'default_value' => false }),

--- a/spec/classes/server/kickstart/files/default_runpuppet
+++ b/spec/classes/server/kickstart/files/default_runpuppet
@@ -16,7 +16,7 @@ function ensure_running {
   running="false"
   timeout=0
   while [ $timeout -lt 300 ] && [ "$running" == "false" ]; do
-    if [[ "$(/usr/bin/curl -sS --cert $ssldir/ssl/certs/<%= @_puppet_server %>.pem --key $ssldir/puppet/ssl/private_keys/<%= @_puppet_server %>.pem -k -H 'Accept: s' https://<%= @_puppet_ca %>:$ca_port/puppet-ca/v1/certificate_revocation_list/ca 2> /dev/null)" =~ "CRL" ]]; then
+    if [[ "$(/usr/bin/curl -sS --cert $ssldir/ssl/certs/puppet.bar.baz.pem --key $ssldir/puppet/ssl/private_keys/puppet.bar.baz.pem -k -H 'Accept: s' https://puppet.bar.baz:$ca_port/puppet-ca/v1/certificate_revocation_list/ca 2> /dev/null)" =~ "CRL" ]]; then
       running="true"
     fi
     timeout=$[$timeout+1]
@@ -58,24 +58,13 @@ if [ "$LOCKED" == 'true' ]; then
 fi
 
 # Change me to meet the needs of your domain!
-puppet_server="<%= @_puppet_server %>";
+puppet_server="puppet.bar.baz";
 
 logfile="/root/puppet.bootstrap.log";
 delim="--------------------------------------------------------------------------------";
 server=1;
-<%
-  t_puppet_cmd_line = "puppet agent --onetime --no-daemonize --no-show_diff --no-splay"
-
-  if @runpuppet_wait_for_cert
-    t_puppet_cmd_line += " --waitforcert #{@runpuppet_wait_for_cert}"
-  end
-
-  if @runpuppet_print_stats
-    t_puppet_cmd_line += " --evaltrace --summarize"
-  end
--%>
-puppet="<%= t_puppet_cmd_line %> --verbose";
-quiet_puppet="<%= t_puppet_cmd_line %>";
+puppet="puppet agent --onetime --no-daemonize --no-show_diff --no-splay --waitforcert 10 --evaltrace --summarize --verbose";
+quiet_puppet="puppet agent --onetime --no-daemonize --no-show_diff --no-splay --waitforcert 10 --evaltrace --summarize";
 puppetca="puppet ca";
 
 if [ -x "$(command -v puppetserver)" ]; then
@@ -113,13 +102,6 @@ case "$1" in
         fi
     fi
 
-<%
-  if @fips
-    _keylength = '2048'
-  else
-    _keylength = '4096'
-  end
--%>
     read -r -d '' puppet_conf <<'EOM'
 [main]
     vardir            = /opt/puppetlabs/puppet/cache
@@ -128,28 +110,18 @@ case "$1" in
     logdir            = /var/log/puppetlabs/puppet
     report            = false
     rundir            = /var/run/puppetlabs
-    server            = <%= @_puppet_server %>
+    server            = puppet.bar.baz
     ssldir            = /etc/puppetlabs/puppet/ssl
     trusted_node_data = true
     stringify_facts   = false
     digest_algorithm  = sha256
-    keylength         = <%= _keylength %>
+    keylength         = 4096
 EOM
 
     echo "$puppet_conf" > /etc/puppetlabs/puppet/puppet.conf;
-    echo "ca_server = <%= @_puppet_ca %>" >> /etc/puppetlabs/puppet/puppet.conf;
-    echo "ca_port = <%= @puppet_ca_port %>" >> /etc/puppetlabs/puppet/puppet.conf;
+    echo "ca_server = puppet.bar.baz" >> /etc/puppetlabs/puppet/puppet.conf;
+    echo "ca_port = 8141" >> /etc/puppetlabs/puppet/puppet.conf;
 
-<%
-   l_ntp_servers = @ntp_servers
-   unless l_ntp_servers.empty?
-     if l_ntp_servers.kind_of?(Hash)
-       l_ntp_servers = l_ntp_servers.keys.sort
-     end
--%>
-    echo "Setting the system time against <%= l_ntp_servers.join(' ') %>";
-    /usr/sbin/ntpdate -b <%= l_ntp_servers.join(' ') %>;
-<% end -%>
 
     echo "Running Puppet Bootstrap (This may take some time)";
     touch /root/.fullrun;

--- a/spec/classes/server/kickstart/runpuppet_spec.rb
+++ b/spec/classes/server/kickstart/runpuppet_spec.rb
@@ -10,6 +10,24 @@ describe 'simp::server::kickstart::runpuppet' do
           facts
         end
 
+        context 'default parameters (using fixtures/hieradata/default.yaml)' do
+          it { is_expected.to compile.with_all_deps }
+          it {
+          expected_content = File.read(File.join(File.dirname(__FILE__), 'files',
+            'default_runpuppet'))
+            is_expected.to create_file('/var/www/ks/runpuppet').with_content(expected_content)
+          }
+        end
+
+        context 'with fips=true' do
+          let(:params) {{
+            :fips => true
+          }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/var/www/ks/runpuppet').with_content(/keylength         = 2048/) }
+        end
+
         context 'specify_ntp_servers_array' do
           let(:params) {{
             :ntp_servers => ['1.2.3.4','5.6.7.8']


### PR DESCRIPTION
- For EL7, in the runpuppet init script used to bootstrap kickstarted
  clients, persist the hostname retrieved by DHCP as a static hostname.
  This prevents problems that can arise when the DHCP lease expires
  in the middle of the client bootstrap puppet runs.

SIMP-4819 #close