### PR TITLE
(SIMP-5213) simp::server::kickstart usability bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Thu Aug 30 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.6.0-0
+- Fix a usability bug in which simp::server::kickstart did not allow
+  the bootstrap scripts provided by simp::server::kickstart::runpuppet
+  and simp::server::kickstart::simp_client_bootstrap to be configured
+  via hieradata, when those classes were managed by simp::server::kickstart.
+
 * Mon Aug 27 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.6.0-0
 - Switch from using 'sudosh' as the default logging shell to using 'tlog'
 - Add a 'simp::admin::default_admin_sudo_cmnds' option to allow users to easily

--- a/manifests/server/kickstart.pp
+++ b/manifests/server/kickstart.pp
@@ -47,15 +47,11 @@ class simp::server::kickstart (
   if $manage_dhcp      { include '::dhcp::dhcpd' }
   if $manage_tftpboot  { include '::tftpboot' }
   if $manage_runpuppet {
-    class { 'simp::server::kickstart::runpuppet':
-      location => "${data_dir}/ks/runpuppet"
-    }
+    contain 'simp::server::kickstart::runpuppet'
   }
 
   if $manage_simp_client_bootstrap {
-    class { 'simp::server::kickstart::simp_client_bootstrap':
-      directory => "${data_dir}/ks"
-    }
+    contain 'simp::server::kickstart::simp_client_bootstrap'
   }
 
   $_trusted_nets = nets2cidr($trusted_nets)

--- a/manifests/server/kickstart/runpuppet.pp
+++ b/manifests/server/kickstart/runpuppet.pp
@@ -2,8 +2,12 @@
 # to bootstrap provisioned clients, adding them to puppet and running it in a
 # fashion similar so `simp bootstrap`.
 #
-# @param location The location of the runpuppet file to be placed when
-#   generated.
+# @param data_dir
+#   The location of the web root in which the kickstart directory
+#   will reside.  Only used to compute the default for `location`.
+#
+# @param location
+#   The location of the runpuppet file to be placed when generated.
 #
 # @param ntp_servers
 #   An array of ntp servers or hash of server/value pairs that should
@@ -50,7 +54,8 @@ class simp::server::kickstart::runpuppet (
   Optional[Simplib::Host]     $puppet_server           = simplib::lookup('simp_options::puppet::server', { 'default_value' => undef }),
   Optional[Simplib::Host]     $puppet_ca               = simplib::lookup('simp_options::puppet::ca', { 'default_value' => undef }),
   Simplib::Port               $puppet_ca_port          = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),
-  Stdlib::Absolutepath        $location                = '/var/www/ks/runpuppet',
+  Stdlib::Absolutepath        $data_dir                = simplib::lookup('simp::server::kickstart::data_dir', { 'default_value' => '/var/www'}),
+  Stdlib::Absolutepath        $location                = "${data_dir}/ks/runpuppet",
   Boolean                     $runpuppet_print_stats   = true,
   Variant[Integer[0],Boolean] $runpuppet_wait_for_cert = 10
 ) {

--- a/manifests/server/kickstart/simp_client_bootstrap.pp
+++ b/manifests/server/kickstart/simp_client_bootstrap.pp
@@ -16,8 +16,13 @@
 #   uses `bootstrap_simp_client` to bootstrap the server and then
 #   reboots the client to complete the bootstrap operation
 #
+# @param data_dir
+#   The location of the web root in which the kickstart directory
+#   will reside.  Only used to compute the default for `directory`.
+#
 # @param directory
-#   The directory containing the three managed scripts.
+#   The directory containing the three managed scripts. By default
+#   is a subdirectory within `data_dir`.
 #
 # @param service_root_name
 #   The root name of the sysv/systemd service scripts.
@@ -104,7 +109,8 @@
 #   will be fixed, when Puppet fully supports FIPS mode.
 #
 class simp::server::kickstart::simp_client_bootstrap (
-  Stdlib::Absolutepath        $directory               = '/var/www/ks',
+  Stdlib::Absolutepath        $data_dir                = simplib::lookup('simp::server::kickstart::data_dir', { 'default_value' => '/var/www'}),
+  Stdlib::Absolutepath        $directory               = "${data_dir}/ks",
   String                      $service_root_name       = 'simp_client_bootstrap',
   Variant[Array, Hash]        $ntp_servers             = simplib::lookup('simp_options::ntpd::servers', { 'default_value' => [] }),
   Boolean                     $set_static_hostname     = true,

--- a/spec/acceptance/suites/no_simp_server/kickstart_spec.rb
+++ b/spec/acceptance/suites/no_simp_server/kickstart_spec.rb
@@ -1,18 +1,19 @@
 require 'spec_helper_acceptance'
 
-test_name 'simp::server::kickstart::runpuppet'
+test_name 'simp::server::kickstart'
 
 host_pairs = [{ :server => 'server-el7',  :client => 'server-el6' },
               { :server => 'server-el6',  :client => 'server-el7' }]
 
-describe 'simp::server::kickstart::runpuppet' do
+describe 'simp::server::kickstart' do
   let(:manifest) {
     <<-EOS
       class{ 'simp::server::kickstart':
-        manage_dhcp      => false,
-        manage_tftpboot  => false,
-        manage_runpuppet => true,
-        sslverifyclient  => none,
+        manage_dhcp                  => false,
+        manage_tftpboot              => false,
+        manage_runpuppet             => true,
+        manage_simp_client_bootstrap => true,
+        sslverifyclient              => none,
       }
     EOS
   }
@@ -25,6 +26,11 @@ simp::server::kickstart::runpuppet::ntp_servers: []
 simp::server::kickstart::runpuppet::puppet_server: 'puppet.test.test'
 simp::server::kickstart::runpuppet::puppet_ca: 'puppetca.test.test'
 simp::server::kickstart::runpuppet::puppet_ca_port: 8140
+simp::server::kickstart::simp_client_bootstrap::fips: #{(ENV['BEAKER_fips'] == 'yes').to_s}
+simp::server::kickstart::simp_client_bootstrap::ntp_servers: []
+simp::server::kickstart::simp_client_bootstrap::puppet_server: 'puppet.test.test'
+simp::server::kickstart::simp_client_bootstrap::puppet_ca: 'puppetca.test.test'
+simp::server::kickstart::simp_client_bootstrap::puppet_ca_port: 8140
 simp_apache::ssl: false
 simp_apache::rsync_web_root: false
 simp_apache::conf::allowroot:
@@ -36,7 +42,7 @@ simp_apache::conf::allowroot:
   }
   context 'on a non-simp test host' do
     # Using puppet_apply as a helper
-    it 'should provide a correctly-configured `runpuppet` file over HTTP' do
+    it 'should provide correctly-configured bootstrap files over HTTP' do
 
       hosts.each do |host|
         _clients=(hosts-[host])
@@ -46,6 +52,9 @@ simp_apache::conf::allowroot:
         set_hieradata_on(host, hieradata.gsub('ALLOW_IP',client.ip))
         apply_manifest_on host, manifest
         on client, "curl http://server-el7/ks/runpuppet -f | grep '^ *server *= *puppet\.test\.test'"
+        on client, "curl http://server-el7/ks/simp_client_bootstrap.service -f | grep 'puppet-server puppet\.test\.test'"
+        on client, "curl http://server-el7/ks/simp_client_bootstrap -f | grep 'puppet-server puppet\.test\.test'"
+        on client, "curl http://server-el7/ks/bootstrap_simp_client -f | grep '^class BootstrapSimpClient'"
       end
     end
   end

--- a/spec/classes/server/kickstart_spec.rb
+++ b/spec/classes/server/kickstart_spec.rb
@@ -24,22 +24,51 @@ describe 'simp::server::kickstart' do
           os_facts
         end
 
-        let(:params) {{ :data_dir => '/var/www' }}
+        context 'default settings' do
+          let(:params) {{ :data_dir => '/var/www' }}
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_class('simp_apache') }
-        it { is_expected.to create_class('dhcp::dhcpd') }
-        it { is_expected.to create_class('tftpboot') }
-        it { is_expected.to create_simp_apache__site('ks').with_content(/Allow from 1.2.3.4\/24/) }
-        it { is_expected.to create_file('/var/www/ks').with_mode('2640') }
-        it { is_expected.to create_file('/var/www/ks/runpuppet') }
-        it { is_expected.to create_file('/var/www/ks/simp_client_bootstrap') }
-        it { is_expected.to create_file('/var/www/ks/simp_client_bootstrap.service') }
-        it { is_expected.to create_file('/var/www/ks/bootstrap_simp_client') }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('simp_apache') }
+          it { is_expected.to create_class('dhcp::dhcpd') }
+          it { is_expected.to create_class('tftpboot') }
+          it { is_expected.to create_simp_apache__site('ks').with_content(/Allow from 1.2.3.4\/24/) }
+          it { is_expected.to create_file('/var/www/ks').with_mode('2640') }
+          it { is_expected.to contain_class('simp::server::kickstart::runpuppet') }
+          it { is_expected.to contain_class('simp::server::kickstart::simp_client_bootstrap') }
+        end
+
+        context 'manage_dhcp = false' do
+          let(:params) {{ :manage_dhcp => false }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to_not create_class('dhcp::dhcpd') }
+        end
+
+        context 'manage_tftpboot = false' do
+          let(:params) {{ :manage_tftpboot => false }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to_not create_class('tftpboot') }
+        end
+
+        context 'manage_runpuppet = false' do
+          let(:params) {{ :manage_runpuppet => false }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to_not contain_class('simp::server::kickstart::runpuppet') }
+        end
+
+        context 'manage_simp_client_bootstrap = false' do
+          let(:params) {{ :manage_simp_client_bootstrap => false }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to_not contain_class('simp::server::kickstart::simp_client_bootstrap') }
+        end
 
         context 'alternate_data_dir' do
           let(:params) {{ :data_dir => '/srv/www' }}
 
+          it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_file('/var/www/ks').with_target('/srv/www/ks') }
         end
       end


### PR DESCRIPTION
Fixed a usability bug in which simp::server::kickstart did not allow
the bootstrap scripts provided by simp::server::kickstart::runpuppet
and simp::server::kickstart::simp_client_bootstrap to be configured
via hieradata, when those classes were managed by simp::server::kickstart.

SIMP-5213 #close