### PR TITLE
(SIMP-4849) Add Windows support to the module

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+* Mon Apr 30 2018 Dylan Cochran <dylan.cochran@onyxpoint.com> - 4.5.0-0
+- Add Windows support to simp-simp
+
+* Mon Apr 30 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.4.2-0
+- Narrow the focus of the internal hieradata to ensure correct runs on
+  unsupported OSs
+- Update unsupported OS tests
+- Add a test to ensure that an error is throw if an invalid scenario is
+  specified
+
 * Fri Apr 27 2018 Nick Miller <nick.miller@onyxpoint.com> - 4.4.2-0
 - Add simp::netconsole class to manage the netconsole kernel feature
 - Fix a few puppet-lint warnings
@@ -15,14 +25,6 @@
   selinux.  This may change the defaults for selinux in the `simp_lite`
   scenario.
   
-* Tue Apr 17 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.4.2-0
-- Narrow the focus of the internal hieradata to ensure correct runs on
-  unsupported OSs
-- Update unsupported OS tests
-- Add a test to ensure that an error is throw if an invalid scenario is
-  specified
-
-
 * Mon Apr 16 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.4.2-0
 - In the runpuppet init script used to bootstrap kickstarted clients,
   for EL7, persist the hostname retrieved by DHCP as a static hostname.

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -20,11 +20,12 @@ lookup_options:
       strategy: unique
       # Disable this for now.
       #knockout_prefix: --
-
-# This is all that we support on unknown operating systems
 simp::scenario_map:
   none: []
-
+  remote_access: []
+  poss: []
+  simp_lite: []
+  simp: []
 simp::server::scenario_map:
   none: []
   remote_access: "%{alias('simp::server::data')}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,12 +173,13 @@ class simp (
   else {
     fail("ERROR - Invalid scenario '${scenario}' for the given scenario map.")
   }
-
+  if (downcase($facts['kernel']) == 'linux') {
   file { "${facts['puppet_vardir']}/simp":
     ensure => 'directory',
     mode   => '0750',
     owner  => 'root',
     group  => 'root'
+  }
   }
 
   if $enable_filebucketing {

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -1,6 +1,6 @@
 # Places SIMP version related information on the filesystem
 class simp::version {
-
+  if (downcase($facts['kernel']) == 'linuc') {
   file { '/etc/simp':
     ensure => 'directory',
     owner  => 'root',
@@ -21,5 +21,6 @@ class simp::version {
     owner  => 'root',
     group  => 'root',
     mode   => '0640'
+  }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.4.2",
+  "version": "4.5.0",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",
@@ -157,6 +157,19 @@
       "operatingsystemrelease": [
         "6",
         "7"
+      ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+	"Server 2008",
+        "Server 2008 R2",
+        "Server 2012",
+        "Server 2012 R2",
+        "Server 2016",
+        "7",
+        "8",
+        "10"
       ]
     }
   ]


### PR DESCRIPTION
* Add conditional on Windows platforms, that changes the simp.version
  location depending on whether it was Windows or not.
* Add module data for $facts['puppet_vardir']/simp user, group, and mode
* Add stub data for scenarios, there's no reason to fail a catalog compile
  just by including simp.

Fixes enterprise-meta#338
SIMP-4849 #close