### PR TITLE
(SIMP-6317) Use simplib::host_is_me, simplib::simp_version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 * Thu Mar 21 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.8.0-0
 - Replaced use of the simplib's Puppet 3 array_include function with
   stdlib's member function
+- Use simplib::host_is_me in lieu of simplib's Puppet 3 host_is_me
+- Use simplib::simp_version in lieu of simplib's Puppet 3 simp_version
 
 * Wed Mar 20 2019 Joseph Sharkey <shark.bruhaha@gmail.com> - 4.8.0-0
 - Added switched out chkrootkit for rkhunter on el7 instances

--- a/functions/yum/repo/sanitize_simp_release_slug.pp
+++ b/functions/yum/repo/sanitize_simp_release_slug.pp
@@ -13,7 +13,7 @@ function simp::yum::repo::sanitize_simp_release_slug(
     $_release_slug = $simp_release_slug
   }
   else {
-    $simp_version = simp_version()
+    $simp_version = simplib::simp_version()
     $_simp_maj_version = (split($simp_version,'\.'))[0]
 
     if $_simp_maj_version in ['6', '5'] {

--- a/manifests/scenario/base.pp
+++ b/manifests/scenario/base.pp
@@ -152,7 +152,7 @@ class simp::scenario::base (
       $_rsync_stunnel_svr = $rsync_stunnel
     }
 
-    unless host_is_me($_rsync_stunnel_svr) {
+    unless simplib::host_is_me($_rsync_stunnel_svr) {
       stunnel::connection { 'rsync':
         connect => ["${_rsync_stunnel_svr}:8730"],
         accept  => '127.0.0.1:873'

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -37,6 +37,6 @@ class simp::version () {
     owner   => $simp_root_dir_user,
     group   => $simp_root_dir_group,
     mode    => $simp_root_dir_mode,
-    content => simp_version()
+    content => simplib::simp_version()
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -134,7 +134,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.12.0 < 4.0.0"
+      "version_requirement": ">= 3.15.0 < 4.0.0"
     },
     {
       "name": "simp/ssh",

--- a/spec/classes/yum/repo/internet_simp_dependencies_spec.rb
+++ b/spec/classes/yum/repo/internet_simp_dependencies_spec.rb
@@ -1,5 +1,8 @@
 require 'spec_helper'
 
+metadata_file = File.expand_path(File.join(__dir__, '..', '..', '..', '..', 'metadata.json'))
+metadata_json = File.read(metadata_file, {:encoding => "utf-8"} )
+
 describe 'simp::yum::repo::internet_simp_dependencies' do
 
   on_supported_os.each do |os, os_facts|
@@ -18,27 +21,28 @@ describe 'simp::yum::repo::internet_simp_dependencies' do
 
       context 'when `simp_release_slug` is undef' do
         ['4.0.0', ''].each do |_version|
-          context "when `simp_version() returns an unsupported value (#{_version})" do
+          context "when `simplib::simp_version() returns an unsupported value (#{_version})" do
             let(:params) {{}}
+            it do
+              File.stubs(:read).with('/etc/simp/simp.version').returns(_version)
+              File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns(metadata_json)
+              File.stubs(:read).with(regexp_matches(/metadata.json/)).returns(metadata_json)
 
-            before(:each) do
-              Puppet::Parser::Functions.newfunction(:simp_version, :type => :rvalue) { |args|
-                _version
-              }
+              is_expected.to raise_error(/SIMP/)
             end
-            it { is_expected.to raise_error(/SIMP/)}
           end
         end
 
         ['6.0.0', '6.1.0-foo'].each do |_version|
-          describe "when `simp_version() is valid (#{_version})" do
+          describe "when `simplib::simp_version() is valid (#{_version})" do
             let(:params) {{}}
-            before(:each) do
-              Puppet::Parser::Functions.newfunction(:simp_version, :type => :rvalue) { |args|
-                _version
-              }
+            it do
+              File.stubs(:read).with('/etc/simp/simp.version').returns(_version)
+              File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns(metadata_json)
+              File.stubs(:read).with(regexp_matches(/metadata.json/)).returns(metadata_json)
+
+              is_expected.to compile.with_all_deps
             end
-            it { is_expected.to compile.with_all_deps }
           end
         end
 

--- a/spec/classes/yum/repo/internet_simp_server_spec.rb
+++ b/spec/classes/yum/repo/internet_simp_server_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
+metadata_file = File.expand_path(File.join(__dir__, '..', '..', '..', '..', 'metadata.json'))
+metadata_json = File.read(metadata_file, {:encoding => "utf-8"} )
+
 describe 'simp::yum::repo::internet_simp_server' do
+
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
@@ -18,30 +22,30 @@ describe 'simp::yum::repo::internet_simp_server' do
 
       context 'when `simp_release_slug` is undef' do
         ['4.0.0', ''].each do |_version|
-          context "when `simp_version() returns an unsupported value (#{_version})" do
+          context "when `simplib::simp_version() returns an unsupported value (#{_version})" do
             let(:params) {{}}
+            it do
+              File.stubs(:read).with('/etc/simp/simp.version').returns(_version)
+              File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns(metadata_json)
+              File.stubs(:read).with(regexp_matches(/metadata.json/)).returns(metadata_json)
 
-            before(:each) do
-              Puppet::Parser::Functions.newfunction(:simp_version, :type => :rvalue) { |args|
-                _version
-              }
+              is_expected.to raise_error(/SIMP/)
             end
-            it { is_expected.to raise_error(/SIMP/)}
           end
         end
 
         ['6.0.0', '6.1.0-foo'].each do |_version|
-          describe "when `simp_version() is valid (#{_version})" do
+          describe "when `simplib::simp_version() is valid (#{_version})" do
             let(:params) {{}}
-            before(:each) do
-              Puppet::Parser::Functions.newfunction(:simp_version, :type => :rvalue) { |args|
-                _version
-              }
+            it do
+              File.stubs(:read).with('/etc/simp/simp.version').returns(_version)
+              File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns(metadata_json)
+              File.stubs(:read).with(regexp_matches(/metadata.json/)).returns(metadata_json)
+
+              is_expected.to compile.with_all_deps
             end
-            it { is_expected.to compile.with_all_deps }
           end
         end
-
       end
     end
   end


### PR DESCRIPTION
- Use simplib::host_is_me in lieu of simplib's Puppet 3 host_is_me
- Use simplib::simp_version in lieu of simplib's Puppet 3 simp_version

SIMP-6317 #close
SIMP-6316 #comment pupmod-simp-simp