### PR TITLE
(SIMP-5043) Fix testing with Puppetfile

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,14 +2,15 @@
 fixtures:
   repositories:
     # Kluge for testing the automatic cert generation
+    # Note: Ideally, would like to name this 'environment', to match
+    # the name of the component in a simp-core Puppetfile.  However,
+    # pluginsync on the VMs barfs with a module named 'environment'
     simp_environment: https://github.com/simp/simp-environment-skeleton
     # End Kluge
     acpid: https://github.com/simp/pupmod-simp-acpid
     aide: https://github.com/simp/pupmod-simp-aide
     auditd: https://github.com/simp/pupmod-simp-auditd
     at: https://github.com/simp/pupmod-simp-at
-    augeasproviders: https://github.com/simp/augeasproviders
-    augeasproviders_base: https://github.com/simp/augeasproviders_base
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
     augeasproviders_puppet: https://github.com/simp/augeasproviders_puppet
@@ -40,7 +41,6 @@ fixtures:
     iptables: https://github.com/simp/pupmod-simp-iptables
     issue: https://github.com/simp/pupmod-simp-issue
     java: https://github.com/simp/puppetlabs-java
-    java_ks: https://github.com/simp/puppetlabs-java_ks
     kmod: https://github.com/simp/puppet-kmod.git
     krb5: https://github.com/simp/pupmod-simp-krb5
     logrotate: https://github.com/simp/pupmod-simp-logrotate
@@ -73,6 +73,7 @@ fixtures:
     simpcat: https://github.com/simp/pupmod-simp-concat
     simplib: https://github.com/simp/pupmod-simp-simplib
     simp_apache: https://github.com/simp/pupmod-simp-apache
+    simp_banners: https://github.com/simp/pupmod-simp-simp_banners
     simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     simp_rsyslog: https://github.com/simp/pupmod-simp-simp_rsyslog
@@ -95,7 +96,11 @@ fixtures:
     tuned: https://github.com/simp/pupmod-simp-tuned
     upstart: https://github.com/simp/pupmod-simp-upstart
     useradd: https://github.com/simp/pupmod-simp-useradd
+    vox_selinux:
+      repo: https://github.com/simp/pupmod-voxpupuli-selinux
+      branch: simp-master
     xinetd: https://github.com/simp/pupmod-simp-xinetd
-    '../acceptance/rsync_shares/simp': https://github.com/simp/simp-rsync.git
+    # Kluge for rsync data
+    '../acceptance/rsync_shares/simp': https://github.com/simp/simp-rsync-skeleton
   symlinks:
     simp: "#{source_dir}"

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,70 @@
 require 'simp/rake/pupmod/helpers'
 require 'puppet-strings/tasks'
 
+
 Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
+
+# Be sure to remove the rsync_share we have kludged into
+# spec/fixtures/acceptance, by specifying a relative path in .fixtures.yml
+Rake::Task[:spec_clean].enhance do
+  require 'fileutils'
+  FileUtils.rm_rf('spec/fixtures/acceptance')
+end
+
+
+# Fix non-modules fixtures that simp-rake-helpers can't handle when
+# SIMP_RSPEC_PUPPETFILE or SIMP_RSPEC_MODULEPATH are set.
+#
+# MONKEY PATCH WARNING:  This is hideously fragile!!! It aliases an internal
+# method in simp-rake-helpers.
+class Simp::Rake::Pupmod::Helpers
+  alias_method :orig_custom_fixtures_hook, :custom_fixtures_hook
+
+  def custom_fixtures_hook(opts = {
+    :short_name          => nil,
+    :puppetfile          => nil,
+    :modulepath          => nil,
+    :local_fixtures_mods => nil,
+  })
+
+    if ENV['SIMP_RSPEC_FIXTURES_OVERRIDE'] == 'yes'
+      # This will never work because simp-rake-helpers removes anything
+      # that does not have a metadata.json file in spec/fixtures/modules.
+      fail('SIMP_RSPEC_FIXTURES_OVERRIDE cannot be set for this project because of custom, non-module fixtures')
+    end
+
+    puts ">>> #{__FILE__}: Customizing fixtures not handle by simp-rake-helpers"
+
+    # TODO Discover this based on a URL match instead of depending upon a
+    # hardcoded hash
+    assets = {
+      'simp_environment'                => 'environment',
+      '../acceptance/rsync_shares/simp' => 'rsync_data'
+    }
+
+    # Adjust the names of the assets to match what is in a simp-core Puppetfile
+    assets.each do |orig_name, puppetfile_name|
+      opts[:local_fixtures_mods].delete(orig_name)
+      opts[:local_fixtures_mods] << puppetfile_name
+    end
+
+    # This temporary fixtures file has just about everything we need, except,
+    # the names for the non-module assets are wrong and the acceptance tests
+    # won't work unless these are reverted back to what was in the
+    # .fixtures.yml file.
+    puts '>>>>> Generating custom fixtures file'
+    custom_fixtures_path = orig_custom_fixtures_hook(opts)
+
+    # Revert the non-module entries back to their original names
+    custom_fixtures = YAML.load_file(custom_fixtures_path)
+    puts ">>>>> Fixing custom fixtures file #{custom_fixtures_path}"
+    assets.each do |orig_name, puppetfile_name|
+      entry = custom_fixtures['fixtures']['repositories'][puppetfile_name].dup
+      custom_fixtures['fixtures']['repositories'].delete(puppetfile_name)
+      custom_fixtures['fixtures']['repositories'][orig_name] = entry
+    end
+    File.open(custom_fixtures_path, 'w') { |file| file.write custom_fixtures.to_yaml }
+
+    custom_fixtures_path
+  end
+end

--- a/spec/classes/puppetdb_spec.rb
+++ b/spec/classes/puppetdb_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe 'simp::puppetdb' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts.merge(:puppet_settings => { 'main' => { 'hostprivkey' => 'blah' } })
+          { :puppet_settings => { 'main' => { 'hostprivkey' => 'blah' } }}.merge(os_facts)
         end
         context 'with default parameters' do
           let(:hieradata) { 'simp__puppetdb' }


### PR DESCRIPTION
- Add monkey-patch logic to the Rakefile to work around
  simp-rake-helper problems when SIMP_RSPEC_PUPPETFILE
  or SIMP_RSPEC_MODULEPATH environment variables are set
- Add missing simp_banners fixture
- Add missing vox_selinux fixture
- Fix spec test bug caused by a bad facts merge

SIMP-5043#comment pupmod-simp-simp test tooling
SIMP-5086#comment pupmod-simp-simp fixture fix