### PR TITLE
(SIMP-5855) Increase max inotify watches

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Tue Dec 11 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.6.1-0
+- Added sysctl value to increase  max  number of inotify user watchs.
+  Default = 8192, New Value 65535.
+  - If max number is reached systemctl fails with "Not enough Space on Disk"
+  even though there is plenty of space.
+  - See https://unix.stackexchange.com/questions/13751/kernel-inotify-watch-limit-reached
+  for some helpful information.
+
 * Thu Oct 18 2018 Nick Miller <nick.miller@onyxpoint.com> - 4.6.0-0
 - Added $simp::server::yum::createrepo_ensure parameter
   - Changed the package from 'latest' to 'installed'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,10 @@
 * Tue Dec 11 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.6.1-0
-- Added sysctl value to increase  max  number of inotify user watchs.
-  Default = 8192, New Value 65535.
+- Added sysctl value to increase max number of inotify user watches.
+  Default = 8192, New Value 102400 which is roughly 100M on a 64 bit system.
   - If max number is reached systemctl fails with "Not enough Space on Disk"
-  even though there is plenty of space.
+    even though there is plenty of space.
   - See https://unix.stackexchange.com/questions/13751/kernel-inotify-watch-limit-reached
-  for some helpful information.
+    for some helpful information.
 
 * Thu Oct 18 2018 Nick Miller <nick.miller@onyxpoint.com> - 4.6.0-0
 - Added $simp::server::yum::createrepo_ensure parameter

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -27,6 +27,9 @@
 # @param net__core__netdev_max_backlog
 # @param net__core__somaxconn
 # @param net__ipv4__tcp_tw_reuse
+# @param fs__inotify__max_user_watch
+#     Increase the number of inotify watches allowed in order to prevent
+#     systemctl error: "Not Enough Disk Space" caused when it reaches limit.
 #
 # Security Related Settings:
 # @param fs__suid_dumpable
@@ -103,6 +106,7 @@ class simp::sysctl (
   Integer[0]           $net__core__netdev_max_backlog                  = 2048,
   Integer[0]           $net__core__somaxconn                           = 2048,
   Integer[0,1]         $net__ipv4__tcp_tw_reuse                        = 1,
+  Integer[8912]        $fs__inotify__max_user_watches                  = 65535,
   Integer[0,1]         $fs__suid_dumpable                              = 0,          # CCE-27044-7
   String               $kernel__core_pattern                           = '/var/core/%u_%g_%p_%t_%h_%e.core',
   Integer[0]           $kernel__core_pipe_limit                        = 0,
@@ -172,7 +176,8 @@ class simp::sysctl (
     'net.core.optmem_max'               : value => $net__core__optmem_max;
     'net.core.netdev_max_backlog'       : value => $net__core__netdev_max_backlog;
     'net.core.somaxconn'                : value => $net__core__somaxconn;
-    'net.ipv4.tcp_tw_reuse'             : value => $net__ipv4__tcp_tw_reuse
+    'net.ipv4.tcp_tw_reuse'             : value => $net__ipv4__tcp_tw_reuse;
+    'fs.inotify.max_user_watches'       : value => $fs__inotify__max_user_watches
   }
 
   # This may not exist until additional packages are present

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -106,7 +106,7 @@ class simp::sysctl (
   Integer[0]           $net__core__netdev_max_backlog                  = 2048,
   Integer[0]           $net__core__somaxconn                           = 2048,
   Integer[0,1]         $net__ipv4__tcp_tw_reuse                        = 1,
-  Integer[8912]        $fs__inotify__max_user_watches                  = 65535,
+  Integer[8912]        $fs__inotify__max_user_watches                  = 102400,
   Integer[0,1]         $fs__suid_dumpable                              = 0,          # CCE-27044-7
   String               $kernel__core_pattern                           = '/var/core/%u_%g_%p_%t_%h_%e.core',
   Integer[0]           $kernel__core_pipe_limit                        = 0,
@@ -155,7 +155,8 @@ class simp::sysctl (
 
   simplib::assert_metadata( $module_name )
 
-  validate_sysctl_value('kernel.core_pattern',$kernel__core_pattern)
+  simplib::validate_sysctl_value('kernel.core_pattern',$kernel__core_pattern)
+  simplib::validate_sysctl_value('fs.inotify.max_user_watches', $fs__inotify__max_user_watches)
 
   sysctl {
     'net.unix.max_dgram_qlen'           : value => $net__unix__max_dgram_qlen;

--- a/metadata.json
+++ b/metadata.json
@@ -118,7 +118,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.9.0 < 4.0.0"
+      "version_requirement": ">= 3.12.0 < 4.0.0"
     },
     {
       "name": "simp/tftpboot",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/spec/classes/sysctl_spec.rb
+++ b/spec/classes/sysctl_spec.rb
@@ -15,6 +15,7 @@ describe 'simp::sysctl' do
         it { is_expected.not_to create_sysctl('net.ipv6.conf.all.disable_ipv6').with(:value => 1 ) }
         it { is_expected.not_to create_sysctl('net.ipv6.conf.all.accept_source_route').with(:value => 0 ) }
         it { is_expected.not_to create_sysctl('net.ipv6.conf.default.accept_source_route').with(:value => 0 ) }
+        it { is_expected.to create_sysctl('fs.inotify.max_user_watches').with(:value => 65535 ) }
       end
 
       context "with ipv6 => true" do

--- a/spec/classes/sysctl_spec.rb
+++ b/spec/classes/sysctl_spec.rb
@@ -15,7 +15,7 @@ describe 'simp::sysctl' do
         it { is_expected.not_to create_sysctl('net.ipv6.conf.all.disable_ipv6').with(:value => 1 ) }
         it { is_expected.not_to create_sysctl('net.ipv6.conf.all.accept_source_route').with(:value => 0 ) }
         it { is_expected.not_to create_sysctl('net.ipv6.conf.default.accept_source_route').with(:value => 0 ) }
-        it { is_expected.to create_sysctl('fs.inotify.max_user_watches').with(:value => 65535 ) }
+        it { is_expected.to create_sysctl('fs.inotify.max_user_watches').with(:value => 102400 ) }
       end
 
       context "with ipv6 => true" do


### PR DESCRIPTION
- puppetserver was getting error "Not enough space on disk"
  when running systemctl which is caused by running out of inotify
  user watches.  
- increased fs.inotify.max_user_watchs from 8192 to 65535 to
  prevent this.

SIMP-5855 #close