### PR TITLE
(SIMP-5943) Add deferred_resources to defaults

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,6 +11,8 @@ fixtures:
     aide: https://github.com/simp/pupmod-simp-aide
     auditd: https://github.com/simp/pupmod-simp-auditd
     at: https://github.com/simp/pupmod-simp-at
+    # For puppet 6
+    #augeas_core: https://github.com/simp/pupmod-puppetlabs-augeas_core
     augeasproviders_apache: https://github.com/simp/augeasproviders_apache
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
@@ -27,6 +29,7 @@ fixtures:
     clamav: https://github.com/simp/pupmod-simp-clamav
     concat: https://github.com/simp/puppetlabs-concat
     cron: https://github.com/simp/pupmod-simp-cron
+    deferred_resources: https://github.com/simp/pupmod-simp-deferred_resources
     datacat: https://github.com/simp/puppet-datacat
     dhcp: https://github.com/simp/pupmod-simp-dhcp
     fips: https://github.com/simp/pupmod-simp-fips
@@ -63,6 +66,8 @@ fixtures:
     rsync: https://github.com/simp/pupmod-simp-rsync
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog
     selinux: https://github.com/simp/pupmod-simp-selinux
+    # For puppet 6
+    #selinux_core: https://github.com/simp/pupmod-puppetlabs-selinux_core
     simpcat: https://github.com/simp/pupmod-simp-concat
     simplib: https://github.com/simp/pupmod-simp-simplib
     simp_apache: https://github.com/simp/pupmod-simp-apache

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Wed Mar 06 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.7.0-0
+- Added the, intert by default, deferred_resources class to all class lists in
+  case the users want to use the functionality. This is particularly relevant
+  to various compliance profiles.
+
 * Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.7.0-0
 - Update URLs in the README.md
 - Expand the upper bound for the concat and stdlib Puppet modules

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 * Wed Mar 06 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.7.0-0
-- Added the, intert by default, deferred_resources class to all class lists in
+- Added the, inert by default, deferred_resources class to all class lists in
   case the users want to use the functionality. This is particularly relevant
   to various compliance profiles.
 

--- a/data/os/CentOS.yaml
+++ b/data/os/CentOS.yaml
@@ -4,6 +4,7 @@ simp::scenario_map:
   none: []
   poss:
     - pupmod
+    - deferred_resources
     - simp::scenario::poss
 
   remote_access:
@@ -15,6 +16,7 @@ simp::scenario_map:
     - simp::admin
     - simp::sssd::client
     - ssh
+    - deferred_resources
     - simp::scenario::poss
 
   simp_lite:
@@ -28,6 +30,7 @@ simp::scenario_map:
     - chkrootkit
     - at
     - cron
+    - deferred_resources
     - incron
     - useradd
     - resolv
@@ -60,6 +63,7 @@ simp::scenario_map:
     - chkrootkit
     - at
     - cron
+    - deferred_resources
     - incron
     - useradd
     - resolv
@@ -96,6 +100,7 @@ simp::scenario_map:
     - chkrootkit
     - at
     - cron
+    - deferred_resources
     - incron
     - useradd
     - resolv
@@ -128,6 +133,7 @@ simp::server::data:
   - at
   - chkrootkit
   - cron
+  - deferred_resources
   - incron
   - issue
   - ntpd

--- a/data/os/OracleLinux.yaml
+++ b/data/os/OracleLinux.yaml
@@ -4,6 +4,7 @@ simp::scenario_map:
   none: []
   poss:
     - pupmod
+    - deferred_resources
     - simp::scenario::poss
 
   remote_access:
@@ -15,6 +16,7 @@ simp::scenario_map:
     - simp::admin
     - simp::sssd::client
     - ssh
+    - deferred_resources
     - simp::scenario::poss
 
   simp_lite:
@@ -28,6 +30,7 @@ simp::scenario_map:
     - chkrootkit
     - at
     - cron
+    - deferred_resources
     - incron
     - useradd
     - resolv
@@ -60,6 +63,7 @@ simp::scenario_map:
     - chkrootkit
     - at
     - cron
+    - deferred_resources
     - incron
     - useradd
     - resolv
@@ -96,6 +100,7 @@ simp::scenario_map:
     - chkrootkit
     - at
     - cron
+    - deferred_resources
     - incron
     - useradd
     - resolv
@@ -128,6 +133,7 @@ simp::server::data:
   - at
   - chkrootkit
   - cron
+  - deferred_resources
   - incron
   - issue
   - ntpd

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -4,6 +4,7 @@ simp::scenario_map:
   none: []
   poss:
     - pupmod
+    - deferred_resources
     - simp::scenario::poss
 
   remote_access:
@@ -15,6 +16,7 @@ simp::scenario_map:
     - simp::admin
     - simp::sssd::client
     - ssh
+    - deferred_resources
     - simp::scenario::poss
 
   simp_lite:
@@ -28,6 +30,7 @@ simp::scenario_map:
     - chkrootkit
     - at
     - cron
+    - deferred_resources
     - incron
     - useradd
     - resolv
@@ -60,6 +63,7 @@ simp::scenario_map:
     - chkrootkit
     - at
     - cron
+    - deferred_resources
     - incron
     - useradd
     - resolv
@@ -96,6 +100,7 @@ simp::scenario_map:
     - chkrootkit
     - at
     - cron
+    - deferred_resources
     - incron
     - useradd
     - resolv
@@ -128,6 +133,7 @@ simp::server::data:
   - at
   - chkrootkit
   - cron
+  - deferred_resources
   - incron
   - issue
   - ntpd

--- a/metadata.json
+++ b/metadata.json
@@ -61,6 +61,10 @@
       "version_requirement": ">= 0.1.0 < 1.0.0"
     },
     {
+      "name": "simp/deferred_resources",
+      "version_requirement": ">= 0.1.0 < 1.0.0"
+    },
+    {
       "name": "simp/dhcp",
       "version_requirement": ">= 6.0.0 < 7.0.0"
     },

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -203,6 +203,7 @@ describe 'simp' do
         context 'when scenario is set to' do
           poss = [
             'pupmod',
+            'deferred_resources'
           ]
           simp_lite = [
             'simp::scenario::base',
@@ -235,14 +236,14 @@ describe 'simp' do
           simp = [
             'pam::wheel',
             'selinux',
-            'svckill',
+            'svckill'
           ]
           scenarios = {
             'simp' => {
               'contains' => [
                 simp,
                 simp_lite,
-                poss,
+                poss
               ],
               'does_not_contain' => [
               ]
@@ -250,7 +251,7 @@ describe 'simp' do
             'simp_lite' => {
               'contains' => [
                 simp_lite,
-                poss,
+                poss
               ],
               'does_not_contain' => [
                 simp
@@ -258,11 +259,11 @@ describe 'simp' do
             },
             'poss' => {
               'contains' => [
-                poss,
+                poss
               ],
               'does_not_contain' => [
                 simp_lite,
-                simp,
+                simp
               ]
             }
           }


### PR DESCRIPTION
Added the, inert by default, deferred_resources class so that the
functionality is available via Hiera if desired.

This is particularly relevant to various compliance profiles.

SIMP-5943 #close