### PR TITLE
(SIMP-5289) Fix range of simp/timezone

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -130,7 +130,7 @@
     },
     {
       "name": "simp/timezone",
-      "version_requirement": ">= 4.1.0 < 6.0.0"
+      "version_requirement": ">= 4.0.0 < 6.0.0"
     },
     {
       "name": "simp/tlog",


### PR DESCRIPTION
The previous SIMP-5289 PR failed to adjust the
range of simp/timezone dependencies required.

SIMP-5289 #comment fix simp-timezone dep range