### PR TITLE
(SIMP-4859) Separate runpuppet script from the services

### DIFF
--- a/.pmtignore
+++ b/.pmtignore
@@ -1,0 +1,17 @@
+.*.sw?
+.yardoc
+dist/
+pkg/
+spec/fixtures/
+spec/rp_env/
+!/spec/hieradata/default.yaml
+!/spec/fixtures/site.pp
+.rspec_system
+.vagrant/
+.bundle/
+Gemfile.lock
+vendor/
+junit/
+log/
+doc/
+tests/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu May 03 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.4.2-0
+- Create standalone SIMP client bootstrap script, bootstrap_simp_client.
+
 * Fri Apr 27 2018 Nick Miller <nick.miller@onyxpoint.com> - 4.4.2-0
 - Add simp::netconsole class to manage the netconsole kernel feature
 - Fix a few puppet-lint warnings

--- a/files/var/www/ks/bootstrap_simp_client
+++ b/files/var/www/ks/bootstrap_simp_client
@@ -30,7 +30,6 @@ class BootstrapSimpClient
 
   # general program config
   DEFAULT_LOG_FILE              = '/root/puppet.bootstrap.log'
-#  DEFAULT_DRY_RUN               = false
   DEFAULT_QUIET                 = false
   DEFAULT_DEBUG                 = false
 
@@ -63,11 +62,11 @@ class BootstrapSimpClient
 
   def configure_puppet
     info(title('Setting puppet configuration', 2))
-    
+
     unless File.exist?(@options[:puppet_conf_file])
       raise ConfigurationError.new("Could not find puppet.conf at '#{@options[:puppet_conf_file]}'. Please check your puppet installation and try again.")
     end
-      
+
     puppet_config = <<EOM
 [main]
 vardir            = /opt/puppetlabs/puppet/cache

--- a/files/var/www/ks/bootstrap_simp_client
+++ b/files/var/www/ks/bootstrap_simp_client
@@ -11,7 +11,11 @@ class BootstrapSimpClient
   class ConfigurationError < RuntimeError; end
 
   # puppet config
-  DEFAULT_PUPPET_CONF_FILE      = `puppet config print config`.strip
+  if File.exist?('/opt/puppetlabs/bin/puppet')
+    DEFAULT_PUPPET_CONF_FILE    = `/opt/puppetlabs/bin/puppet config print config`.strip
+  else
+    DEFAULT_PUPPET_CONF_FILE    = '/etc/puppetlabs/puppet/puppet.conf'
+  end
   DEFAULT_PUPPET_CA_PORT        = 8141
   DEFAULT_DIGEST_ALGORITHM      = 'sha256'
   DEFAULT_PUPPET_KEYLENGTH      = 4096
@@ -59,6 +63,11 @@ class BootstrapSimpClient
 
   def configure_puppet
     info(title('Setting puppet configuration', 2))
+    
+    unless File.exist?(@options[:puppet_conf_file])
+      raise ConfigurationError.new("Could not find puppet.conf at '#{@options[:puppet_conf_file]}'. Please check your puppet installation and try again.")
+    end
+      
     puppet_config = <<EOM
 [main]
 vardir            = /opt/puppetlabs/puppet/cache

--- a/files/var/www/ks/bootstrap_simp_client
+++ b/files/var/www/ks/bootstrap_simp_client
@@ -11,7 +11,7 @@ class BootstrapSimpClient
   class ConfigurationError < RuntimeError; end
 
   # puppet config
-  DEFAULT_PUPPET_CONF_FILE      = '/etc/puppetlabs/puppet/puppet.conf'
+  DEFAULT_PUPPET_CONF_FILE      = `puppet config print config`.strip
   DEFAULT_PUPPET_CA_PORT        = 8141
   DEFAULT_DIGEST_ALGORITHM      = 'sha256'
   DEFAULT_PUPPET_KEYLENGTH      = 4096
@@ -52,6 +52,10 @@ class BootstrapSimpClient
     }
     @retry_interval = nil
   end
+
+  #####################################################################
+  # Helper methods, nominally used internally
+  #####################################################################
 
   def configure_puppet
     info(title('Setting puppet configuration', 2))
@@ -334,69 +338,6 @@ EOM
     @retry_interval = nil
   end
 
-  def run(args)
-    parse_command_line(args)
-    return 0 if @options[:help_requested] # already have logged help
-
-    set_up_log
-
-    info('Starting Puppet bootstrap')
-    info(DELIM)
-    Timeout::timeout(@options[:max_seconds]) do
-      info(title('Setting up system for Puppet bootstrap', 1))
-      info("    Detailed log written to #{@options[:log_file]}.")
-      debug("#{File.basename(__FILE__)} options: #{@options}")
-      configure_puppet
-      set_system_time
-
-      info(title('Running Puppet bootstrap (This may take some time)', 1))
-      info()
-      info(">>> Be sure to sign this client's Puppet cert request when it comes in! <<<")
-      info()
-
-      run_puppet_agent('--tags pupmod,simp',
-        title('Initial puppet agent run with pupmod,simp tags', 2))
-
-      fix_file_contexts
-
-      # SIMP is not single-run idempotent
-      (1..@options[:num_puppet_runs]).each do |run|
-        run_puppet_agent(nil,
-          title("#{run} of #{@options[:num_puppet_runs]} puppet agent runs", 2))
-      end
-
-      info(DELIM)
-      info('Puppet bootstrap successfully completed.')
-      return 0
-    end
-  rescue SignalException =>e
-    info(DELIM)
-    if e.inspect == 'Interrupt'
-      error("Processing interrupted! Exiting.")
-    else
-      error("Process received signal #{e.message}. Exiting!")
-      error(e.backtrace.first(10))
-    end
-    return 1
-  rescue ConfigurationError => e
-    # don't have a log file yet so just send to stderr
-    $stderr.puts "ERROR: #{e.message}"
-    return 1
-  rescue Timeout::Error
-    info(DELIM)
-    error("ERROR: Failed to complete Puppet bootstrap within #{@options[:max_seconds]} seconds")
-    return 1
-  rescue RuntimeError =>e
-    info(DELIM)
-    error("ERROR: #{e.message}")
-    return 1
-  rescue => e
-    info(DELIM)
-    error("ERROR: #{e.message}")
-    error(e.backtrace.first(10))
-    return 1
-  end
-
   # Run a puppet agent command until it succeeds, where success
   # is defined to be any exit code that is not 1.
   def run_puppet_agent(extra_args=nil, title='puppet agent run')
@@ -489,7 +430,10 @@ EOM
     end
   end
 
-  ############# logging methods #############
+  #####################################################################
+  # Logging methods
+  #####################################################################
+
   def title(msg, level)
     case level
     when 1
@@ -552,6 +496,73 @@ EOM
         $stdout.puts(message) if @options[:debug]
       end
     end
+  end
+
+  #####################################################################
+  # The main method: run()
+  #####################################################################
+
+  def run(args)
+    parse_command_line(args)
+    return 0 if @options[:help_requested] # already have logged help
+
+    set_up_log
+
+    info('Starting Puppet bootstrap')
+    info(DELIM)
+    Timeout::timeout(@options[:max_seconds]) do
+      info(title('Setting up system for Puppet bootstrap', 1))
+      info("    Detailed log written to #{@options[:log_file]}.")
+      debug("#{File.basename(__FILE__)} options: #{@options}")
+      configure_puppet
+      set_system_time
+
+      info(title('Running Puppet bootstrap (This may take some time)', 1))
+      info()
+      info(">>> Be sure to sign this client's Puppet cert request when it comes in! <<<")
+      info()
+
+      run_puppet_agent('--tags pupmod,simp',
+        title('Initial puppet agent run with pupmod,simp tags', 2))
+
+      fix_file_contexts
+
+      # SIMP is not single-run idempotent
+      (1..@options[:num_puppet_runs]).each do |run|
+        run_puppet_agent(nil,
+          title("#{run} of #{@options[:num_puppet_runs]} puppet agent runs", 2))
+      end
+
+      info(DELIM)
+      info('Puppet bootstrap successfully completed.')
+      return 0
+    end
+  rescue SignalException =>e
+    info(DELIM)
+    if e.inspect == 'Interrupt'
+      error("Processing interrupted! Exiting.")
+    else
+      error("Process received signal #{e.message}. Exiting!")
+      error(e.backtrace.first(10))
+    end
+    return 1
+  rescue ConfigurationError => e
+    # don't have a log file yet so just send to stderr
+    $stderr.puts "ERROR: #{e.message}"
+    return 1
+  rescue Timeout::Error
+    info(DELIM)
+    error("ERROR: Failed to complete Puppet bootstrap within #{@options[:max_seconds]} seconds")
+    return 1
+  rescue RuntimeError =>e
+    info(DELIM)
+    error("ERROR: #{e.message}")
+    return 1
+  rescue => e
+    info(DELIM)
+    error("ERROR: #{e.message}")
+    error(e.backtrace.first(10))
+    return 1
   end
 
 end

--- a/files/var/www/ks/bootstrap_simp_client
+++ b/files/var/www/ks/bootstrap_simp_client
@@ -1,0 +1,564 @@
+#!/usr/bin/env ruby
+#
+require 'facter'
+require 'fileutils'
+require 'optparse'
+require 'timeout'
+
+class BootstrapSimpClient
+  attr_reader :options
+
+  class ConfigurationError < RuntimeError; end
+
+  # puppet config
+  DEFAULT_PUPPET_CONF_FILE      = '/etc/puppetlabs/puppet/puppet.conf'
+  DEFAULT_PUPPET_CA_PORT        = 8141
+  DEFAULT_DIGEST_ALGORITHM      = 'sha256'
+  DEFAULT_PUPPET_KEYLENGTH      = 4096
+  DEFAULT_PUPPET_WAIT_FOR_CERT  = 10
+  DEFAULT_PRINT_STATS           = true
+
+  # parameters affecting puppet agent runs
+  DEFAULT_NUM_PUPPET_RUNS       = 2
+  DEFAULT_INITIAL_RETRY_SECONDS = 10
+  DEFAULT_RETRY_FACTOR          = 1.5
+  DEFAULT_MAX_SECONDS           = 30*60 # 30 minutes
+
+  # general program config
+  DEFAULT_LOG_FILE              = '/root/puppet.bootstrap.log'
+#  DEFAULT_DRY_RUN               = false
+  DEFAULT_QUIET                 = false
+  DEFAULT_DEBUG                 = false
+
+  DELIM = '='*80
+
+  def initialize
+    @options = {
+      :ntp_servers            => [],
+      :puppet_conf_file       => DEFAULT_PUPPET_CONF_FILE,
+      :puppet_ca_port         => DEFAULT_PUPPET_CA_PORT,
+      :digest_algorithm       => DEFAULT_DIGEST_ALGORITHM,
+      :puppet_keylength       => DEFAULT_PUPPET_KEYLENGTH,
+      :puppet_wait_for_cert   => DEFAULT_PUPPET_WAIT_FOR_CERT,
+      :print_stats            => DEFAULT_PRINT_STATS,
+      :num_puppet_runs        => DEFAULT_NUM_PUPPET_RUNS,
+      :initial_retry_interval => DEFAULT_INITIAL_RETRY_SECONDS,
+      :retry_factor           => DEFAULT_RETRY_FACTOR,
+      :max_seconds            => DEFAULT_MAX_SECONDS,
+      :log_file               => DEFAULT_LOG_FILE,
+      :quiet                  => DEFAULT_QUIET,
+      :debug                  => DEFAULT_DEBUG,
+      :help_requested         => false
+    }
+    @retry_interval = nil
+  end
+
+  def configure_puppet
+    info(title('Setting puppet configuration', 2))
+    puppet_config = <<EOM
+[main]
+vardir            = /opt/puppetlabs/puppet/cache
+classfile         = $vardir/classes.txt
+localconfig       = $vardir/localconfig
+logdir            = /var/log/puppetlabs/puppet
+report            = false
+rundir            = /var/run/puppetlabs
+server            = #{@options[:puppet_server]}
+ssldir            = /etc/puppetlabs/puppet/ssl
+trusted_node_data = true
+stringify_facts   = false
+digest_algorithm  = #{@options[:digest_algorithm]}
+keylength         = #{@options[:puppet_keylength]}
+ca_server         = #{@options[:puppet_ca]}
+ca_port           = #{@options[:puppet_ca_port]}
+EOM
+    debug("Configuration:\n#{puppet_config}")
+    File.open(@options[:puppet_conf_file], 'w') do |file|
+      file.puts(puppet_config)
+    end
+  end
+
+  # Run a command in a child process and return a Hash containing the
+  # process exit status, stdout, stderr
+  def execute(command)
+    debug("Executing: #{command}")
+    out_pipe_r, out_pipe_w = IO.pipe
+    err_pipe_r, err_pipe_w = IO.pipe
+    pid = spawn(command, :out => out_pipe_w, :err => err_pipe_w)
+    out_pipe_w.close
+    err_pipe_w.close
+
+    Process.wait(pid)
+    exitstatus = $?.nil? ? 1 : $?.exitstatus
+    stdout = out_pipe_r.read
+    out_pipe_r.close
+    stderr = err_pipe_r.read
+    err_pipe_r.close
+
+    return {:exitstatus => exitstatus, :stdout => stdout, :stderr => stderr}
+  end
+
+  # If selinux is enabled, relabel the filesystem.
+  # raises RuntimeError if fixfiles fails
+  def fix_file_contexts
+    if Facter.value(:selinux) && !Facter.value(:selinux_current_mode).nil? &&
+        (Facter.value(:selinux_current_mode) != 'disabled')
+      info(title('Relabeling filesystem for selinux', 2))
+
+      # fixfiles will append to the specified log file
+      result = execute("fixfiles -l #{@options[:log_file]} -f relabel")
+
+      if result[:exitstatus] != 0
+        raise "fixfiles failed with #{result[:exitstatus]} exit status"
+      end
+    end
+  end
+
+  def get_retry_interval
+    if @retry_interval.nil?
+      @retry_interval = @options[:initial_retry_interval]
+    else
+      @retry_interval = (@retry_interval * @options[:retry_factor]).round
+    end
+    @retry_interval
+  end
+
+  def not_nil_or_empty?(x)
+    return false if x.nil?
+    if x.respond_to?(:empty?) and x.empty?
+      return false
+    end
+    return true
+  end
+
+  def parse_command_line(args)
+    opt_parser = OptionParser.new do |opts|
+      opts.banner = "Usage: #{File.basename(__FILE__)} -s PUPPETSRV -c PUPPETCA [options]"
+
+      opts.separator ''
+      opts.separator 'REQUIRED:'
+      opts.on(
+        '-s', '--puppet-server PUPPETSRV',
+        'The FQDN of your Puppet server'
+      ) do |puppet_server|
+        @options[:puppet_server] = puppet_server.strip
+      end
+
+      opts.on(
+        '-c', '--puppet-ca PUPPETCA',
+        'The FQDN of your Puppet CA'
+      ) do |puppet_ca|
+        @options[:puppet_ca] = puppet_ca.strip
+      end
+
+      opts.separator ''
+      opts.separator 'OPTIONAL:'
+      opts.on(
+        '-a', '--digest_algorithm DIGEST',
+        'The digest algorithm Puppet uses for file',
+        'resources and the filebucket (e.g. sha256,',
+        "sha384, sha512). Defaults to #{DEFAULT_DIGEST_ALGORITHM}."
+      ) do |digest_algorithm|
+        @options[:digest_algorithm] = digest_algorithm
+      end
+
+      opts.on(
+        '-k', '--puppet-keylength KEYLENGTH',
+        Integer,
+        'Puppet certificate keylength.',
+        "Defaults to #{DEFAULT_PUPPET_KEYLENGTH}."
+      ) do |puppet_keylength|
+        @options[:puppet_keylength] = puppet_keylength
+      end
+
+      opts.on(
+        '-n', '--ntp-servers NTPSRV1,NTPSRV2',
+        Array,
+        'List of ntp servers that should be used',
+        'during client kickstarts to slew the local',
+        'time correctly, prior to PKI key',
+        'distribution.'
+      ) do |ntp_servers|
+        @options[:ntp_servers] = ntp_servers
+      end
+
+      opts.on(
+        '-p', '--puppet-ca-port PORT',
+        Integer,
+        'The port upon which the Puppet CA is',
+        "listening. Defaults to #{DEFAULT_PUPPET_CA_PORT}."
+      ) do |puppet_ca_port|
+        @options[:puppet_ca_port] = puppet_ca_port
+      end
+
+      opts.on(
+        '-r', '--num_puppet-runs NUMRUNS',
+        Integer,
+        'Number of puppet agent runs (after the',
+        'initial tagged run) to execute, in order to',
+        'converge to a stable system configuration.',
+        "Defaults to #{DEFAULT_NUM_PUPPET_RUNS}."
+      ) do |num_puppet_runs|
+        @options[:num_puppet_runs] = num_puppet_runs
+      end
+
+      opts.on(
+        '-i', '--initial-retry-interval INTERVALSECS',
+        Integer,
+        'Initial retry interval in seconds for',
+        'reattempting a failed puppet agent run.',
+        "Defaults to #{DEFAULT_INITIAL_RETRY_SECONDS}."
+      ) do |initial_retry_interval|
+        @options[:initial_retry_interval] = initial_retry_interval
+      end
+
+      opts.on(
+        '-f', '--retry-factor FACTOR',
+        Float,
+        'The factor to be applied to the retry',
+        'interval for a puppet run. The retry',
+        'interval is multiplied by this factor',
+        'for each retry.  For example, if the',
+        'initial retry interval was 10 and the',
+        'retry factor was 1.5, the first retry',
+        'would occur 10 seconds after the initial',
+        'attempt, the second retry would occur',
+        '10*1.5 seconds after that, the third',
+        'retry would occur 10*1.5*1.5 seconds',
+        "after that, etc. Defaults to #{DEFAULT_INITIAL_RETRY_SECONDS}."
+      ) do |retry_factor|
+        @options[:retry_factor] = retry_factor
+      end
+
+      opts.on(
+        '-m', '--max-seconds MAXSECONDS',
+        Integer,
+        'Maximum number of seconds this bootstrap',
+        'script is allowed to run.  Script will',
+        'abort if it does not complete within',
+        "this allotted time. Defaults to #{DEFAULT_MAX_SECONDS}."
+      ) do |max_seconds|
+        @options[:max_seconds] = max_seconds
+      end
+
+      opts.on(
+        '-S', '--[no-]print-stats',
+        'Print statistics for each puppet run',
+        "during bootstrap. Defaults to #{DEFAULT_PRINT_STATS}."
+      ) do |print_stats|
+        @options[:print_stats] = print_stats
+      end
+
+      opts.on(
+        '-w', '--puppet-wait-for-cert WAITSECONDS',
+        Integer,
+        'The wait interval in seconds for checking',
+        'into the puppet master for a signed',
+        'certificate. This checking will only',
+        'continue until a signed certificate is',
+        'presented.  If set to 0, each puppet agent',
+        'run will fail if a signed certificate is',
+        "not presented. Defaults to #{DEFAULT_PUPPET_WAIT_FOR_CERT}."
+      ) do |puppet_wait_for_cert|
+        @options[:puppet_wait_for_cert] = puppet_wait_for_cert
+      end
+
+      opts.on(
+        '-C', '--puppet-config-file CONFIGFILE',
+        'Puppet configuration file. Defaults to',
+        DEFAULT_PUPPET_CONF_FILE
+      ) do |puppet_conf_file|
+        @options[:puppet_conf_file] = puppet_conf_file
+      end
+
+      opts.on(
+        '-l', '--log-file LOGFILE',
+        'Log file. Defaults to',
+        DEFAULT_LOG_FILE
+      ) do |log_file|
+        @options[:log_file] = log_file
+      end
+
+      opts.on(
+        '-q', '--quiet',
+        'Quiet console output. When enabled,',
+        'console messages indicating progress are',
+        "suppressed. Defaults to #{DEFAULT_QUIET}."
+      ) do
+        @options[:quiet] = true
+      end
+
+      opts.on(
+        '-d', '--debug',
+        'Log processing details to the console.',
+        'These details are always written to the',
+        "log file. Defaults to #{DEFAULT_DEBUG}."
+      ) do
+        @options[:debug] = true
+      end
+
+      opts.on( '-h', '--help', 'Print this help message') do
+        @options[:help_requested] = true
+        puts opts
+      end
+    end
+
+    begin
+      opt_parser.parse!(args)
+      return if @options[:help_requested]
+
+      validate_options
+
+      cmd = [
+        '/opt/puppetlabs/bin/puppet',
+        'agent',
+        '--onetime',
+        '--no-daemonize',
+        '--no-show_diff',
+        '--no-splay',
+        '--verbose',
+        '--logdest', @options[:log_file],
+        '--waitforcert', @options[:puppet_wait_for_cert]
+      ]
+
+      cmd += [ '--evaltrace', '--summarize' ] if @options[:print_stats]
+      @options[:puppet_cmd] = cmd.join(' ')
+      reset_retry_interval
+
+    rescue OptionParser::ParseError => e
+      raise ConfigurationError.new("#{e.message}\n#{opt_parser.banner}")
+    end
+  end
+
+  def reset_retry_interval
+    @retry_interval = nil
+  end
+
+  def run(args)
+    parse_command_line(args)
+    return 0 if @options[:help_requested] # already have logged help
+
+    set_up_log
+
+    info('Starting Puppet bootstrap')
+    info(DELIM)
+    Timeout::timeout(@options[:max_seconds]) do
+      info(title('Setting up system for Puppet bootstrap', 1))
+      info("    Detailed log written to #{@options[:log_file]}.")
+      debug("#{File.basename(__FILE__)} options: #{@options}")
+      configure_puppet
+      set_system_time
+
+      info(title('Running Puppet bootstrap (This may take some time)', 1))
+      info()
+      info(">>> Be sure to sign this client's Puppet cert request when it comes in! <<<")
+      info()
+
+      run_puppet_agent('--tags pupmod,simp',
+        title('Initial puppet agent run with pupmod,simp tags', 2))
+
+      fix_file_contexts
+
+      # SIMP is not single-run idempotent
+      (1..@options[:num_puppet_runs]).each do |run|
+        run_puppet_agent(nil,
+          title("#{run} of #{@options[:num_puppet_runs]} puppet agent runs", 2))
+      end
+
+      info(DELIM)
+      info('Puppet bootstrap successfully completed.')
+      return 0
+    end
+  rescue SignalException =>e
+    info(DELIM)
+    if e.inspect == 'Interrupt'
+      error("Processing interrupted! Exiting.")
+    else
+      error("Process received signal #{e.message}. Exiting!")
+      error(e.backtrace.first(10))
+    end
+    return 1
+  rescue ConfigurationError => e
+    # don't have a log file yet so just send to stderr
+    $stderr.puts "ERROR: #{e.message}"
+    return 1
+  rescue Timeout::Error
+    info(DELIM)
+    error("ERROR: Failed to complete Puppet bootstrap within #{@options[:max_seconds]} seconds")
+    return 1
+  rescue RuntimeError =>e
+    info(DELIM)
+    error("ERROR: #{e.message}")
+    return 1
+  rescue => e
+    info(DELIM)
+    error("ERROR: #{e.message}")
+    error(e.backtrace.first(10))
+    return 1
+  end
+
+  # Run a puppet agent command until it succeeds, where success
+  # is defined to be any exit code that is not 1.
+  def run_puppet_agent(extra_args=nil, title='puppet agent run')
+    reset_retry_interval
+    info(title)
+    cmd = "#{@options[:puppet_cmd]} #{extra_args}"
+    result = { :exitstatus => 1 }
+    while result[:exitstatus] == 1
+      result = execute(cmd)
+      if result[:exitstatus] == 1
+        error(result[:stderr])
+        retry_interval = get_retry_interval
+        debug(">>>>>> Command failed.  Retrying in #{retry_interval} seconds")
+        sleep(retry_interval)
+      end
+    end
+  end
+
+  def set_system_time
+    return if @options[:ntp_servers].nil? or @options[:ntp_servers].empty?
+    info(title("Setting the system time against #{@options[:ntp_servers].join(' ')}", 2))
+    # this can fail if ntpd is up and running, so only log any failures
+    result = execute("/usr/sbin/ntpdate -b #{@options[:ntp_servers].join(' ')}")
+    warn(result[:stderr]) if result[:exitstatus] != 0
+  end
+
+  def set_up_log
+    log_file = @options[:log_file]
+    if File.exist?(log_file)
+      timestamp = File.stat(log_file).mtime.strftime("%Y-%m-%dT%H%M%S")
+      log_backup = "#{log_file}.#{timestamp}"
+      debug("Backing up #{log_file} to #{log_backup}")
+      FileUtils.mv(log_file, log_backup)
+    end
+
+    # Note: If the ownership of this file is root:root, puppet agent
+    # will complain in an 'err'-level message, but not fail, when it
+    # writes to the file. However, since there is no puppet user
+    # on the client, this can't be fixed...
+    FileUtils.touch(log_file)
+  end
+
+  # raises ConfigurationError upon validation failure
+  def validate_options
+    unless not_nil_or_empty?(@options[:puppet_server])
+      raise ConfigurationError.new('No Puppet server specified')
+    end
+
+    unless not_nil_or_empty?(@options[:puppet_ca])
+      raise ConfigurationError.new('No Puppet CA specified')
+    end
+
+    if (@options[:puppet_ca_port] < 1) or (@options[:puppet_ca_port] > 65535)
+      msg = "Invalid Puppet CA port '#{@options[:puppet_ca_port]}': must be in [0,65535]"
+      raise ConfigurationError.new(msg)
+    end
+
+    unless @options[:num_puppet_runs] > 0
+      msg = "Invalid number of puppet agent runs '#{@options[:num_puppet_runs]}': must be > 0"
+      raise ConfigurationError.new(msg)
+    end
+
+    unless @options[:puppet_keylength] > 0
+      msg = "Invalid Puppet keylength '#{@options[:puppet_keylength]}': must be > 0"
+      raise ConfigurationError.new(msg)
+    end
+
+    unless @options[:puppet_wait_for_cert] >= 0
+      msg = "Invalid Puppet wait for cert '#{@options[:puppet_wait_for_cert]}': must be >= 0"
+      raise ConfigurationError.new(msg)
+    end
+
+    unless @options[:initial_retry_interval] > 0
+      msg = "Invalid initial retry interval '#{@options[:initial_retry_interval]}': must be > 0"
+      raise ConfigurationError.new(msg)
+    end
+
+    unless @options[:retry_factor] > 0
+      msg = "Invalid retry factor '#{@options[:retry_factor]}': must be > 0"
+      raise ConfigurationError.new(msg)
+    end
+
+    unless @options[:max_seconds] > 0
+      msg = "Invalid max seconds '#{@options[:max_seconds]}': must be > 0"
+      raise ConfigurationError.new(msg)
+    end
+
+    if @options[:quiet] and @options[:debug]
+      raise ConfigurationError.new('--quiet and --debug cannot be used together')
+    end
+  end
+
+  ############# logging methods #############
+  def title(msg, level)
+    case level
+    when 1
+       "*** #{msg} ***"
+    when 2
+       "------ #{msg} ------"
+    when 3
+       "......... #{msg} ........."
+    else
+       msg
+    end
+  end
+
+  def error(msg)
+   log(:err, msg, true)
+  end
+
+  def warn(msg)
+   log(:warning, msg, true)
+  end
+
+  def info(msg='')
+   log(:info, msg, false)
+  end
+
+  def debug(msg='')
+   log(:debug, msg, false)
+  end
+
+  def log(level, msg, suppress_empty_msgs)
+    if msg.is_a?(Array)
+      message = msg.join("\n")
+    else
+      message = msg
+    end
+
+    if suppress_empty_msgs and (message.nil? or message.strip.empty?)
+      return
+    end
+
+    # This executable, 'puppet agent', and, optionally, fixfiles are
+    # writing to the log file, although never at the same time.  So,
+    # we can't keep the log file open. Instead, we append to it with
+    # each log message.
+    prefix = "#{Time.now} #{File.basename(__FILE__)} (#{level.to_s}):"
+    File.open(@options[:log_file], 'a') do |file|
+      file.puts "#{prefix} #{message}"
+    end
+
+    unless @options[:quiet]
+      case level
+      when :err
+        # insert newline to help error message stand out, especially when
+        # the error has left the cursor at the end of the line
+        $stderr.puts
+        $stderr.puts(message)
+      when :warning, :info
+        $stdout.puts(message)
+      when :debug
+        $stdout.puts(message) if @options[:debug]
+      end
+    end
+  end
+
+end
+
+########################################################################
+if __FILE__ == $0
+  bootstrap = BootstrapSimpClient.new
+  exit bootstrap.run(ARGV)
+end
+

--- a/files/var/www/ks/bootstrap_simp_client
+++ b/files/var/www/ks/bootstrap_simp_client
@@ -158,7 +158,7 @@ EOM
       opts.separator ''
       opts.separator 'OPTIONAL:'
       opts.on(
-        '-a', '--digest_algorithm DIGEST',
+        '-a', '--digest-algorithm DIGEST',
         'The digest algorithm Puppet uses for file',
         'resources and the filebucket (e.g. sha256,',
         "sha384, sha512). Defaults to #{DEFAULT_DIGEST_ALGORITHM}."
@@ -196,7 +196,7 @@ EOM
       end
 
       opts.on(
-        '-r', '--num_puppet-runs NUMRUNS',
+        '-r', '--num-puppet-runs NUMRUNS',
         Integer,
         'Number of puppet agent runs (after the',
         'initial tagged run) to execute, in order to',
@@ -229,7 +229,7 @@ EOM
         'attempt, the second retry would occur',
         '10*1.5 seconds after that, the third',
         'retry would occur 10*1.5*1.5 seconds',
-        "after that, etc. Defaults to #{DEFAULT_INITIAL_RETRY_SECONDS}."
+        "after that, etc. Defaults to #{DEFAULT_RETRY_FACTOR}."
       ) do |retry_factor|
         @options[:retry_factor] = retry_factor
       end

--- a/spec/unit/bootstrap_simp_client_spec.rb
+++ b/spec/unit/bootstrap_simp_client_spec.rb
@@ -30,6 +30,9 @@ describe 'BootstrapSimpClient' do
     ]
     @non_quiet_test_args = @test_args.dup
     @non_quiet_test_args.delete_if { |x| x == '-q' }
+
+    # Need to make sure we have something to find
+    FileUtils.touch(@puppet_conf_file)
   end
 
   after :each do
@@ -66,7 +69,7 @@ EOM
         x == @puppet_conf_file ? "#{@puppet_conf_file}.d/#{@puppet_conf_file}" : x
       end
       bootstrap.parse_command_line(bad_test_args)
-      expect { bootstrap.configure_puppet }.to raise_error(Errno::ENOENT)
+      expect { bootstrap.configure_puppet }.to raise_error(/Could not find puppet\.conf/)
     end
   end
 

--- a/spec/unit/bootstrap_simp_client_spec.rb
+++ b/spec/unit/bootstrap_simp_client_spec.rb
@@ -1,0 +1,645 @@
+# Cannot 'require' bootstrap_simp_client Ruby file, because it is missing
+# the '.rb' suffix.  So, use a symlink to it that has the '.rb' suffix.
+# This symlink is in the tests directory.
+$: << File.expand_path(File.join(File.dirname(__FILE__), '..','..','tests'))
+require 'bootstrap_simp_client'
+
+require 'spec_helper'
+require 'tmpdir'
+
+describe 'BootstrapSimpClient' do
+
+  let(:bootstrap) { BootstrapSimpClient.new }
+
+  let(:success_result) {{
+    :exitstatus => 0,
+    :stdout => '',
+    :stderr => ''
+  }}
+
+  before :each do
+    @tmp_dir = Dir.mktmpdir( File.basename( __FILE__ ) )
+    @puppet_conf_file = File.join(@tmp_dir, 'puppet.conf')
+    @log_file = File.join(@tmp_dir, 'bootstrap.log')
+    @test_args = [
+      '-s', 'puppet.test.local',
+      '-c', 'puppetca.test.local',
+      '-C', @puppet_conf_file,
+      '-l', @log_file,
+      '-q'
+    ]
+    @non_quiet_test_args = @test_args.dup
+    @non_quiet_test_args.delete_if { |x| x == '-q' }
+  end
+
+  after :each do
+    FileUtils.remove_entry_secure(@tmp_dir) if @tmp_dir
+  end
+
+  describe '#configure_puppet' do
+    it 'creates puppet config file' do
+      bootstrap.parse_command_line(@test_args)
+      bootstrap.configure_puppet
+      expected = <<EOM
+[main]
+vardir            = /opt/puppetlabs/puppet/cache
+classfile         = $vardir/classes.txt
+localconfig       = $vardir/localconfig
+logdir            = /var/log/puppetlabs/puppet
+report            = false
+rundir            = /var/run/puppetlabs
+server            = puppet.test.local
+ssldir            = /etc/puppetlabs/puppet/ssl
+trusted_node_data = true
+stringify_facts   = false
+digest_algorithm  = sha256
+keylength         = 4096
+ca_server         = puppetca.test.local
+ca_port           = 8141
+EOM
+      expect( File.exist?(@puppet_conf_file) ).to be true
+      expect( File.read(@puppet_conf_file) ).to eq expected
+    end
+
+    it 'fails if it cannot create puppet config file' do
+      bad_test_args = @test_args.map do |x|
+        x == @puppet_conf_file ? "#{@puppet_conf_file}.d/#{@puppet_conf_file}" : x
+      end
+      bootstrap.parse_command_line(bad_test_args)
+      expect { bootstrap.configure_puppet }.to raise_error(Errno::ENOENT)
+    end
+  end
+
+  describe '#execute' do
+    it 'returns appropriate results when command succeeeds' do
+      bootstrap.parse_command_line(@test_args)
+      command = "ls #{__FILE__}"
+      expect( bootstrap.execute(command)[:exitstatus] ).to eq 0
+      expect( bootstrap.execute(command)[:stdout] ).to match "#{__FILE__}"
+      expect( bootstrap.execute(command)[:stderr] ).to eq ''
+    end
+
+    it 'returns appropriate results when command fails' do
+      bootstrap.parse_command_line(@test_args)
+      command = 'ls /some/missing/path1 /some/missing/path2'
+      expect( bootstrap.execute(command)[:exitstatus] ).to_not eq 0
+      expect( bootstrap.execute(command)[:stdout] ).to eq ''
+      expect( bootstrap.execute(command)[:stderr] ).to match /ls: cannot access.*\/some\/missing\/path1.*: No such file or directory/
+    end
+  end
+
+  describe '#fix_file_contexts' do
+    it 'does not execute fixfiles when selinux is not installed' do
+      Facter.stubs(:value).with(:selinux).returns(false)
+      bootstrap.stubs(:execute).with("fixfiles -l #{@log_file} -f relabel").returns({
+        :exitstatus => -1,
+        :stdout => '',
+        :stderr => 'some fixfile error'})
+      bootstrap.parse_command_line(@test_args)
+
+      # if we try to run fixfiles, this will fail
+      bootstrap.fix_file_contexts
+    end
+
+    it 'does not execute fixfiles when selinux mode is disabled' do
+      Facter.stubs(:value).with(:selinux).returns(true)
+      Facter.stubs(:value).with(:selinux_current_mode).returns('disabled')
+      bootstrap.stubs(:execute).with("fixfiles -l #{@log_file} -f relabel").returns({
+        :exitstatus => -1,
+        :stdout => '',
+        :stderr => 'some fixfile error'})
+      bootstrap.parse_command_line(@test_args)
+
+      # if we try to run fixfiles, this will fail
+      bootstrap.fix_file_contexts
+    end
+
+    it 'executes fixfiles when selinux mode is not disabled' do
+      Facter.stubs(:value).with(:selinux).returns(true)
+      Facter.stubs(:value).with(:selinux_current_mode).returns('enforcing')
+      bootstrap.stubs(:execute).with("fixfiles -l #{@log_file} -f relabel").returns(success_result)
+      bootstrap.parse_command_line(@test_args)
+
+      # success means nothing is raised
+      bootstrap.fix_file_contexts
+    end
+
+    it 'fail when fixfiles fails' do
+      Facter.stubs(:value).with(:selinux).returns(true)
+      Facter.stubs(:value).with(:selinux_current_mode).returns('permissive')
+      bootstrap.stubs(:execute).with("fixfiles -l #{@log_file} -f relabel").returns({
+        :exitstatus => -1,
+        :stdout => '',
+        :stderr => 'some fixfile error'})
+      bootstrap.parse_command_line(@test_args)
+
+      expect { bootstrap.fix_file_contexts }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe '#get_retry_interval' do
+    it 'returns initial value upon first execution' do
+      bootstrap.parse_command_line(@test_args)
+      expect( bootstrap.get_retry_interval ).to eq BootstrapSimpClient::DEFAULT_INITIAL_RETRY_SECONDS
+    end
+
+    it 'returns value multiplied by factor upon subsequent executions' do
+      bootstrap.parse_command_line(@test_args)
+      bootstrap.get_retry_interval
+      expected = BootstrapSimpClient::DEFAULT_INITIAL_RETRY_SECONDS*BootstrapSimpClient::DEFAULT_RETRY_FACTOR
+      expected = expected.round
+      expect( bootstrap.get_retry_interval ).to eq expected
+
+      expected *= BootstrapSimpClient::DEFAULT_RETRY_FACTOR
+      expected = expected.round
+      expect( bootstrap.get_retry_interval ).to eq expected
+    end
+  end
+
+  describe '#not_nil_or_empty?' do
+    it 'returns initial value upon first execution' do
+      expect( bootstrap.not_nil_or_empty?('not empty') ).to be true
+      expect( bootstrap.not_nil_or_empty?(['not', 'empty']) ).to be true
+      expect( bootstrap.not_nil_or_empty?({'not' => 'empty'}) ).to be true
+      expect( bootstrap.not_nil_or_empty?(nil) ).to be false
+      expect( bootstrap.not_nil_or_empty?('') ).to be false
+      expect( bootstrap.not_nil_or_empty?([]) ).to be false
+      expect( bootstrap.not_nil_or_empty?({}) ).to be false
+    end
+  end
+
+  # will also test validate_options here
+  describe '#parse_command_line' do
+    it 'uses defaults when only required options are specified' do
+      test_args = [ '-s', 'puppet.test.local', '-c', 'puppetca.test.local']
+      bootstrap.parse_command_line(test_args)
+
+      cmd = '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize' +
+            ' --no-show_diff --no-splay --verbose --logdest' +
+            ' /root/puppet.bootstrap.log --waitforcert 10 --evaltrace' +
+            ' --summarize'
+
+      expected = {
+        :ntp_servers            => [],
+        :puppet_conf_file       => BootstrapSimpClient::DEFAULT_PUPPET_CONF_FILE,
+        :digest_algorithm       => BootstrapSimpClient::DEFAULT_DIGEST_ALGORITHM,
+        :puppet_keylength       => BootstrapSimpClient::DEFAULT_PUPPET_KEYLENGTH,
+        :puppet_ca_port         => BootstrapSimpClient::DEFAULT_PUPPET_CA_PORT,
+        :puppet_wait_for_cert   => BootstrapSimpClient::DEFAULT_PUPPET_WAIT_FOR_CERT,
+        :print_stats            => BootstrapSimpClient::DEFAULT_PRINT_STATS,
+        :num_puppet_runs        => BootstrapSimpClient::DEFAULT_NUM_PUPPET_RUNS,
+        :initial_retry_interval => BootstrapSimpClient::DEFAULT_INITIAL_RETRY_SECONDS,
+        :retry_factor           => BootstrapSimpClient::DEFAULT_RETRY_FACTOR,
+        :max_seconds            => BootstrapSimpClient::DEFAULT_MAX_SECONDS,
+        :log_file               => BootstrapSimpClient::DEFAULT_LOG_FILE,
+        :quiet                  => BootstrapSimpClient::DEFAULT_QUIET,
+        :debug                  => BootstrapSimpClient::DEFAULT_DEBUG,
+        :help_requested         => false,
+        :puppet_server          => 'puppet.test.local',
+        :puppet_ca              => 'puppetca.test.local',
+        :puppet_cmd             => cmd
+      }
+      expect( bootstrap.options ).to eq expected
+    end
+
+    it 'uses configured options when non-conflicting options are specified' do
+      test_args = [
+        '-s', 'puppet.test.local',
+        '-c', 'puppetca.test.local',
+        '-a', 'sha512',
+        '-k', '2048',
+        '-n', 'ntp1.test.local,ntp2.test.local',
+        '-p', '8240',
+        '-r', '3',
+        '-i', '30',
+        '-f', '2.5',
+        '-m', '3600',
+        '--no-print-stats',
+        '-w', '20',
+        '-C', 'mypuppet.conf',
+        '-l', 'mylog.txt',
+        '-d'
+      ]
+      bootstrap.parse_command_line(test_args)
+
+      cmd = '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize' +
+            ' --no-show_diff --no-splay --verbose --logdest' +
+            ' mylog.txt --waitforcert 20'
+
+      expected = {
+        :ntp_servers            => [ 'ntp1.test.local', 'ntp2.test.local'],
+        :puppet_conf_file       => 'mypuppet.conf',
+        :digest_algorithm       => 'sha512',
+        :puppet_keylength       => 2048,
+        :puppet_ca_port         => 8240,
+        :puppet_wait_for_cert   => 20,
+        :print_stats            => false,
+        :num_puppet_runs        => 3,
+        :initial_retry_interval => 30,
+        :retry_factor           => 2.5,
+        :max_seconds            => 3600,
+        :log_file               => 'mylog.txt',
+        :quiet                  => BootstrapSimpClient::DEFAULT_QUIET,
+        :debug                  => true,
+        :help_requested         => false,
+        :puppet_server          => 'puppet.test.local',
+        :puppet_ca              => 'puppetca.test.local',
+        :puppet_cmd             => cmd
+      }
+      expect( bootstrap.options ).to eq expected
+    end
+
+    it 'fails if options fail validation' do
+      expect { bootstrap.parse_command_line([]) }.to raise_error(RuntimeError)
+    end
+
+    it 'fails if unknown options is specified' do
+      expect { bootstrap.parse_command_line(['--oops']) }.to raise_error(RuntimeError)
+    end
+
+    it 'prints help when --help option specified' do
+      expect { bootstrap.parse_command_line([ '-h' ]) }.to output(
+        /Usage: bootstrap_simp_client.rb -s PUPPETSRV -c PUPPETCA \[options\]/).
+        to_stdout
+    end
+  end
+
+  describe '#reset_retry_interval' do
+    it 'returns configured initial value upon execution' do
+      bootstrap.parse_command_line(@test_args)
+      bootstrap.get_retry_interval
+      bootstrap.get_retry_interval
+      bootstrap.reset_retry_interval
+      expect( bootstrap.get_retry_interval ).to eq BootstrapSimpClient::DEFAULT_INITIAL_RETRY_SECONDS
+    end
+  end
+
+  describe '#run' do
+    it 'prints help when --help option specified' do
+      expect( bootstrap.run([ '--help' ] ) ).to eq 0
+      expect { bootstrap.run([ '-h' ]) }.to output(
+        /Usage: bootstrap_simp_client.rb -s PUPPETSRV -c PUPPETCA \[options\]/).
+        to_stdout
+    end
+
+    it 'returns 0 when processing succeeds' do
+      bootstrap.stubs(:execute).with('/usr/sbin/ntpdate -b ntpserver1 ntpserver2').returns(success_result)
+      puppet_cmd1 = '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize' +
+            " --no-show_diff --no-splay --verbose --logdest #{@log_file}" +
+            ' --waitforcert 10 --evaltrace --summarize --tags pupmod,simp'
+      bootstrap.stubs(:execute).with(puppet_cmd1).returns(success_result)
+
+      puppet_cmd2 = '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize' +
+            " --no-show_diff --no-splay --verbose --logdest #{@log_file}" +
+            ' --waitforcert 10 --evaltrace --summarize '
+      bootstrap.stubs(:execute).with(puppet_cmd2).returns(success_result)
+
+      Facter.stubs(:value).with(:selinux).returns(true)
+      Facter.stubs(:value).with(:selinux_current_mode).returns('enforcing')
+      bootstrap.stubs(:execute).with("fixfiles -l #{@log_file} -f relabel").returns(success_result)
+
+      expect( bootstrap.run(@test_args + [ '-n', 'ntpserver1,ntpserver2' ]) ).to eq 0
+
+      # detailed actions are unit tested in other examples, so here only
+      # check for log messages to indicate the methods that executed
+      # the actions were called
+      log = File.read(@log_file)
+      expect( log ).to match(/Setting up system for Puppet bootstrap/)
+      expect( log ).to match(/Setting puppet configuration/)
+      expect( log ).to match(/Setting the system time against ntpserver1 ntpserver2/)
+      expect( log ).to match(/Running Puppet bootstrap/)
+      expect( log ).to match(/Initial puppet agent run with pupmod,simp tags/)
+      expect( log ).to match(/Relabeling filesystem for selinux/)
+      expect( log ).to match(/1 of 2 puppet agent runs/)
+      expect( log ).to match(/2 of 2 puppet agent runs/)
+      expect( log ).to match(/Puppet bootstrap successfully completed/)
+     end
+
+     it 'runs configured number of puppet agent runs' do
+      puppet_cmd1 = '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize' +
+            " --no-show_diff --no-splay --verbose --logdest #{@log_file}" +
+            ' --waitforcert 10 --evaltrace --summarize --tags pupmod,simp'
+      bootstrap.stubs(:execute).with(puppet_cmd1).returns(success_result)
+
+      puppet_cmd2 = '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize' +
+            " --no-show_diff --no-splay --verbose --logdest #{@log_file}" +
+            ' --waitforcert 10 --evaltrace --summarize '
+      bootstrap.stubs(:execute).with(puppet_cmd2).returns(success_result)
+      Facter.stubs(:value).with(:selinux).returns(false)
+
+      expect( bootstrap.run(@test_args + [ '-r', '4' ]) ).to eq 0
+
+      log = File.read(@log_file)
+      expect( log ).to match(/1 of 4 puppet agent runs/)
+      expect( log ).to match(/2 of 4 puppet agent runs/)
+      expect( log ).to match(/3 of 4 puppet agent runs/)
+      expect( log ).to match(/4 of 4 puppet agent runs/)
+     end
+
+     it 'returns 1 when command line options fail validation' do
+       expect( bootstrap.run([]) ).to eq 1
+     end
+
+     it 'returns 1 when fixfiles fails' do
+      puppet_cmd1 = '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize' +
+            " --no-show_diff --no-splay --verbose --logdest #{@log_file}" +
+            ' --waitforcert 10 --evaltrace --summarize --tags pupmod,simp'
+      bootstrap.stubs(:execute).with(puppet_cmd1).returns(success_result)
+
+      puppet_cmd2 = '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize' +
+            " --no-show_diff --no-splay --verbose --logdest #{@log_file}" +
+            ' --waitforcert 10 --evaltrace --summarize '
+      bootstrap.stubs(:execute).with(puppet_cmd2).returns(success_result)
+
+      Facter.stubs(:value).with(:selinux).returns(true)
+      Facter.stubs(:value).with(:selinux_current_mode).returns('enforcing')
+      bootstrap.stubs(:execute).with("fixfiles -l #{@log_file} -f relabel").returns({
+        :exitstatus => -1,
+        :stdout => '',
+        :stderr => 'some fixfile error'})
+
+      expect( bootstrap.run(@test_args) ).to eq 1
+      log = File.read(@log_file)
+      expect( log ).to match(/ERROR: fixfiles failed with -1 exit status/)
+      expect( log ).to_not match(/1 of 2 puppet agent runs/)
+      expect( log ).to_not match(/2 of 2 puppet agent runs/)
+      expect( log ).to_not match(/Puppet bootstrap successfully completed/)
+     end
+
+     it 'returns 1 when processing times out' do
+      puppet_cmd = '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize' +
+            " --no-show_diff --no-splay --verbose --logdest #{@log_file}" +
+            ' --waitforcert 10 --evaltrace --summarize --tags pupmod,simp'
+      bootstrap.stubs(:execute).with(puppet_cmd).returns({
+        :exitstatus => 1,
+        :stdout => '',
+        :stderr => "Could not request certificate: The certificate retrieved from the master does not match the agent's private key."
+      })
+
+      expect( bootstrap.run(@test_args + [ '-i', '1', '-m', '2' ]) ).to eq 1
+      log = File.read(@log_file)
+      expect( log ).to match(/Initial puppet agent run with pupmod,simp tags/)
+      expect( log ).to match(/Could not request certificate/)
+      expect( log ).to match(/>>>>>> Command failed.  Retrying in 1 seconds/)
+      expect( log ).to match(/>>>>>> Command failed.  Retrying in 2 seconds/)
+      expect( log ).to match(/ERROR: Failed to complete Puppet bootstrap within 2 seconds/)
+     end
+  end
+
+  describe '#run_puppet_agent' do
+
+    it 'executes the puppet agent command' do
+      cmd = '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize' +
+            " --no-show_diff --no-splay --verbose --logdest #{@log_file}" +
+            ' --waitforcert 10 --evaltrace --summarize '
+      bootstrap.stubs(:execute).with(cmd).returns(success_result)
+      bootstrap.parse_command_line(@test_args)
+      bootstrap.run_puppet_agent
+      expect( File.read(@log_file) ).to match(/puppet agent run/)
+    end
+
+    it 'executes the puppet agent command with extra arguments' do
+      cmd = '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize' +
+            " --no-show_diff --no-splay --verbose --logdest #{@log_file}" +
+            ' --waitforcert 10 --evaltrace --summarize --tags pupmod,simp'
+      bootstrap.stubs(:execute).with(cmd).returns(success_result)
+      bootstrap.parse_command_line(@test_args)
+      bootstrap.run_puppet_agent('--tags pupmod,simp', 'tagged run')
+      expect( File.read(@log_file) ).to match(/tagged run/)
+    end
+
+    it 'when puppet agent command fails, retries until it succeeds' do
+      failed_result = {
+        :exitstatus => 1,
+        :stdout => '',
+        :stderr => 'some puppet agent error'
+      }
+
+      cmd = '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize' +
+            " --no-show_diff --no-splay --verbose --logdest #{@log_file}" +
+            ' --waitforcert 10 --evaltrace --summarize '
+      results = [failed_result, failed_result, success_result]
+      bootstrap.stubs(:execute).with(cmd).returns(*results)
+      bootstrap.parse_command_line(@test_args + ['-i', '1'])
+      bootstrap.run_puppet_agent
+      log = File.read(@log_file)
+      expect( log ).to match(/\(info\): puppet agent run/)
+      expect( log ).to match(/\(err\): some puppet agent error/)
+      expect( log ).to match(/\(debug\): >>>>>> Command failed.  Retrying in 1 seconds/)
+      expect( log ).to match(/\(debug\): >>>>>> Command failed.  Retrying in 2 seconds/)
+    end
+  end
+
+  describe '#set_system_time' do
+    it 'does nothing if no ntp servers are configured' do
+      bootstrap.stubs(:execute).returns({
+        :exitstatus => -1,
+        :stdout => '',
+        :stderr => 'some ntpdate error'})
+      bootstrap.parse_command_line(@test_args)
+
+      # if we try to run ntdpdate, this will fail
+      bootstrap.set_system_time
+    end
+
+    it 'when ntp servers are configured it runs ntpdate' do
+      bootstrap.stubs(:execute).with('/usr/sbin/ntpdate -b ntpserver1 ntpserver2').returns(success_result)
+      bootstrap.parse_command_line(@test_args + [ '-n', 'ntpserver1,ntpserver2' ])
+      bootstrap.set_system_time
+    end
+
+    it 'logs error when ntpdate fails' do
+      bootstrap.stubs(:execute).with('/usr/sbin/ntpdate -b ntpserver1 ntpserver2').returns({
+        :exitstatus => -1,
+        :stdout => '',
+        :stderr => 'some ntpdate error'})
+      bootstrap.parse_command_line(@test_args + [ '-n', 'ntpserver1,ntpserver2' ])
+      bootstrap.set_system_time
+      expect( File.read(@log_file) ).to match(/\(warning\): some ntpdate error/)
+    end
+  end
+
+  describe '#set_up_log' do
+    it 'creates log file for this run' do
+      bootstrap.parse_command_line(@test_args)
+      bootstrap.set_up_log
+      expect( File.exist?(@log_file) ).to be true
+    end
+
+    it 'backs up existing log' do
+      FileUtils.touch(@log_file, :mtime => Time.new(2017, 1, 13, 11, 42, 3))
+      bootstrap.parse_command_line(@test_args)
+      bootstrap.set_up_log
+      backup = "#{@log_file}.2017-01-13T114203"
+      expect( File.exist?(backup) ).to be true
+      expect( File.exist?(@log_file) ).to be true
+    end
+  end
+
+  # test using parse_command_line
+  describe '#validate_options' do
+    it 'fails when puppet server is not specified' do
+      expect { bootstrap.parse_command_line([]) }.to raise_error(
+        BootstrapSimpClient::ConfigurationError, /No Puppet server specified/)
+    end
+
+    it 'fails when puppet CA is not specified' do
+      expect { bootstrap.parse_command_line(['-s', 'puppet.test.local']) }.to raise_error(
+        BootstrapSimpClient::ConfigurationError, /No Puppet CA specified/)
+    end
+
+    it 'fails when invalid puppet CA port is specified' do
+      expect { bootstrap.parse_command_line(@test_args + ['-p', '65536']) }.to raise_error(
+        BootstrapSimpClient::ConfigurationError, /Invalid Puppet CA port '65536': /)
+    end
+
+    it 'fails when invalid number of puppet agent runs is specified' do
+      expect { bootstrap.parse_command_line(@test_args + ['-r', '0']) }.to raise_error(
+        BootstrapSimpClient::ConfigurationError, /Invalid number of puppet agent runs '0': /)
+    end
+
+    it 'fails when invalid puppet keylength is specified' do
+      expect { bootstrap.parse_command_line(@test_args + ['-k', '0']) }.to raise_error(
+        BootstrapSimpClient::ConfigurationError, /Invalid Puppet keylength '0': /)
+    end
+
+    it 'fails when invalid puppet wait for cert is specified' do
+      expect { bootstrap.parse_command_line(@test_args + ['-w', '-10']) }.to raise_error(
+        BootstrapSimpClient::ConfigurationError, /Invalid Puppet wait for cert '-10': /)
+    end
+
+    it 'fails when invalid initial retry interval is specified' do
+      expect { bootstrap.parse_command_line(@test_args + ['-i', '0']) }.to raise_error(
+        BootstrapSimpClient::ConfigurationError, /Invalid initial retry interval '0': /)
+    end
+
+    it 'fails when invalid retry factor is specified' do
+      expect { bootstrap.parse_command_line(@test_args + ['-f', '0']) }.to raise_error(
+        BootstrapSimpClient::ConfigurationError, /Invalid retry factor '0.0': /)
+    end
+
+    it 'fails when invalid max seconds is specified' do
+      expect { bootstrap.parse_command_line(@test_args + ['-m', '0']) }.to raise_error(
+        BootstrapSimpClient::ConfigurationError, /Invalid max seconds '0': /)
+    end
+
+    it 'fails when both --quiet and --debug are specified' do
+      expect { bootstrap.parse_command_line(@test_args + ['--quiet', '--debug']) }.to raise_error(
+        BootstrapSimpClient::ConfigurationError, /--quiet and --debug cannot be used together/)
+    end
+  end
+
+  describe '#title' do
+    it 'formats level 1 titles' do
+      expect( bootstrap.title('Level 0',0) ).to eq 'Level 0'
+      expect( bootstrap.title('Level 1',1) ).to eq '*** Level 1 ***'
+      expect( bootstrap.title('Level 2',2) ).to eq '------ Level 2 ------'
+      expect( bootstrap.title('Level 3',3) ).to eq '......... Level 3 .........'
+      expect( bootstrap.title('Level 4',4) ).to eq 'Level 4'
+    end
+  end
+
+  describe '#error' do
+    it "writes to log with 'err' level and to stderr, pre-pending with blank line" do
+      bootstrap.parse_command_line(@non_quiet_test_args)
+      message = 'This is an error message'
+      expect { bootstrap.error(message) }.to output("\n#{message}\n").to_stderr
+      expect( File.read(@log_file) ).to match(/\(err\): #{message}/)
+    end
+
+    it 'suppresses empty error messages' do
+      bootstrap.parse_command_line(@non_quiet_test_args)
+      expect { bootstrap.error('') }.to_not output.to_stderr
+      # haven't run set_up_log or appended to the log, so the
+      # file will not exist
+      expect( File.exist?(@log_file) ).to be false
+    end
+  end
+
+  describe '#warn' do
+    it "writes to log with 'warning' level and to stdout" do
+      bootstrap.parse_command_line(@non_quiet_test_args)
+      message = 'This is an warn message'
+      expect { bootstrap.warn(message) }.to output("#{message}\n").to_stdout
+      expect( File.read(@log_file) ).to match(/\(warning\): #{message}/)
+    end
+
+    it 'suppresses empty warning messages' do
+      bootstrap.parse_command_line(@non_quiet_test_args)
+      expect { bootstrap.warn('') }.to_not output.to_stdout
+      # haven't run set_up_log or appended to the log, so the
+      # file will not exist
+      expect( File.exist?(@log_file) ).to be false
+    end
+  end
+
+  describe '#info' do
+    it "writes to log with 'info' level and to stdout" do
+      bootstrap.parse_command_line(@non_quiet_test_args)
+      message = 'This is an info message'
+      expect { bootstrap.info(message) }.to output("#{message}\n").to_stdout
+      expect( File.read(@log_file) ).to match(/\(info\): #{message}/)
+    end
+
+    it 'does not suppress empty info messages' do
+      bootstrap.parse_command_line(@non_quiet_test_args)
+      expect { bootstrap.info('') }.to output("\n").to_stdout
+      expect( File.read(@log_file) ).to match(/\(info\): \n/)
+    end
+  end
+
+  describe '#debug' do
+    it "writes to log with 'debug' level and to stdout when --debug specified" do
+      bootstrap.parse_command_line(@non_quiet_test_args + ['-d'])
+      message = 'This is an debug message'
+      expect { bootstrap.debug(message) }.to output("#{message}\n").to_stdout
+      expect( File.read(@log_file) ).to match(/\(debug\): #{message}/)
+    end
+
+    it "writes to log with 'debug' level, only, when --debug is not specified" do
+      bootstrap.parse_command_line(@non_quiet_test_args)
+      message = 'This is an debug message'
+      expect { bootstrap.debug(message) }.to_not output.to_stdout
+      expect( File.read(@log_file) ).to match(/\(debug\): #{message}/)
+    end
+
+    it 'does not suppress empty debug messages' do
+      bootstrap.parse_command_line(@non_quiet_test_args + ['-d'])
+      expect { bootstrap.debug('') }.to output("\n").to_stdout
+      expect( File.read(@log_file) ).to match(/\(debug\): \n/)
+    end
+  end
+
+  describe '#log' do
+    # rest of functionality is completely tested by the other log methods
+    it 'prepends message with a timestamp and process id' do
+      bootstrap.parse_command_line(@test_args)
+      Time.stubs(:now).returns(Time.new(2017, 1, 13, 11, 42, 3, '-05:00'))
+      bootstrap.info('This is an info message')
+      expected = "2017-01-13 11:42:03 -0500 bootstrap_simp_client.rb (info): This is an info message\n"
+      expect( File.read(@log_file) ).to eq expected
+    end
+
+    it 'logs array input in one message with embedded newlines' do
+      bootstrap.parse_command_line(@test_args)
+      Time.stubs(:now).returns(Time.new(2017, 1, 13, 11, 42, 3, '-05:00'))
+      bootstrap.info(['message1', 'message2'])
+      expected = "2017-01-13 11:42:03 -0500 bootstrap_simp_client.rb (info): message1\nmessage2\n"
+      expect( File.read(@log_file) ).to eq expected
+    end
+
+    it 'suppresses console out while still writing to the log, when --quiet specified' do
+      bootstrap.parse_command_line(@test_args)
+      expect { bootstrap.error('error message') }.to_not output.to_stderr
+      expect { bootstrap.warn('warn message') }.to_not output.to_stdout
+    end
+
+    it 'fails when it cannot write to the log file' do
+      test_args = @test_args.map do |x|
+        x == @log_file ? "#{@tmp_dir}/logs/#{@log_file}" : x
+      end
+      bootstrap.parse_command_line(test_args)
+      expect { bootstrap.info('info message') }.to raise_error(Errno::ENOENT)
+    end
+  end
+end

--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,2 @@
+This directory is for links to files that need to have the '.rb' suffix, in
+order to be included via 'require' in a unit test.

--- a/tests/bootstrap_simp_client.rb
+++ b/tests/bootstrap_simp_client.rb
@@ -1,0 +1,1 @@
+../files/var/www/ks/bootstrap_simp_client


### PR DESCRIPTION
Created bootstrap_simp_client script to be used by service scripts.
- Contains the bootstrap actions of existing runpuppet
- As an enhancement, now support exponential backoff on failure
  to connect to the Puppet server.

Note: Use of this script and its download during kickstart are
addressed in other tickets.

SIMP-4859 #close