### PR TITLE
(SIMP-5483) Acceptance Testing

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -87,7 +87,9 @@ fixtures:
     swap: https://github.com/simp/pupmod-simp-swap
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
     tftpboot: https://github.com/simp/pupmod-simp-tftpboot
-    timezone: https://github.com/simp/pupmod-simp-timezone
+    timezone:
+      repo: https://github.com/simp/pupmod-simp-timezone
+      branch: simp-master
     tlog: https://github.com/simp/pupmod-simp-tlog
     tuned: https://github.com/simp/pupmod-simp-tuned
     upstart: https://github.com/simp/pupmod-simp-upstart

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Oct 17 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.6.0-0
+- Update fixtures to use correct branch of timezone.  (Soma as in
+  the tracking file for 6.3
+
 * Wed Oct 10 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.6.0-0
 - Remove unnecessary simp/freeradius dependency in metadata.json
 


### PR DESCRIPTION
- updated fixtures file to use same version of timezone as puppet
  tracking, simp-master. Master currently has an error.

SIMP-5483 #comment update pupmod-simp-simp