### PR TITLE
(SIMP-4249) Use saz-timezone 5.1.1

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -88,9 +88,7 @@ fixtures:
     swap: https://github.com/simp/pupmod-simp-swap
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
     tftpboot: https://github.com/simp/pupmod-simp-tftpboot
-    timezone:
-      repo: https://github.com/simp/pupmod-simp-timezone
-      branch: simp-master
+    timezone: https://github.com/simp/pupmod-simp-timezone
     tlog: https://github.com/simp/pupmod-simp-tlog
     tuned: https://github.com/simp/pupmod-simp-tuned
     upstart: https://github.com/simp/pupmod-simp-upstart

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 11 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.7.0-0
+- Replaced simp-timezone (temporary SIMP fork) with saz-timezone
+  and set the lower bound to 5.1.1 in the metadata.json
+
 * Wed Mar 06 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.7.0-0
 - Added the, inert by default, deferred_resources class to all class lists in
   case the users want to use the functionality. This is particularly relevant

--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,10 @@
       "version_requirement": ">= 2.1.0 < 3.0.0"
     },
     {
+      "name": "herculesteam/augeasproviders_sysctl",
+      "version_requirement": ">= 2.2.0 < 3.0.0"
+    },
+    {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 2.2.0 < 6.0.0"
     },
@@ -29,32 +33,28 @@
       "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
+      "name": "saz/timezone",
+      "version_requirement": ">= 5.1.1 < 6.0.0"
+    },
+    {
       "name": "simp/aide",
       "version_requirement": ">= 6.0.0 < 7.0.0"
-    },
-    {
-      "name": "simp/simp_apache",
-      "version_requirement": ">= 6.0.1 < 7.0.0"
-    },
-    {
-      "name": "simp/auditd",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
-    },
-    {
-      "name": "herculesteam/augeasproviders_sysctl",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
     },
     {
       "name": "simp/at",
       "version_requirement": ">= 0.0.5 < 1.0.0"
     },
     {
-      "name": "simp/clamav",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "name": "simp/auditd",
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     },
     {
       "name": "simp/chkrootkit",
       "version_requirement": ">= 0.1.0 < 1.0.0"
+    },
+    {
+      "name": "simp/clamav",
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
       "name": "simp/cron",
@@ -117,6 +117,10 @@
       "version_requirement": ">= 2.3.0 < 3.0.0"
     },
     {
+      "name": "simp/simp_apache",
+      "version_requirement": ">= 6.0.1 < 7.0.0"
+    },
+    {
       "name": "simp/simp_openldap",
       "version_requirement": ">= 6.0.0 < 7.0.0"
     },
@@ -155,10 +159,6 @@
     {
       "name": "simp/tftpboot",
       "version_requirement": ">= 6.0.0 < 7.0.0"
-    },
-    {
-      "name": "simp/timezone",
-      "version_requirement": ">= 4.0.0 < 6.0.0"
     },
     {
       "name": "simp/tlog",


### PR DESCRIPTION
- Update to use saz-timezone 5.1.1, instead of temporary simp-timezone
- Clean up ordering of dependencies in the metadata.json

 SIMP-4249 #comment pupmod-simp-simp