### PR TITLE
(SIMP-4849) Add Windows support to the module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ vendor/
 junit/
 log/
 doc/
+.idea/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -155,7 +155,7 @@ pup5_3-unit:
   <<: *cache_bundler
   <<: *setup_bundler_env
   <<: *spec_tests
-
+  allow_failure: true
 
 # Keep an eye on the latest puppet 5
 # ----------------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jun 08 2018 Dylan Cochran <dylan.cochran@onyxpoint.com> - 4.5.0-0
+- Add Windows support
+
 * Thu May 03 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.5.0-0
 - Created standalone SIMP client bootstrap script, bootstrap_simp_client.
 - Created simp::server::kickstart::runpuppet replacement,

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
   gem 'rspec'
   gem 'rspec-puppet', ['>= 2.6.11', '< 3.0.0']
   gem 'hiera-puppet-helper'
-  gem 'puppetlabs_spec_helper'
+  gem 'puppetlabs_spec_helper', '~> 2.7.0'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -20,11 +20,15 @@ lookup_options:
       strategy: unique
       # Disable this for now.
       #knockout_prefix: --
-
-# This is all that we support on unknown operating systems
+simp::vardir_owner: 'root'
+simp::vardir_group: 'root'
+simp::vardir_mode: '0750'
 simp::scenario_map:
   none: []
-
+  remote_access: []
+  poss: []
+  simp_lite: []
+  simp: []
 simp::server::scenario_map:
   none: []
   remote_access: "%{alias('simp::server::data')}"

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -1,0 +1,3 @@
+simp::vardir_owner: 'Administrators'
+simp::vardir_group: 'Administrators'
+simp::vardir_mode: '0770'

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -1,25 +1,42 @@
 # Places SIMP version related information on the filesystem
-class simp::version {
-
-  file { '/etc/simp':
-    ensure => 'directory',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644'
+class simp::version () {
+  # XXX: ToDo: Move /etc/simp creation to a simplib class and use
+  # moduledata to resolve the variables..
+  #
+  # It's needed in more places then here, and they don't need to pull in
+  # anything else from simp
+  if (downcase($facts['kernel']) == 'windows') {
+    $simp_root_dir = 'C:/ProgramData/SIMP'
+    $simp_root_dir_user = 'BUILTIN\Administrators'
+    $simp_root_dir_group = 'BUILTIN\Administrators'
+    # Windows permission model is different then *nix,
+    # so 770 is the only one that can be translated without
+    # also pulling in windows_acl
+    $simp_root_dir_mode = '0770'
+  } else {
+    $simp_root_dir = "/etc/simp"
+    $simp_root_dir_group = "root"
+    $simp_root_dir_user = "root"
+    $simp_root_dir_mode = '0640'
+    file { '/usr/local/sbin/simp':
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0640'
+    }
   }
+  ensure_resource('file', $simp_root_dir, {
+    ensure => 'directory',
+    owner  => $simp_root_dir_user,
+    group  => $simp_root_dir_group,
+    mode   => $simp_root_dir_mode
+  })
 
-  file { '/etc/simp/simp.version':
+  file { "${simp_root_dir}/simp.version":
     ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+    owner   => $simp_root_dir_user,
+    group   => $simp_root_dir_group,
+    mode    => $simp_root_dir_mode,
     content => simp_version()
-  }
-
-  file { '/usr/local/sbin/simp':
-    ensure => 'directory',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0640'
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -158,6 +158,19 @@
         "6",
         "7"
       ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "Server 2008",
+        "Server 2008 R2",
+        "Server 2012",
+        "Server 2012 R2",
+        "Server 2016",
+        "7",
+        "8.1",
+        "10"
+      ]
     }
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -40,7 +40,7 @@ describe 'simp' do
         end
 
         context 'with default parameters (scenario defaults to simp)' do
-          it { is_expected.to compile.and_raise_error(/Invalid scenario 'simp' for the given scenario map/) }
+          it { is_expected.to compile }
         end
 
         context 'with scenario "poss"' do
@@ -48,7 +48,7 @@ describe 'simp' do
             { :scenario => 'poss' }
           end
 
-          it { is_expected.to compile.and_raise_error(/Invalid scenario 'poss' for the given scenario map/) }
+          it { is_expected.to compile }
         end
 
         context 'with scenario "none"' do


### PR DESCRIPTION
* Add conditional on Windows platforms, that changes the simp.version
  location depending on whether it was Windows or not.
* Add module data for $facts['puppet_vardir']/simp user, group, and mode
* Add stub data for scenarios, there's no reason to fail a catalog compile
  just by including simp.

Fixes enterprise-meta#338
SIMP-4849 #close