### PR TITLE
(SIMP-6339) Fix Sensitive value on root password

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -28,13 +28,20 @@ fixtures:
     autofs: https://github.com/simp/pupmod-simp-autofs
     chkrootkit: https://github.com/simp/pupmod-simp-chkrootkit
     clamav: https://github.com/simp/pupmod-simp-clamav
+    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
     concat: https://github.com/simp/puppetlabs-concat
     cron: https://github.com/simp/pupmod-simp-cron
+    cron_core:
+      repo: https://github.com/simp/pupmod-puppetlabs-cron_core.git
+      puppet_version: ">= 6.0.0"
     deferred_resources: https://github.com/simp/pupmod-simp-deferred_resources
     datacat: https://github.com/simp/puppet-datacat
     dhcp: https://github.com/simp/pupmod-simp-dhcp
     fips: https://github.com/simp/pupmod-simp-fips
     haveged: https://github.com/simp/pupmod-simp-haveged
+    host_core:
+      repo: https://github.com/simp/pupmod-puppetlabs-host_core.git
+      puppet_version: ">= 6.0.0"
     incron: https://github.com/simp/pupmod-simp-incron
     inifile: https://github.com/simp/puppetlabs-inifile
     iptables: https://github.com/simp/pupmod-simp-iptables
@@ -44,6 +51,9 @@ fixtures:
     krb5: https://github.com/simp/pupmod-simp-krb5
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     motd: https://github.com/simp/puppetlabs-motd
+    mount_core:
+      repo: https://github.com/simp/pupmod-puppetlabs-mount_core.git
+      puppet_version: ">= 6.0.0"
     named: https://github.com/simp/pupmod-simp-named
     nfs: https://github.com/simp/pupmod-simp-nfs
     nsswitch: https://github.com/simp/puppet-nsswitch
@@ -79,6 +89,9 @@ fixtures:
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     simp_rsyslog: https://github.com/simp/pupmod-simp-simp_rsyslog
     ssh: https://github.com/simp/pupmod-simp-ssh
+    sshkeys_core:
+      repo: https://github.com/simp/pupmod-puppetlabs-sshkeys_core.git
+      puppet_version: ">= 6.0.0"
     sssd: https://github.com/simp/pupmod-simp-sssd
     stdlib: https://github.com/simp/puppetlabs-stdlib
     stunnel: https://github.com/simp/pupmod-simp-stunnel
@@ -100,6 +113,9 @@ fixtures:
       repo: https://github.com/simp/pupmod-voxpupuli-selinux
       branch: simp-master
     xinetd: https://github.com/simp/pupmod-simp-xinetd
+    yumrepo_core:
+      repo: https://github.com/simp/pupmod-puppetlabs-yumrepo_core.git
+      puppet_version: ">= 6.0.0"
     # Kluge for rsync data
     '../acceptance/rsync_shares/simp': https://github.com/simp/simp-rsync-skeleton
   symlinks:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,10 +69,10 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_5_5_7: &pup_5_5_7
+.pup_5_5_10: &pup_5_5_10
   image: 'ruby:2.4'
   variables:
-    PUPPET_VERSION: '5.5.7'
+    PUPPET_VERSION: '5.5.10'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
@@ -150,8 +150,8 @@ pup5-unit:
   <<: *pup_5
   <<: *unit_tests
 
-pup5.5.7-unit:
-  <<: *pup_5_5_7
+pup5.5.10-unit:
+  <<: *pup_5_5_10
   <<: *unit_tests
 
 pup6-unit:
@@ -160,80 +160,80 @@ pup6-unit:
 
 # Acceptance tests
 # ==============================================================================
-pup5.5.7-base-apps:
-  <<: *pup_5_5_7
+pup5.5.10-base-apps:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'bundle exec rake spec_clean'
     - 'bundle exec rake beaker:suites[base_apps]'
 
-pup5.5.7:
-  <<: *pup_5_5_7
+pup5.5.10:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'bundle exec rake spec_clean'
     - 'bundle exec rake beaker:suites[default]'
 
-pup5.5.7-fips:
-  <<: *pup_5_5_7
+pup5.5.10-fips:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'bundle exec rake spec_clean'
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
 
-pup5.5.7-no_simp_server:
-  <<: *pup_5_5_7
+pup5.5.10-no_simp_server:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:
     - 'bundle exec rake spec_clean'
     - 'bundle exec rake beaker:suites[no_simp_server]'
 
-pup5.5.7-netconsole:
-  <<: *pup_5_5_7
+pup5.5.10-netconsole:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'bundle exec rake spec_clean'
     - 'bundle exec rake beaker:suites[netconsole]'
 
-pup5.5.7-one_shot_scenario:
-  <<: *pup_5_5_7
+pup5.5.10-one_shot_scenario:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'bundle exec rake spec_clean'
     - 'bundle exec rake beaker:suites[scenario_one_shot]'
 
-pup5.5.7-poss_scenario:
-  <<: *pup_5_5_7
+pup5.5.10-poss_scenario:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'bundle exec rake spec_clean'
     - 'bundle exec rake beaker:suites[scenario_poss]'
 
-pup5.5.7-remote_access_scenario:
-  <<: *pup_5_5_7
+pup5.5.10-remote_access_scenario:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'bundle exec rake spec_clean'
     - 'bundle exec rake beaker:suites[scenario_remote_access]'
 
-pup5.5.7-oel:
-  <<: *pup_5_5_7
+pup5.5.10-oel:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'bundle exec rake spec_clean'
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup5.5.7-oel-fips:
-  <<: *pup_5_5_7
+pup5.5.10-oel-fips:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:
     - 'bundle exec rake spec_clean'
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
 
-# pup5.5.7-compliance-fips:
-#   <<: *pup_5_5_7
+# pup5.5.10-compliance-fips:
+#   <<: *pup_5_5_10
 #   <<: *compliance_base
 #   script:
 #     - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,14 +5,11 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.1      4.10.6   2.1.9  TBD
-# SIMP 6.2      4.10.12  2.1.9  TBD
 # SIMP 6.3      5.5.7    2.4.4  TBD***
 # PE 2018.1     5.5.8    2.4.4  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
 ---
 stages:
   - 'sanity'
@@ -65,18 +62,6 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_4: &pup_4
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.0'
-    MATRIX_RUBY_VERSION: '2.1'
-
-.pup_4_10: &pup_4_10
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.10.4'
-    MATRIX_RUBY_VERSION: '2.1'
-
 .pup_5: &pup_5
   image: 'ruby:2.4'
   variables:
@@ -92,7 +77,6 @@ variables:
     MATRIX_RUBY_VERSION: '2.4'
 
 .pup_6: &pup_6
-  allow_failure: true
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '~> 6.0'
@@ -151,10 +135,6 @@ sanity_checks:
 # Linting
 #-----------------------------------------------------------------------
 
-pup4-lint:
-  <<: *pup_4
-  <<: *lint_tests
-
 pup5-lint:
   <<: *pup_5
   <<: *lint_tests
@@ -172,10 +152,6 @@ pup5-unit:
 
 pup5.5.7-unit:
   <<: *pup_5_5_7
-  <<: *unit_tests
-
-pup4.10-unit:
-  <<: *pup_4_10
   <<: *unit_tests
 
 pup6-unit:
@@ -241,43 +217,6 @@ pup5.5.7-remote_access_scenario:
     - 'bundle exec rake spec_clean'
     - 'bundle exec rake beaker:suites[scenario_remote_access]'
 
-pup4.10:
-  <<: *pup_4_10
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites'
-
-pup4.10-fips:
-  <<: *pup_4_10
-  <<: *acceptance_base
-  <<: *only_with_SIMP_FULL_MATRIX
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
-
-pup4.10-one_shot_scenario:
-  <<: *pup_4_10
-  <<: *acceptance_base
-  <<: *only_with_SIMP_FULL_MATRIX
-  script:
-    - 'bundle exec rake spec_clean'
-    - 'bundle exec rake beaker:suites[scenario_one_shot]'
-
-pup4.10-poss_scenario:
-  <<: *pup_4_10
-  <<: *acceptance_base
-  <<: *only_with_SIMP_FULL_MATRIX
-  script:
-    - 'bundle exec rake spec_clean'
-    - 'bundle exec rake beaker:suites[scenario_poss]'
-
-pup4.10-remote_access_scenario:
-  <<: *pup_4_10
-  <<: *acceptance_base
-  <<: *only_with_SIMP_FULL_MATRIX
-  script:
-    - 'bundle exec rake spec_clean'
-    - 'bundle exec rake beaker:suites[scenario_remote_access]'
-
 pup5.5.7-oel:
   <<: *pup_5_5_7
   <<: *acceptance_base
@@ -298,3 +237,10 @@ pup5.5.7-oel-fips:
 #   <<: *compliance_base
 #   script:
 #     - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'
+
+pup6:
+  <<: *pup_6
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake spec_clean'
+    - 'bundle exec rake beaker:suites[default]'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,11 +70,11 @@ variables:
     MATRIX_RUBY_VERSION: '2.4'
 
 .pup_5_5_10: &pup_5_5_10
-  image: 'ruby:2.4'
+  image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '5.5.10'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
-    MATRIX_RUBY_VERSION: '2.4'
+    MATRIX_RUBY_VERSION: '2.5'
 
 .pup_6: &pup_6
   image: 'ruby:2.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,12 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.2      4.10     2.1.9  TBD
-# PE 2016.4     4.10     2.1.9  2018-12-31 (LTS)
 # PE 2017.3     5.3      2.4.4  2018-12-31
 # SIMP 6.3      5.5      2.4.4  TBD***
 # PE 2018.1     5.5      2.4.4  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
 
 ---
 language: ruby
@@ -44,9 +41,6 @@ global:
   - STRICT_VARIABLES=yes
 
 jobs:
-  allow_failures:
-    - name: 'Latest Puppet 6.x (allowed to fail)'
-
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
@@ -61,13 +55,6 @@ jobs:
         - bundle exec rake pkg:create_tag_changelog
         - bundle exec rake lint
         - bundle exec puppet module build
-
-    - stage: spec
-      name: 'Puppet 4.10 (SIMP 6.2, PE 2016.4)'
-      rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.10.0"
-      script:
-        - bundle exec rake spec_parallel
 
     - stage: spec
       name: 'Puppet 5.3 (PE 2017.3)'
@@ -91,7 +78,7 @@ jobs:
         - bundle exec rake spec_parallel
 
     - stage: spec
-      name: 'Latest Puppet 6.x (allowed to fail)'
+      name: 'Latest Puppet 6.x'
       rvm: 2.5.1
       env: PUPPET_VERSION="~> 6.0"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# PE 2017.3     5.3      2.4.4  2018-12-31
-# SIMP 6.3      5.5      2.4.4  TBD***
-# PE 2018.1     5.5      2.4.4  2020-05 (LTS)***
+# PE 2017.3     5.3      2.4.5  2018-12-31
+# SIMP 6.3      5.5      2.4.5  TBD***
+# PE 2018.1     5.5      2.4.5  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
@@ -44,7 +44,7 @@ jobs:
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
@@ -58,13 +58,13 @@ jobs:
 
     - stage: spec
       name: 'Puppet 5.3 (PE 2017.3)'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.3.0"
       script:
         - bundle exec rake spec_parallel
 
     - stage: spec
-      rvm: 2.4.4
+      rvm: 2.4.5
       name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1)'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
@@ -72,7 +72,7 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 5.x'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec_parallel
@@ -85,7 +85,7 @@ jobs:
         - bundle exec rake spec_parallel
 
     - stage: deploy
-      rvm: 2.4.4
+      rvm: 2.4.5
       script:
         - true
       before_deploy:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Mon Apr 01 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.8.0-0
+- Fixed a bug where the root password field was attempting to set an 'undef'
+  value as Sensitive.
+- Bumped the supported Puppet version to include Puppet 6
+- Removed Puppet 4 from the supported list
+
 * Mon Mar 25 2019 Joseph Sharkey <shark.bruhaha@gmail.com> - 4.8.0-0
 - Standardized cron datatypes to use the Simplib::Cron::### types.  This
   allows more flexibility in cron scheduling.

--- a/functions/yum/repo/sanitize_simp_release_slug.pp
+++ b/functions/yum/repo/sanitize_simp_release_slug.pp
@@ -9,6 +9,8 @@ function simp::yum::repo::sanitize_simp_release_slug(
   Variant[String,Undef] $simp_release_slug = undef
 ) {
 
+  inspect(simplib::simp_version())
+
   if defined('$simp_release_slug') and !empty($simp_release_slug) {
     $_release_slug = $simp_release_slug
   }

--- a/functions/yum/repo/sanitize_simp_release_slug.pp
+++ b/functions/yum/repo/sanitize_simp_release_slug.pp
@@ -9,8 +9,6 @@ function simp::yum::repo::sanitize_simp_release_slug(
   Variant[String,Undef] $simp_release_slug = undef
 ) {
 
-  inspect(simplib::simp_version())
-
   if defined('$simp_release_slug') and !empty($simp_release_slug) {
     $_release_slug = $simp_release_slug
   }

--- a/manifests/root_user.pp
+++ b/manifests/root_user.pp
@@ -64,10 +64,10 @@ class simp::root_user (
     }
 
     if $password {
-      $_password = $password
+      $_password = Sensitive($password)
     }
     elsif $hashed_password {
-      $_password = $hashed_password
+      $_password = Sensitive($hashed_password)
     }
     else {
       $_password = undef
@@ -82,7 +82,7 @@ class simp::root_user (
       shell      => $shell,
       membership => 'minimum',
       forcelocal => true,
-      password   => Sensitive($_password)
+      password   => $_password
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -188,7 +188,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.4 < 6.0.0"
+      "version_requirement": ">= 5.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/yum/repo/internet_simp_dependencies_spec.rb
+++ b/spec/classes/yum/repo/internet_simp_dependencies_spec.rb
@@ -6,6 +6,10 @@ metadata_json = File.read(metadata_file, {:encoding => "utf-8"} )
 describe 'simp::yum::repo::internet_simp_dependencies' do
 
   on_supported_os.each do |os, os_facts|
+    before(:each) do
+      Puppet::Parser::Functions.newfunction(:load_module_metadata, :type => :rvalue) { |args| JSON.load(metadata_json) }
+    end
+
     context "on #{os}" do
 
       let(:facts) do
@@ -23,11 +27,12 @@ describe 'simp::yum::repo::internet_simp_dependencies' do
         ['4.0.0', ''].each do |_version|
           context "when `simplib::simp_version() returns an unsupported value (#{_version})" do
             let(:params) {{}}
-            it do
-              File.stubs(:read).with('/etc/simp/simp.version').returns(_version)
-              File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns(metadata_json)
-              File.stubs(:read).with(regexp_matches(/metadata.json/)).returns(metadata_json)
 
+            let(:pre_condition) do
+              "function simplib::simp_version() { '#{_version}' }"
+            end
+
+            it do
               is_expected.to raise_error(/SIMP/)
             end
           end
@@ -36,11 +41,12 @@ describe 'simp::yum::repo::internet_simp_dependencies' do
         ['6.0.0', '6.1.0-foo'].each do |_version|
           describe "when `simplib::simp_version() is valid (#{_version})" do
             let(:params) {{}}
-            it do
-              File.stubs(:read).with('/etc/simp/simp.version').returns(_version)
-              File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns(metadata_json)
-              File.stubs(:read).with(regexp_matches(/metadata.json/)).returns(metadata_json)
 
+            let(:pre_condition) do
+              "function simplib::simp_version() { '#{_version}' }"
+            end
+
+            it do
               is_expected.to compile.with_all_deps
             end
           end

--- a/spec/classes/yum/repo/internet_simp_server_spec.rb
+++ b/spec/classes/yum/repo/internet_simp_server_spec.rb
@@ -4,11 +4,12 @@ metadata_file = File.expand_path(File.join(__dir__, '..', '..', '..', '..', 'met
 metadata_json = File.read(metadata_file, {:encoding => "utf-8"} )
 
 describe 'simp::yum::repo::internet_simp_server' do
-
-
   on_supported_os.each do |os, os_facts|
-    context "on #{os}" do
+    before(:each) do
+      Puppet::Parser::Functions.newfunction(:load_module_metadata, :type => :rvalue) { |args| JSON.load(metadata_json) }
+    end
 
+    context "on #{os}" do
       let(:facts) do
         os_facts
       end
@@ -24,11 +25,11 @@ describe 'simp::yum::repo::internet_simp_server' do
         ['4.0.0', ''].each do |_version|
           context "when `simplib::simp_version() returns an unsupported value (#{_version})" do
             let(:params) {{}}
-            it do
-              File.stubs(:read).with('/etc/simp/simp.version').returns(_version)
-              File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns(metadata_json)
-              File.stubs(:read).with(regexp_matches(/metadata.json/)).returns(metadata_json)
 
+            let(:pre_condition) do
+              "function simplib::simp_version() { '#{_version}' }"
+            end
+            it do
               is_expected.to raise_error(/SIMP/)
             end
           end
@@ -37,11 +38,11 @@ describe 'simp::yum::repo::internet_simp_server' do
         ['6.0.0', '6.1.0-foo'].each do |_version|
           describe "when `simplib::simp_version() is valid (#{_version})" do
             let(:params) {{}}
-            it do
-              File.stubs(:read).with('/etc/simp/simp.version').returns(_version)
-              File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns(metadata_json)
-              File.stubs(:read).with(regexp_matches(/metadata.json/)).returns(metadata_json)
 
+            let(:pre_condition) do
+              "function simplib::simp_version() { '#{_version}' }"
+            end
+            it do
               is_expected.to compile.with_all_deps
             end
           end


### PR DESCRIPTION
- Fixed a bug where the root password field was attempting to set an 'undef'
  value as Sensitive.
- Bumped the supported Puppet version to include Puppet 6
- Removed Puppet 4 from the supported list

SIMP-6339 #close