### PR TITLE
Avoid touching Puppet's vardir in Bolt

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 - Standardized cron datatypes to use the Simplib::Cron::### types.  This
   allows more flexibility in cron scheduling.
 
+* Mon Mar 25 2019 Nick Miller <nick.miller@onyxpoint.com> - 4.8.0-0
+- Add exceptions to the filebucket management and the vardir/simp management
+  to support running from Bolt
+
 * Thu Mar 21 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.8.0-0
 - Replaced use of the simplib's Puppet 3 array_include function with
   stdlib's member function

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -86,7 +86,8 @@ class simp::puppetdb (
     }
     else {
       warning('$read_database_ssl is deprecated and will be removed in the next major release. Please use $read_database_jdbc_ssl_properties = "" instead.')
-      $_read_database_jdbc_ssl_properties = ''
+
+      $_read_database_jdbc_ssl_properties = '' # lint:ignore:empty_string_assignment
     }
   }
   else {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -200,6 +200,25 @@ describe 'simp' do
           end
         end
 
+        context 'when running from Bolt' do
+          let(:environment) { 'bolt_catalog' }
+
+          context 'will not create a filebucket' do
+            let(:params) {{
+              :enable_filebucketing => true,
+              :filebucket_server    => 'my.puppet.server'
+            }}
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.not_to create_filebucket('simp') }
+          end
+
+          context 'will not create vardir/simp dir' do
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.not_to create_file('/opt/puppetlabs/puppet/cache/simp') }
+          end
+        end
+
         context 'when scenario is set to' do
           poss = [
             'pupmod',


### PR DESCRIPTION
When compiling catalogs in Bolt, the system vardir is on the machine
running Bolt, not the target machine. This caused permission errors.