### PR TITLE
(SIMP-6112) Use (namespaced) simplib::join_mount_opts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
-  - gem install -v '~> 1.16' bundler
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,22 @@
-* Mon Jan 21 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.6.1-0
+* Fri Feb 15 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.7.0-0
+- Use simplib::join_mount_opts() in lieu of join_mount_opts(), a
+  deprecated simplib Puppet 3 function.
+- Use simplib::nets2cidr() in lieu of nets2cidr(), a deprecated
+  simplib Puppet 3 function.
+- Use Puppet's String() in lieu of to_string(), a deprecated simplib
+  Puppet 3 function.
+- Use simp_apache::munge_httpd_networks() in lieu of
+  munge_httpd_networks(), a deprecated simp_apache Puppet 3 function.
+- Use ssh::global_known_hosts() in lieu of ssh_global_known_hosts(),
+  a deprecated ssh Puppet 3 function.
+
+* Mon Jan 21 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.7.0-0
 - Update the dependency list in metadata.json
 
-* Wed Jan 02 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 4.6.1-0
+* Wed Jan 02 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 4.7.0-0
 - Add the ability to set the root user password in `simp::root_user`
 
-* Tue Dec 11 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.6.1-0
+* Tue Dec 11 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.7.0-0
 - Added sysctl value to increase max number of inotify user watches.
   Default = 8192, New Value 102400 which is roughly 100M on a 64 bit system.
   - If max number is reached systemctl fails with "Not enough Space on Disk"

--- a/manifests/mountpoints/tmp.pp
+++ b/manifests/mountpoints/tmp.pp
@@ -74,7 +74,7 @@ class simp::mountpoints::tmp (
           ensure   => 'mounted',
           target   => '/etc/fstab',
           fstype   => $facts['tmp_mount_fstype_tmp'],
-          options  => join_mount_opts($_tmp_mount_tmp_opts,$tmp_opts),
+          options  => simplib::join_mount_opts($_tmp_mount_tmp_opts,$tmp_opts),
           device   => $facts['tmp_mount_path_tmp'],
           pass     => '1',
           remounts => true
@@ -85,7 +85,7 @@ class simp::mountpoints::tmp (
           ensure   => 'mounted',
           target   => '/etc/fstab',
           fstype   => 'none',
-          options  => join_mount_opts(['bind'],$tmp_opts),
+          options  => simplib::join_mount_opts(['bind'],$tmp_opts),
           device   => $facts['tmp_mount_path_tmp'],
           remounts => true
         }
@@ -108,7 +108,7 @@ class simp::mountpoints::tmp (
         ensure   => 'mounted',
         target   => '/etc/fstab',
         fstype   => 'none',
-        options  => join_mount_opts(['bind'],$tmp_opts),
+        options  => simplib::join_mount_opts(['bind'],$tmp_opts),
         device   => '/tmp',
         remounts => true,
         notify   => Exec['remount /tmp']
@@ -133,7 +133,7 @@ class simp::mountpoints::tmp (
           ensure   => 'mounted',
           target   => '/etc/fstab',
           fstype   => $facts['tmp_mount_fstype_var_tmp'],
-          options  => join_mount_opts($_tmp_mount_var_tmp_opts,$var_tmp_opts),
+          options  => simplib::join_mount_opts($_tmp_mount_var_tmp_opts,$var_tmp_opts),
           device   => $facts['tmp_mount_path_var_tmp'],
           pass     => '1',
           remounts => true
@@ -144,7 +144,7 @@ class simp::mountpoints::tmp (
           ensure   => 'mounted',
           target   => '/etc/fstab',
           fstype   => 'none',
-          options  => join_mount_opts(['bind'],$var_tmp_opts),
+          options  => simplib::join_mount_opts(['bind'],$var_tmp_opts),
           device   => $facts['tmp_mount_path_var_tmp'],
           remounts => true
         }
@@ -165,7 +165,7 @@ class simp::mountpoints::tmp (
         ensure   => 'mounted',
         device   => '/tmp',
         fstype   => 'none',
-        options  => join_mount_opts(['bind'],$var_tmp_opts),
+        options  => simplib::join_mount_opts(['bind'],$var_tmp_opts),
         target   => '/etc/fstab',
         remounts => true,
         notify   => Exec['remount /var/tmp']
@@ -188,7 +188,7 @@ class simp::mountpoints::tmp (
       # properly.
       mount { '/dev/shm':
         ensure   => 'mounted',
-        options  => join_mount_opts($_tmp_mount_dev_shm_opts,$dev_shm_opts),
+        options  => simplib::join_mount_opts($_tmp_mount_dev_shm_opts,$dev_shm_opts),
         device   => $facts['tmp_mount_path_dev_shm'],
         fstype   => 'tmpfs',
         target   => '/etc/fstab',

--- a/manifests/scenario/base.pp
+++ b/manifests/scenario/base.pp
@@ -95,7 +95,7 @@ class simp::scenario::base (
 
   assert_private()
 
-  runlevel { to_string($runlevel): }
+  runlevel { String($runlevel): }
 
   if ($sssd and $stock_sssd) { include '::simp::sssd::client' }
 
@@ -136,7 +136,7 @@ class simp::scenario::base (
   }
 
   if $use_ssh_global_known_hosts {
-    ssh_global_known_hosts()
+    ssh::global_known_hosts()
 
     sshkey_prune { '/etc/ssh/ssh_known_hosts': }
   }

--- a/manifests/server/kickstart.pp
+++ b/manifests/server/kickstart.pp
@@ -54,7 +54,7 @@ class simp::server::kickstart (
     contain 'simp::server::kickstart::simp_client_bootstrap'
   }
 
-  $_trusted_nets = nets2cidr($trusted_nets)
+  $_trusted_nets = simplib::nets2cidr($trusted_nets)
 
   include '::simp_apache'
   simp_apache::site { 'ks':

--- a/manifests/server/ldap.pp
+++ b/manifests/server/ldap.pp
@@ -49,7 +49,7 @@ class simp::server::ldap (
   include '::simp_openldap::slapo::syncprov'
   if $enable_lastbind { include '::simp_openldap::slapo::lastbind' }
 
-  $s_rid = to_string($rid)
+  $s_rid = String($rid)
   if $is_slave {
     simp_openldap::server::syncrepl { $s_rid: }
   }

--- a/manifests/server/yum.pp
+++ b/manifests/server/yum.pp
@@ -16,7 +16,7 @@ class simp::server::yum (
 
   simplib::assert_metadata( $module_name )
 
-  $_trusted_nets = nets2cidr($trusted_nets)
+  $_trusted_nets = simplib::nets2cidr($trusted_nets)
 
   include '::simp_apache'
   simp_apache::site { 'yum':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",
@@ -34,7 +34,7 @@
     },
     {
       "name": "simp/simp_apache",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.1 < 7.0.0"
     },
     {
       "name": "simp/auditd",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -86,7 +86,7 @@ describe 'simp' do
         end
         let(:hieradata) { "sssd::domains: ['LDAP']" }
 
-        context 'with default paramters' do
+        context 'with default parameters' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_file('/opt/puppetlabs/puppet/cache/simp') }
           it { is_expected.to create_host('puppet.bar.baz').with_ip('1.2.3.4') }

--- a/spec/classes/scenario/base_spec.rb
+++ b/spec/classes/scenario/base_spec.rb
@@ -1,0 +1,141 @@
+require 'spec_helper'
+
+# We have to test simp::scenario::base via simp, because
+# simp::scenario::base is private.  To take advantage of hooks
+# built into puppet-rspec, the class described needs to be the class
+# instantiated, i.e., simp.
+describe 'simp' do
+  def server_facts_hash
+    return {
+      'serverversion' => Puppet.version,
+      'servername'    => 'puppet.bar.baz',
+      'serverip'      => '1.2.3.4'
+    }
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts = os_facts.dup
+        facts[:openssh_version] = '5.8'
+        facts[:augeasversion] = '1.2.3'
+        facts[:puppet_vardir] = '/opt/puppetlabs/puppet/cache'
+        facts[:puppet_settings] = {
+          'main' => {
+            'ssldir' => '/opt/puppetlabs/puppet/vardir',
+          },
+          'agent' => {
+            'server' => 'puppet.bar.baz'
+          }
+        }
+
+        facts
+      end
+
+      context 'default parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp::scenario::base') }
+        it { is_expected.to create_runlevel('3') }
+        it { is_expected.to create_class('simp::sssd::client') }
+        it { is_expected.to create_class('simp::sudoers') }
+        it { is_expected.to create_class('simp::ctrl_alt_del') }
+        it { is_expected.to create_class('simp::root_user') }
+        # simp_options::pam is not set in spec/fixtures/hieradata/default.yaml
+        it { is_expected.to_not create_class('simp::pam_limits::max_logins') }
+        it { is_expected.to create_class('postfix') }
+        it { is_expected.to_not create_class('postfix::server') }
+        # simp_options::ldap is not set in spec/fixtures/hieradata/default.yaml
+        it { is_expected.to_not create_class('simp_openldap::client') }
+        it { is_expected.to create_class('simp::rc_local') }
+      end
+
+      context "runlevel = 'graphical'" do
+        let(:params) {{ :runlevel =>  'graphical'  }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_runlevel('graphical') }
+      end
+
+      context 'sssd = false' do
+        let(:params) {{ :sssd => false }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to_not create_class('simp::sssd::client') }
+      end
+
+      context 'stock_sssd = false' do
+        let(:params) {{ :stock_sssd => false }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to_not create_class('simp::sssd::client') }
+      end
+
+      context 'use_sudoers_aliases = false' do
+        let(:params) {{ :use_sudoers_aliases => false }}
+        it { is_expected.to compile.with_all_deps }
+        # SIMP-6133
+        pending { is_expected.to_not create_class('simp::sudoers') }
+      end
+
+      context 'manage_ctrl_alt_del = false' do
+        let(:params) {{ :manage_ctrl_alt_del => false }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to_not create_class('simp::ctrl_alt_del') }
+      end
+
+      context 'manage_root_metadata = false' do
+        let(:params) {{ :manage_root_metadata => false }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to_not create_class('simp::root_user') }
+      end
+
+      context 'restrict_max_logins = false' do
+        let(:params) {{ :restrict_max_logins => false, :pam => true }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to_not create_class('simp::pam_limits::max_logins') }
+      end
+
+      context 'pam = true' do
+        let(:params) {{ :pam => true }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp::pam_limits::max_logins') }
+      end
+
+      context 'mail_server = false' do
+        let(:params) {{ :mail_server => false }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to_not create_class('postfix') }
+        it { is_expected.to_not create_class('postfix::server') }
+      end
+
+      context "mail_server = 'remote'" do
+        let(:params) {{ :mail_server => 'remote' }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('postfix::server') }
+      end
+
+      context 'ldap = true' do
+        let(:params) {{ :ldap => true }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp_openldap::client') }
+      end
+
+      context 'ipa fact set ' do
+        let(:facts) do
+          super().merge({
+            :ipa => {
+              :domain => 'ipa.example.com',
+              :server => 'ipaserver.example.com',
+            }
+          })
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to_not create_class('simp_openldap::client') }
+      end
+
+      context 'manage_rc_local = false' do
+        let(:params) {{ :manage_rc_local => false }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to_not create_class('simp::rc_local') }
+      end
+    end
+  end
+end

--- a/spec/classes/server/kickstart_spec.rb
+++ b/spec/classes/server/kickstart_spec.rb
@@ -1,4 +1,4 @@
-# Can't run this until lwe get access to server_facts
+# Can't run this until we get access to server_facts
 require 'spec_helper'
 
 describe 'simp::server::kickstart' do
@@ -31,7 +31,8 @@ describe 'simp::server::kickstart' do
           it { is_expected.to create_class('simp_apache') }
           it { is_expected.to create_class('dhcp::dhcpd') }
           it { is_expected.to create_class('tftpboot') }
-          it { is_expected.to create_simp_apache__site('ks').with_content(/Allow from 1.2.3.4\/24/) }
+          it { is_expected.to create_simp_apache__site('ks').with_content(/Allow from 1.2.3.0\/24/) }
+          it { is_expected.to create_simp_apache__site('ks').with_content(/Allow from 5.6.0.0\/16/) }
           it { is_expected.to create_file('/var/www/ks').with_mode('2640') }
           it { is_expected.to contain_class('simp::server::kickstart::runpuppet') }
           it { is_expected.to contain_class('simp::server::kickstart::simp_client_bootstrap') }
@@ -69,6 +70,19 @@ describe 'simp::server::kickstart' do
           let(:params) {{ :data_dir => '/srv/www' }}
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_file('/var/www/ks').with_target('/srv/www/ks') }
+        end
+
+        context 'trusted_nets = [ 0.0.0.0/0 ]' do
+          # Apache needs 0.0.0.0/0 to be translated to ALL
+          let(:params) {{ :trusted_nets => [ '0.0.0.0/0' ] }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_simp_apache__site('ks').with_content(/Allow from ALL/) }
+        end
+
+        context 'trusted_nets = ALL' do
+          let(:params) {{ :trusted_nets => [ 'ALL' ] }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_simp_apache__site('ks').with_content(/Allow from ALL/) }
         end
       end
     end

--- a/spec/classes/server/ldap_spec.rb
+++ b/spec/classes/server/ldap_spec.rb
@@ -2,25 +2,23 @@ require 'spec_helper'
 
 describe 'simp::server::ldap' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          if ['RedHat', 'CentOS', 'OracleLinux'].include?(facts[:operatingsystem]) && facts[:operatingsystemmajrelease].to_s < '7'
-            facts[:apache_version] = '2.2'
-            facts[:grub_version] = '0.9'
-            facts[:init_systems] = ['rc','sysv','upstart']
-          else
-            facts[:apache_version] = '2.4'
-            facts[:grub_version] = '2.0~beta'
-            facts[:init_systems] = ['rc','sysv','systemd']
-          end
-
-          facts[:selinux_current_mode] = 'enforcing'
-
-          facts
+          os_facts
         end
 
-        it { is_expected.to compile.with_all_deps }
+        context 'default parameters' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('simp_openldap') }
+          it { is_expected.to create_class('simp_openldap::server') }
+          it { is_expected.to create_class('simp_openldap::slapo::ppolicy') }
+          it { is_expected.to create_class('simp_openldap::slapo::syncprov') }
+          it { is_expected.to_not create_simp_openldap__server__syncrepl('111') }
+          it { is_expected.to create_simp_openldap__server__limits('Host_Bind_DN_Unlimited_Query') }
+          it { is_expected.to create_simp_openldap__server__limits('LDAP_Sync_DN_Unlimited_Query') }
+        end
+
 
         context 'is_slave' do
           let(:params){{ :is_slave => true }}

--- a/spec/classes/server/yum_spec.rb
+++ b/spec/classes/server/yum_spec.rb
@@ -1,28 +1,44 @@
-# Can't run this until we get access to server_facts
 require 'spec_helper'
 
 describe 'simp::server::yum' do
-  on_supported_os.each do |os, facts|
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) do
-        if facts[:operatingsystemmajrelease].to_s < '7'
-          facts[:apache_version] = '2.2'
-          facts[:grub_version] = '0.9'
-          facts[:init_systems] = ['rc','sysv','upstart']
-        else
-          facts[:apache_version] = '2.4'
-          facts[:grub_version] = '2.0~beta'
-          facts[:init_systems] = ['rc','sysv','systemd']
-        end
-
-        facts[:selinux_current_mode] = 'enforcing'
-
-        facts
+        os_facts
       end
 
-      context 'base' do
+      context 'default parameters' do
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_simp_apache__site('yum') }
+        it { is_expected.to contain_simp_apache__site('yum').with_content( <<-EOM
+Alias /yum /var/www/yum
+
+<Location /yum>
+    Options +Indexes
+
+    Order allow,deny
+    Allow from 127.0.0.1
+    Allow from ::1
+    Allow from 1.2.3.0/24
+    Allow from 5.6.0.0/16
+    Allow from example.com
+</Location>
+
+          EOM
+        ) }
+        it { is_expected.to contain_package('createrepo') }
+      end
+
+      context 'trusted_nets = [ 0.0.0.0/0 ]' do
+        # Apache needs 0.0.0.0/0 to be translated to ALL
+        let(:params) {{ :trusted_nets => [ '0.0.0.0/0' ] }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_simp_apache__site('yum').with_content(/Allow from ALL/) }
+      end
+
+      context 'trusted_nets = ALL' do
+        let(:params) {{ :trusted_nets => [ 'ALL' ] }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_simp_apache__site('yum').with_content(/Allow from ALL/) }
       end
     end
   end

--- a/templates/etc/httpd/conf.d/ks.conf.erb
+++ b/templates/etc/httpd/conf.d/ks.conf.erb
@@ -1,7 +1,7 @@
 <%
   t_allowroot = nil
-  if @_trusted_nets
-    t_allowroot = scope.function_munge_httpd_networks(Array(@_trusted_nets)).map{ |x|
+  unless @_trusted_nets.empty?
+    t_allowroot = scope.call_function('simp_apache::munge_httpd_networks',[ @_trusted_nets ]).map{ |x|
       x = "    Allow from #{x}"
     }.join("\n")
   end

--- a/templates/etc/httpd/conf.d/yum.conf.erb
+++ b/templates/etc/httpd/conf.d/yum.conf.erb
@@ -1,7 +1,7 @@
 <%
   t_allowroot = nil
-  if @_trusted_nets
-    t_allowroot = scope.function_munge_httpd_networks(Array(@_trusted_nets)).map{ |x|
+  unless @_trusted_nets.empty?
+    t_allowroot = scope.call_function('simp_apache::munge_httpd_networks',[ @_trusted_nets ]).map{ |x|
       x = "    Allow from #{x}"
     }.join("\n")
   end


### PR DESCRIPTION
- Adjust version to match new parameters added to `simp::root_user` in
  an earlier commit
- Use simplib::join_mount_opts() in lieu of join_mount_opts(), a
  deprecated simplib Puppet 3 function.
- Use simplib::nets2cidr() in lieu of nets2cidr(), a deprecated
  simplib Puppet 3 function.
- Use Puppet's String() in lieu of to_string(), a deprecated simplib
  Puppet 3 function.
- Use simp_apache::munge_httpd_networks() in lieu of
  munge_httpd_networks(), a deprecated simp_apache Puppet 3 function.
- Use ssh::global_known_hosts() in lieu of ssh_global_known_hosts(),
  a deprecated ssh Puppet 3 function.

SIMP-6112 #close