### PR TITLE
(SIMP-6217) Update to 7.1.0 puppetdb module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -54,7 +54,7 @@ fixtures:
       ref: 5.12.1
     puppetdb:
       repo: https://github.com/simp/puppetlabs-puppetdb
-      ref: 6.0.2
+      ref: 7.1.0
     pupmod: https://github.com/simp/pupmod-simp-pupmod
     puppet_authorization:
       repo: https://github.com/simp/puppetlabs-puppet_authorization

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,13 @@
 * Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.7.0-0
-- Update URLs in the README.md
-- Expand the upper bound for the concat and stdlib Puppet modules
+- Deprecated simp::puppetdb::read_database_ssl.  Use
+  simp::puppetdb::read_database_jdbc_ssl_properties which maps
+  directly to puppetdb::server::read_database_jdbc_ssl_properties
+  (puppetdb version >= 7.0.0).
+- Updated to a minimum puppetdb module version 7.1.0 in the
+  metadata.json and expanded the upper bound accordingly
+- Expanded the upper bound for the concat and stdlib Puppet modules
   in the metadata.json
+- Updated URLs in the README.md
 
 * Mon Feb 18 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.7.0-0
 - Update the dependency list in metadata.json

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -32,6 +32,12 @@
 # @param read_database_password
 # @param read_database_name
 # @param read_database_ssl
+#   This parameter has been deprecated, because its corresponding
+#   ``puppetdb::server`` parameter has been replaced with
+#   ``puppetdb::server::read_database_jdbc_ssl_properties``.
+#   Use $read_database_jdbc_ssl_properties = '?ssl=true' instead.
+#
+# @param read_database_jdbc_ssl_properties
 # @param manage_firewall
 # @param manage_puppetserver
 # @param java_max_memory
@@ -41,36 +47,51 @@
 # @param java_prefer_ipv4
 # @param firewall
 #
-# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-simp/graphs/contributors
 #
 class simp::puppetdb (
-  Simplib::Netlist     $trusted_nets           = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] }),
-  Simplib::IP          $listen_address         = '127.0.0.1',
-  Simplib::Port        $listen_port            = 8138,
-  Boolean              $open_listen_port       = false,
-  Boolean              $ssl_deploy_certs       = true,
-  Boolean              $ssl_set_cert_paths     = true,
-  Simplib::IP          $ssl_listen_address     = '0.0.0.0',
-  Simplib::Port        $ssl_listen_port        = 8139,
-  Boolean              $use_puppet_ssl_certs   = true,
-  Boolean              $disable_ssl            = false,
-  Boolean              $manage_package_repo    = false,
-  String               $database_password      = simplib::passgen('simp_puppetdb'),
-  String               $read_database_username = 'simp_puppetdb',
-  String               $read_database_password = simplib::passgen('simp_read_puppetdb'),
-  String               $read_database_name     = 'simp_puppetdb',
-  Boolean              $read_database_ssl      = true,
-  Boolean              $manage_firewall        = true,
-  Boolean              $manage_puppetserver    = true,
-  String               $java_max_memory        = '40%',
-  Optional[String]     $java_start_memory      = undef,
-  Stdlib::Absolutepath $java_tmpdir            = '/opt/puppetlabs/puppet/cache/pdb_tmp',
-  Boolean              $java_heapdump_on_oom   = false,
-  Boolean              $java_prefer_ipv4       = true,
-  Boolean              $firewall               = simplib::lookup('simp_options::firewall', { 'default_value' => false })
+  Simplib::Netlist     $trusted_nets                      = simplib::lookup('simp_options::trusted_nets', { 'default_value'            => ['127.0.0.1'] }),
+  Simplib::IP          $listen_address                    = '127.0.0.1',
+  Simplib::Port        $listen_port                       = 8138,
+  Boolean              $open_listen_port                  = false,
+  Boolean              $ssl_deploy_certs                  = true,
+  Boolean              $ssl_set_cert_paths                = true,
+  Simplib::IP          $ssl_listen_address                = '0.0.0.0',
+  Simplib::Port        $ssl_listen_port                   = 8139,
+  Boolean              $use_puppet_ssl_certs              = true,
+  Boolean              $disable_ssl                       = false,
+  Boolean              $manage_package_repo               = false,
+  String               $database_password                 = simplib::passgen('simp_puppetdb'),
+  String               $read_database_username            = 'simp_puppetdb',
+  String               $read_database_password            = simplib::passgen('simp_read_puppetdb'),
+  String               $read_database_name                = 'simp_puppetdb',
+  Optional[Boolean]    $read_database_ssl                 = undef,
+  String               $read_database_jdbc_ssl_properties = '?ssl=true',
+  Boolean              $manage_firewall                   = true,
+  Boolean              $manage_puppetserver               = true,
+  String               $java_max_memory                   = '40%',
+  Optional[String]     $java_start_memory                 = undef,
+  Stdlib::Absolutepath $java_tmpdir                       = '/opt/puppetlabs/puppet/cache/pdb_tmp',
+  Boolean              $java_heapdump_on_oom              = false,
+  Boolean              $java_prefer_ipv4                  = true,
+  Boolean              $firewall                          = simplib::lookup('simp_options::firewall', { 'default_value' => false })
 ) {
 
   simplib::assert_metadata( $module_name )
+
+  if $read_database_ssl !~ Undef {
+    if $read_database_ssl {
+      warning('$read_database_ssl is deprecated and will be removed in the next major release. Please use $read_database_jdbc_ssl_properties = "?ssl=true" instead.')
+      $_read_database_jdbc_ssl_properties = '?ssl=true'
+    }
+    else {
+      warning('$read_database_ssl is deprecated and will be removed in the next major release. Please use $read_database_jdbc_ssl_properties = "" instead.')
+      $_read_database_jdbc_ssl_properties = ''
+    }
+  }
+  else {
+    $_read_database_jdbc_ssl_properties = $read_database_jdbc_ssl_properties
+  }
 
   $_simp_manage_firewall = ($manage_firewall and $firewall)
 
@@ -103,22 +124,22 @@ class simp::puppetdb (
   }
 
   $_my_defaults = {
-    'listen_address'         => $listen_address,
-    'listen_port'            => $listen_port,
-    'open_listen_port'       => $open_listen_port,
-    'ssl_deploy_certs'       => $ssl_deploy_certs,
-    'ssl_set_cert_paths'     => $ssl_set_cert_paths,
-    'ssl_listen_address'     => $ssl_listen_address,
-    'ssl_listen_port'        => $ssl_listen_port,
-    'disable_ssl'            => $disable_ssl,
-    'manage_package_repo'    => $manage_package_repo,
-    'database_password'      => $database_password,
-    'read_database_username' => $read_database_username,
-    'read_database_password' => $read_database_password,
-    'read_database_name'     => $read_database_name,
-    'read_database_ssl'      => $read_database_ssl,
-    'manage_firewall'        => ($manage_firewall and !($_simp_manage_firewall)),
-    'java_args'              => $_java_args
+    'listen_address'                    => $listen_address,
+    'listen_port'                       => $listen_port,
+    'open_listen_port'                  => $open_listen_port,
+    'ssl_deploy_certs'                  => $ssl_deploy_certs,
+    'ssl_set_cert_paths'                => $ssl_set_cert_paths,
+    'ssl_listen_address'                => $ssl_listen_address,
+    'ssl_listen_port'                   => $ssl_listen_port,
+    'disable_ssl'                       => $disable_ssl,
+    'manage_package_repo'               => $manage_package_repo,
+    'database_password'                 => $database_password,
+    'read_database_username'            => $read_database_username,
+    'read_database_password'            => $read_database_password,
+    'read_database_name'                => $read_database_name,
+    'read_database_jdbc_ssl_properties' => $_read_database_jdbc_ssl_properties,
+    'manage_firewall'                   => ($manage_firewall and !($_simp_manage_firewall)),
+    'java_args'                         => $_java_args
   }
 
   class { 'puppetdb': * => $_my_defaults }

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/puppetdb",
-      "version_requirement": ">= 5.1.2 < 7.0.0"
+      "version_requirement": ">= 7.1.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/classes/puppetdb_spec.rb
+++ b/spec/classes/puppetdb_spec.rb
@@ -7,12 +7,54 @@ describe 'simp::puppetdb' do
         let(:facts) do
           { :puppet_settings => { 'main' => { 'hostprivkey' => 'blah' } }}.merge(os_facts)
         end
+
         context 'with default parameters' do
           let(:hieradata) { 'simp__puppetdb' }
-          # Overriding the file definition for puppetdb::ssl_cert/key/ca to use
-          # undef for content results in:
-          # Could not understand source file://: bad URI(absolute but no path)
-          pending('is_expected.to compile.with_all_deps')
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('simp::puppetdb') }
+          it { is_expected.to contain_class('puppetdb').with(
+            :listen_address                    => '127.0.0.1',
+            :listen_port                       => 8138,
+            :open_listen_port                  => false,
+            :ssl_deploy_certs                  => true,
+            :ssl_set_cert_paths                => true,
+            :ssl_listen_address                => '0.0.0.0',
+            :ssl_listen_port                   => 8139,
+            :disable_ssl                       => false,
+            :manage_package_repo               => false,
+#            :database_password      => varies from run-to-run
+            :read_database_username            => 'simp_puppetdb',
+#            :read_database_password => varies from run-to-run
+            :read_database_name                => 'simp_puppetdb',
+            :read_database_jdbc_ssl_properties => '?ssl=true',
+            :manage_firewall                   => false,
+#            :java_args              => Xmx & Xms vary because of OS memory differences in facts
+          ) }
+          it { is_expected.to contain_class('puppetdb::master::config') }
+          it {
+            is_expected.to contain_file("#{Puppet[:confdir]}/puppetdb.conf").with( {
+              :owner => 'root',
+              :group => 'root',
+              :mode  => '0644'
+            } )
+          }
+        end
+
+        context 'with read_database_ssl = true' do
+          let(:hieradata) { 'simp__puppetdb' }
+          let(:params) {{ :read_database_ssl => true }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('puppetdb').with_read_database_jdbc_ssl_properties('?ssl=true') }
+        end
+
+        context 'with read_database_ssl = false' do
+          let(:hieradata) { 'simp__puppetdb' }
+          let(:params) {{ :read_database_ssl => false }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('puppetdb').with_read_database_jdbc_ssl_properties('') }
         end
 
         context 'with use_puppet_ssl_certs => false' do


### PR DESCRIPTION
- Deprecated simp::puppetdb::read_database_ssl.  Use
  simp::puppetdb::read_database_jdbc_ssl_properties which maps
  directly to puppetdb::server::read_database_jdbc_ssl_properties
  (puppetdb version >= 7.0.0).
- Updated to a minimum puppetdb module version 7.1.0 in the
  metadata.json and expanded the upper bound accordingly
- Expanded the upper bound for the concat and stdlib Puppet modules
  in the metadata.json
- Updated URLs in the README.md

SIMP-6217 #comment pupmod-simp-simp