### PR TITLE
(SIMP-5289) Revert to simp/timezone

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -129,7 +129,7 @@
       "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
-      "name": "saz/timezone",
+      "name": "simp/timezone",
       "version_requirement": ">= 4.1.0 < 6.0.0"
     },
     {


### PR DESCRIPTION
Revert from saz/timezone to simp/timezone.  Although using
saz/timezone from here in out makes sense from a Puppet module
perspective, it cannot be done because a design flaw in the
simp-adapter causes RPM upgrade failures.  Instead, we will
pull forward the latest saz/timezone changes into simp/timezone.

We will revert to saz/timezone when we redesign module packaging.

SIMP-5289 #comment revert to simp/timezone in pupmod-simp-simp