### PR TITLE
(SIMP-6213) Use latest concat and others in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -25,11 +25,7 @@ fixtures:
     autofs: https://github.com/simp/pupmod-simp-autofs
     chkrootkit: https://github.com/simp/pupmod-simp-chkrootkit
     clamav: https://github.com/simp/pupmod-simp-clamav
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     cron: https://github.com/simp/pupmod-simp-cron
     datacat: https://github.com/simp/puppet-datacat
     dhcp: https://github.com/simp/pupmod-simp-dhcp
@@ -55,14 +51,14 @@ fixtures:
     postfix: https://github.com/simp/pupmod-simp-postfix
     postgresql:
       repo: https://github.com/simp/puppetlabs-postgresql
-      ref: 5.2.1
+      ref: 5.12.1
     puppetdb:
       repo: https://github.com/simp/puppetlabs-puppetdb
       ref: 6.0.2
     pupmod: https://github.com/simp/pupmod-simp-pupmod
     puppet_authorization:
       repo: https://github.com/simp/puppetlabs-puppet_authorization
-      ref: 0.4.0
+      ref: 0.5.0
     resolv: https://github.com/simp/pupmod-simp-resolv
     rsync: https://github.com/simp/pupmod-simp-rsync
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.7.0-0
+- Update URLs in the README.md
+- Expand the upper bound for the concat and stdlib Puppet modules
+  in the metadata.json
+
 * Mon Feb 18 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.7.0-0
 - Update the dependency list in metadata.json
 - Fix the one_shot scenario tests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html) [![Build Status](https://travis-ci.org/simp/pupmod-simp-simp.svg)](https://travis-ci.org/simp/pupmod-simp-dummy) [![SIMP compatibility](https://img.shields.io/badge/SIMP%20compatibility-4.2.*%2F5.1.*-orange.svg)](https://img.shields.io/badge/SIMP%20compatibility-4.2.*%2F5.1.*-orange.svg)
+[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/73/badge)](https://bestpractices.coreinfrastructure.org/projects/73)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/simp/simp.svg)](https://forge.puppetlabs.com/simp/simp)
+[![Puppet Forge Downloads](https://img.shields.io/puppetforge/dt/simp/simp.svg)](https://forge.puppetlabs.com/simp/simp)
+[![Build Status](https://travis-ci.org/simp/pupmod-simp-simp.svg)](https://travis-ci.org/simp/pupmod-simp-simp)
 
 #### Table of Contents
 
@@ -23,7 +27,7 @@ This module is a component of the [System Integrity Management Platform](https:/
 
 If you find any issues, please submit them via [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](https://simp-project.atlassian.net/wiki/display/SD/Contributing+to+SIMP) and visit our [developer wiki](https://simp-project.atlassian.net/wiki/display/SD/SIMP+Development+Home).
+Please read our [Contribution Guide] (https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 This module should be used within the SIMP ecosystem and will be of limited
 independent use
@@ -115,8 +119,7 @@ Linux-compatible distribution such as EL6 and EL7.
 
 ## Development
 
-Please see the [SIMP Contribution Guidelines](https://simp-project.atlassian.net/wiki/display/SD/Contributing+to+SIMP).
-
+Please read our [Contribution Guide] (https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ### Unit tests
 

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 5.0.0"
+      "version_requirement": ">= 2.2.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/puppetdb",
@@ -26,7 +26,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/aide",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Test with (newer) pinned versions of Puppet modules:
  - postgresql 5.12.1
  - puppet_authorization 0.5.0
- Update URLs in the README.md
- Expand the upper bound for the concat and stdlib Puppet modules
  in the metadata.json

SIMP-6213 #comment pupmod-simp-simp