### PR TITLE
(SIMP-4966) Remove explicit 'host_list' calls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Jun 20 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.5.0-0
+- Use the sudo::user_specification default host list which is correct for
+  almost all cases
+
 * Fri Jun 08 2018 Dylan Cochran <dylan.cochran@onyxpoint.com> - 4.5.0-0
 - Add Windows support
 - Change /root perms to RPM default of 0550

--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -106,7 +106,6 @@ class simp::admin (
 
   sudo::user_specification { 'admin global':
     user_list => ["%${admin_group}"],
-    host_list => [$facts['fqdn']],
     runas     => 'ALL',
     cmnd      => $_shell_cmd,
     passwd    => !$passwordless_admin_sudo
@@ -114,7 +113,6 @@ class simp::admin (
 
   sudo::user_specification { 'auditors':
     user_list => ["%${auditor_group}"],
-    host_list => [$facts['fqdn']],
     runas     => 'root',
     cmnd      => ['AUDIT'],
     passwd    => !$passwordless_auditor_sudo
@@ -124,7 +122,6 @@ class simp::admin (
   # They allow you to recover from destroying the certs in your environment.
   sudo::user_specification { 'admin run puppet':
     user_list => ["%${admin_group}"],
-    host_list => [$facts['fqdn']],
     runas     => 'root',
     cmnd      => ['/usr/sbin/puppet', '/opt/puppetlabs/bin/puppet'],
     passwd    => !$passwordless_admin_sudo
@@ -138,7 +135,6 @@ class simp::admin (
   }
   sudo::user_specification { 'admin clean puppet certs':
     user_list => ["%${admin_group}"],
-    host_list => [$facts['fqdn']],
     runas     => 'root',
     cmnd      => ["/bin/rm -rf ${$_ssldir}"],
     passwd    => !$passwordless_admin_sudo
@@ -160,5 +156,4 @@ class simp::admin (
     priority => 10,
     content  => $_content,
   }
-
 }


### PR DESCRIPTION
This allows the sane defaults in the `sudo` module to take care of
setting the `host_list` parameter on any `sudo::user_specification`
entries.

SIMP-4966 #close