### PR TITLE
(SIMP-3858) Remove simp_options::selinux

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,11 @@
 * Mon Apr 23 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> 4.4.2-0
-- Simp_options::selinux was suppose to determine if the selinux module
+- Simp_options::selinux was supposed to determine if the selinux module
   was included.  This was getting overridden by the class lists and selinux
   module was included. This change removes the simp_options::selinux setting
   to stop this confussion.  See the scenario maps in the data section to see what
   scenarios include the selinux module.  See the selinux module to see how to
   use puppet to enable/disable selinux.  This may change the defaults for selinux in
-  the simp_lite scenario.
+  the `simp_lite` scenario.
 
 * Mon Apr 16 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.4.2-0
 - In the runpuppet init script used to bootstrap kickstarted clients,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+* Mon Apr 23 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> 4.4.2-0
+- Simp_options::selinux was suppose to determine if the selinux module
+  was included.  This was getting overridden by the class lists and selinux
+  module was included. This change removes the simp_options::selinux setting
+  to stop this confussion.  See the scenario maps in the data section to see what
+  scenarios include the selinux module.  See the selinux module to see how to
+  use puppet to enable/disable selinux.  This may change the defaults for selinux in
+  the simp_lite scenario.
+
 * Mon Apr 16 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.4.2-0
 - In the runpuppet init script used to bootstrap kickstarted clients,
   for EL7, persist the hostname retrieved by DHCP as a static hostname.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,12 @@
 * Mon Apr 23 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> 4.4.2-0
-- Simp_options::selinux was supposed to determine if the selinux module
-  was included.  This was getting overridden by the class lists and selinux
-  module was included. This change removes the simp_options::selinux setting
-  to stop this confussion.  See the scenario maps in the data section to see what
-  scenarios include the selinux module.  See the selinux module to see how to
-  use puppet to enable/disable selinux.  This may change the defaults for selinux in
-  the `simp_lite` scenario.
+- simp_options::selinux was supposed to determine if the selinux module was
+  included.  However, this value was getting overridden by the class lists
+  which independently included the selinux module. This change removes the
+  unused simp_options::selinux setting to eliminate the confusion.  See the
+  scenario maps in the data section to see what scenarios include the selinux
+  module.  See the selinux module to see how to use puppet to enable/disable
+  selinux.  This may change the defaults for selinux in the `simp_lite`
+  scenario.
 
 * Mon Apr 16 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.4.2-0
 - In the runpuppet init script used to bootstrap kickstarted clients,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -10,9 +10,6 @@
 # @param clamav
 #   Enable SIMP management of Antivirus
 #
-# @param selinux
-#   Enable SIMP management of SELinux
-#
 # @param auditd
 #   Enable SIMP management of auditing
 #

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -35,7 +35,6 @@ class simp::server (
   Boolean $allow_simp_user = false,
   Boolean $pam             = simplib::lookup('simp_options::pam', { 'default_value'     => false }),
   Boolean $clamav          = simplib::lookup('simp_options::clamav', { 'default_value'  => false }),
-  Boolean $selinux         = simplib::lookup('simp_options::selinux', { 'default_value' => false }),
   Boolean $auditd          = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
   String  $scenario        = simplib::lookup('simp::scenario', { 'default_value' => 'simp' }),
   Array[String] $classes   = [],
@@ -56,7 +55,6 @@ class simp::server (
   }
 
   if $clamav  { include '::clamav' }
-  if $selinux { include '::selinux' }
   if $auditd  { include '::auditd' }
 
   if $allow_simp_user {

--- a/spec/acceptance/suites/scenario_one_shot/00_simp_spec.rb
+++ b/spec/acceptance/suites/scenario_one_shot/00_simp_spec.rb
@@ -66,7 +66,6 @@ simp_options::firewall: true
 simp_options::haveged: true
 simp_options::logrotate: true
 simp_options::pam: true
-simp_options::selinux: true
 simp_options::sssd: true
 simp_options::syslog: true
 simp_options::tcpwrappers: true

--- a/spec/acceptance/suites/scenario_remote_access/templates/client_hieradata.yaml.erb
+++ b/spec/acceptance/suites/scenario_remote_access/templates/client_hieradata.yaml.erb
@@ -35,7 +35,6 @@ simp_options::logrotate: false
 simp_options::pam: true
 # Set to 'true' for non-puppetserver based acceptance
 #simp_options::pki: simp
-simp_options::selinux: false
 simp_options::sssd: true
 simp_options::stunnel: false
 simp_options::syslog: false

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -28,7 +28,6 @@ simp_options::puppet::ca_port : 8141
 simp_options::puppet::server : 'puppet.bar.baz'
 simp_options::rsync::server : 'rsync.bar.baz'
 simp_options::rsync::timeout : 1
-simp_options::selinux : false
 simp_options::auditd : true
 simp_options::firewall : true
 


### PR DESCRIPTION
  - removed the check for simp_options::selinux.  The inclussion of
    selinux module will rely on the scenario class lists.

SIMP-3858 #comment pupmod-simp-simp updated
SIMP-4529 #close