### PR TITLE
(SIMP-5495) Ability to disable KDUMP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Fri Mar 01 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> 4.7.0-0
+- Add kdump manifest to enable/disable kdump
+- By default this will disable kdump.  To enable kdump, set
+  simp::kdump::enabled to true in hiera.
+- Added simp::kdump to the scenario lists.
+
 * Mon Feb 18 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.7.0-0
 - Update the dependency list in metadata.json
 - Fix the one_shot scenario tests

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Fri Mar 01 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> 4.7.0-0
+* Tue Mar 05 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> 4.7.0-0
 - Add kdump manifest to enable/disable kdump
 - By default this will disable kdump.  To enable kdump, set
   simp::kdump::enabled to true in hiera.

--- a/data/os/CentOS.yaml
+++ b/data/os/CentOS.yaml
@@ -41,6 +41,7 @@ simp::scenario_map:
     - simp::admin
     - simp::base_apps
     - simp::base_services
+    - simp::kdump
     - simp::yum::schedule
     - simp::kmod_blacklist
     - simp::mountpoints
@@ -73,6 +74,7 @@ simp::scenario_map:
     - simp::admin
     - simp::base_apps
     - simp::base_services
+    - simp::kdump
     - simp::yum::schedule
     - simp::kmod_blacklist
     - simp::mountpoints
@@ -110,6 +112,7 @@ simp::scenario_map:
     - simp::base_apps
     - simp::base_services
     - simp::yum::schedule
+    - simp::kdump
     - simp::kmod_blacklist
     - simp::mountpoints
     - simp::nsswitch
@@ -141,6 +144,7 @@ simp::server::data:
   - simp::admin
   - simp::base_apps
   - simp::base_services
+  - simp::kdump
   - simp::kmod_blacklist
   - simp::mountpoints
   - simp::nsswitch

--- a/data/os/OracleLinux.yaml
+++ b/data/os/OracleLinux.yaml
@@ -41,6 +41,7 @@ simp::scenario_map:
     - simp::admin
     - simp::base_apps
     - simp::base_services
+    - simp::kdump
     - simp::yum::schedule
     - simp::kmod_blacklist
     - simp::mountpoints
@@ -73,6 +74,7 @@ simp::scenario_map:
     - simp::admin
     - simp::base_apps
     - simp::base_services
+    - simp::kdump
     - simp::yum::schedule
     - simp::kmod_blacklist
     - simp::mountpoints
@@ -110,6 +112,7 @@ simp::scenario_map:
     - simp::base_apps
     - simp::base_services
     - simp::yum::schedule
+    - simp::kdump
     - simp::kmod_blacklist
     - simp::mountpoints
     - simp::nsswitch
@@ -141,6 +144,7 @@ simp::server::data:
   - simp::admin
   - simp::base_apps
   - simp::base_services
+  - simp::kdump
   - simp::kmod_blacklist
   - simp::mountpoints
   - simp::nsswitch

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -41,6 +41,7 @@ simp::scenario_map:
     - simp::admin
     - simp::base_apps
     - simp::base_services
+    - simp::kdump
     - simp::yum::schedule
     - simp::kmod_blacklist
     - simp::mountpoints
@@ -74,6 +75,7 @@ simp::scenario_map:
     - simp::base_apps
     - simp::base_services
     - simp::yum::schedule
+    - simp::kdump
     - simp::kmod_blacklist
     - simp::mountpoints
     - simp::nsswitch
@@ -109,6 +111,7 @@ simp::scenario_map:
     - simp::admin
     - simp::base_apps
     - simp::base_services
+    - simp::kdump
     - simp::yum::schedule
     - simp::kmod_blacklist
     - simp::mountpoints
@@ -141,6 +144,7 @@ simp::server::data:
   - simp::admin
   - simp::base_apps
   - simp::base_services
+  - simp::kdump
   - simp::kmod_blacklist
   - simp::mountpoints
   - simp::nsswitch

--- a/manifests/kdump.pp
+++ b/manifests/kdump.pp
@@ -1,0 +1,52 @@
+# Manage the state of kdump
+#
+# This module enables/disables kdump in the kernel and
+# installs/removes the kexec-tools package as needed,
+#
+# This module does not configure the kdump configuration files.
+#
+# If it is desired for simp to not manage the state of kdump
+# use the knockout prefix to remove it from the class list.
+#
+# @param enabled
+#   Allow ``ctrl-alt-del`` to restart the system
+#
+# @param  crashkernel
+#   The value for the crashdump boot parameter.
+#
+# @param package_ensure
+#   The ensure value for installed packages.
+#
+class simp::kdump (
+  Boolean   $enabled        = false,
+  String    $crashkernel    = auto,
+  String    $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
+) {
+
+  simplib::assert_metadata( $module_name )
+
+  $_package_ensure = $enabled ? {
+    true  => $package_ensure,
+    false => 'absent'
+  }
+
+  package { 'kexec-tools':
+    ensure => $_package_ensure
+  }
+
+  $_kernel_ensure = $enabled ? {
+    true  => 'present',
+    false => 'absent'
+  }
+
+  kernel_parameter { 'crashkernel':
+    ensure => $_kernel_ensure,
+    value  => $crashkernel,
+    notify => Reboot_notify['kdump_reboot']
+  }
+
+  reboot_notify { 'kdump_reboot':
+    reason => 'The status of the crashkernel kernel parameter (used for kdump) has changed.'
+  }
+
+}

--- a/spec/acceptance/suites/default/60_kdump_spec.rb
+++ b/spec/acceptance/suites/default/60_kdump_spec.rb
@@ -58,23 +58,5 @@ describe 'simp::kdump class' do
       end
     end
 
-    context 'with enabled = true and crashkernel = auto and memory fact < 1G' do
-
-      it 'should apply manifest2' do
-        result = apply_manifest_on(host, manifest2, :catch_failures => true)
-        expect(result.output).to include('kdump_reboot => The status of the crashkernel kernel parameter (used for kdump) has changed.')
-      end
-
-      it 'should reboot and set kernel param' do
-        host.reboot
-        result = on(host, %(cat /proc/cmdline)).stdout
-        expect(result).to match(/crashkernel=128M/)
-        expect(check_for_package(host, 'kexec-tools')).to be true
-      end
-
-      it 'should be idempotent' do
-        apply_manifest_on(host, manifest2, :catch_changes => true)
-      end
-    end
   end
 end

--- a/spec/acceptance/suites/default/60_kdump_spec.rb
+++ b/spec/acceptance/suites/default/60_kdump_spec.rb
@@ -74,5 +74,7 @@ describe 'simp::kdump class' do
 
       it 'should be idempotent' do
         apply_manifest_on(host, manifest2, :catch_changes => true)
+      end
+    end
   end
 end

--- a/spec/acceptance/suites/default/60_kdump_spec.rb
+++ b/spec/acceptance/suites/default/60_kdump_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper_acceptance'
+
+test_name 'simp::kdump class'
+
+describe 'simp::kdump class' do
+  let(:manifest) {
+    <<-EOS
+      include 'simp::kdump'
+    EOS
+  }
+
+  let(:manifest2) {
+    <<-EOS
+      class {'simp::kdump':
+        enabled => true,
+      }
+    EOS
+  }
+
+  hosts.each do |host|
+    context 'default parameters' do
+      it 'should apply kdump with no errors' do
+        apply_manifest_on(host, manifest, :catch_failures => true)
+      end
+
+      it 'should be idempotent' do
+        apply_manifest_on(host, manifest, :catch_changes => true)
+      end
+
+      it 'should reboot and  remove kernel param' do
+        host.reboot
+        result = on(host, %(cat /proc/cmdline)).stdout
+        expect(result).to_not match(/crashkernel/)
+        expect(check_for_package(host, 'kexec-tools')).to be false
+      end
+
+    end
+
+    context 'with enabled = true' do
+      it 'should apply manifest2' do
+        apply_manifest_on(host, manifest2, :catch_changes => true)
+      end
+
+      it 'should reboot and set kernel param' do
+        host.reboot
+        result = on(host, %(cat /proc/cmdline)).stdout
+        expect(result).to match(/crashkernel=auto/)
+        expect(check_for_package(host, 'kexec-tools')).to be true
+      end
+    end
+
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -225,6 +225,7 @@ describe 'simp' do
             'simp::admin',
             'simp::base_apps',
             'simp::base_services',
+            'simp::kdump',
             'simp::yum::schedule',
             'simp::kmod_blacklist',
             'simp::mountpoints',

--- a/spec/classes/kdump_spec.rb
+++ b/spec/classes/kdump_spec.rb
@@ -2,9 +2,8 @@ require 'spec_helper'
 
 describe 'simp::kdump' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { facts }
 
         shared_examples_for "a structured module" do
           it { is_expected.to compile.with_all_deps }
@@ -13,6 +12,9 @@ describe 'simp::kdump' do
         end
 
         context 'with default params' do
+          let(:facts) {
+            os_facts.merge( :memorysize_mb => 2500 )
+          }
           let(:params) {{ :package_ensure => 'installed' }}
 
           it_behaves_like "a structured module"
@@ -24,6 +26,9 @@ describe 'simp::kdump' do
         end
 
         context 'with enabled = true' do
+          let(:facts) {
+            os_facts.merge( :memorysize_mb => 2500 )
+          }
           let(:params) {{
             :package_ensure => 'installed',
             :enabled        => true
@@ -39,6 +44,9 @@ describe 'simp::kdump' do
         end
 
         context 'with params set' do
+          let(:facts) {
+            os_facts.merge( :memorysize_mb => 2500 )
+          }
           let(:params) {{
             :package_ensure => 'latest',
             :crashkernel    => '32M',
@@ -51,6 +59,26 @@ describe 'simp::kdump' do
             'ensure' => 'present',
             'notify' => 'Reboot_notify[kdump_reboot]',
             'value'  => '32M'
+          } )}
+        end
+
+        context 'with enabled = true, crashkernel = auto and memory < 1G' do
+          let(:params) {{
+            :package_ensure => 'installed',
+            :enabled        => true
+          }}
+
+          let(:facts) {
+            os_facts.merge( :memorysize_mb => 500 )
+          }
+
+          it_behaves_like "a structured module"
+          it { is_expected.to create_package('kexec-tools').with_ensure('installed') }
+          it { is_expected.to  contain_notify('kdump_memory_warning') }
+          it { is_expected.to create_kernel_parameter('crashkernel').with({
+            'ensure' => 'present',
+            'notify' => 'Reboot_notify[kdump_reboot]',
+            'value'  => 'auto'
           } )}
         end
 

--- a/spec/classes/kdump_spec.rb
+++ b/spec/classes/kdump_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe 'simp::kdump' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+
+        shared_examples_for "a structured module" do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('simp::kdump') }
+          it { is_expected.to contain_reboot_notify('kdump_reboot')}
+        end
+
+        context 'with default params' do
+          let(:params) {{ :package_ensure => 'installed' }}
+
+          it_behaves_like "a structured module"
+          it { is_expected.to create_kernel_parameter('crashkernel').with({
+            'ensure' => 'absent',
+            'notify' => 'Reboot_notify[kdump_reboot]'
+          })}
+          it { is_expected.to create_package('kexec-tools').with({:ensure => 'absent'}) }
+        end
+
+        context 'with enabled = true' do
+          let(:params) {{
+            :package_ensure => 'installed',
+            :enabled        => true
+          }}
+
+          it_behaves_like "a structured module"
+          it { is_expected.to create_package('kexec-tools').with_ensure('installed') }
+          it { is_expected.to create_kernel_parameter('crashkernel').with({
+            'ensure' => 'present',
+            'notify' => 'Reboot_notify[kdump_reboot]',
+            'value'  => 'auto'
+          } )}
+        end
+
+        context 'with params set' do
+          let(:params) {{
+            :package_ensure => 'latest',
+            :crashkernel    => '32M',
+            :enabled        => true
+          }}
+
+          it_behaves_like "a structured module"
+          it { is_expected.to create_package('kexec-tools').with_ensure('latest') }
+          it { is_expected.to create_kernel_parameter('crashkernel').with({
+            'ensure' => 'present',
+            'notify' => 'Reboot_notify[kdump_reboot]',
+            'value'  => '32M'
+          } )}
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
- added ability to turn on and off kdump (crashkernel) kernel
      parameter
 - installs/removes kexec-tools as needed
 - default is to disable kdump as suggested by  RHEL7-STIG-V-72057
      DoS RHEL Security Guide - #107
SIMP-5495 #close