### PR TITLE
(SIMP-5919) Manage Root User Password

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Jan 02 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 4.6.2-0
+- Add the ability to set the root user password in `simp::root_user`
+
 * Tue Dec 11 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.6.1-0
 - Added sysctl value to increase max number of inotify user watches.
   Default = 8192, New Value 102400 which is roughly 100M on a 64 bit system.

--- a/manifests/root_user.pp
+++ b/manifests/root_user.pp
@@ -10,10 +10,14 @@
 # @param manage_group
 #  Ensure the root group has appropriate UIDs, etc
 #
+# @param password
+#  Set the root user's password using Puppet
+#
 class simp::root_user (
-  Boolean $manage_perms = true,
-  Boolean $manage_user  = true,
-  Boolean $manage_group = true
+  Boolean           $manage_perms = true,
+  Boolean           $manage_user  = true,
+  Boolean           $manage_group = true,
+  Optional[String]  $password     = undef,
 ){
 
   simplib::assert_metadata( $module_name )
@@ -28,6 +32,12 @@ class simp::root_user (
   }
 
   if $manage_user {
+    # use Sensitive data type for the password if set
+    $l_password = $password ? {
+      undef   => undef,
+      default => Sensitive($password),
+    }
+
     user { 'root':
       ensure     => 'present',
       uid        => '0',
@@ -36,7 +46,8 @@ class simp::root_user (
       home       => '/root',
       shell      => '/bin/bash',
       membership => 'minimum',
-      forcelocal => true
+      forcelocal => true,
+      password   => $l_password,
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/spec/classes/root_user_spec.rb
+++ b/spec/classes/root_user_spec.rb
@@ -10,7 +10,7 @@ describe 'simp::root_user' do
 
       it 'manages root user by default' do
         is_expected.to create_file('/root')
-        is_expected.to create_user('root')
+        is_expected.to create_user('root').without_password
         is_expected.to create_group('root')
       end
 
@@ -27,6 +27,16 @@ describe 'simp::root_user' do
         }
       end
 
+      context 'with password' do
+        let(:params) {{
+          :password => 'mysecretpassword'
+        }}
+        it {
+          is_expected.to create_file('/root')
+          is_expected.to create_user('root').with_password('mysecretpassword')
+          is_expected.to create_group('root')
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
This change adds the ability to set the root user password via SIMP
using the `simp::root_user::password` parameter either with SHA hash
or String via hiera or directly.

SIMP-5919 #close #comment Added password parameter