### PR TITLE
(SIMP-4663) Use systemd for tmp.mounts if possible

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,8 +5,6 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.1      4.10.6   2.1.9  TBD
-# SIMP 6.2      4.10.12  2.1.9  TBD
 # SIMP 6.3      5.5.10   2.4.5  TBD***
 # PE 2018.1     5.5.8    2.4.5  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
@@ -246,4 +244,4 @@ pup6-fips:
   <<: *acceptance_base
   script:
     - 'bundle exec rake spec_clean'
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
 # SIMP 6.3      5.5.10   2.4.5  TBD***
-# PE 2018.1     5.5.8    2.4.5  2020-05 (LTS)***
+# PE 2018.1     5.5.10   2.4.5  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
@@ -70,11 +70,11 @@ variables:
     MATRIX_RUBY_VERSION: '2.4'
 
 .pup_5_5_10: &pup_5_5_10
-  image: 'ruby:2.5'
+  image: 'ruby:2.4.5'
   variables:
     PUPPET_VERSION: '5.5.10'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
-    MATRIX_RUBY_VERSION: '2.5'
+    MATRIX_RUBY_VERSION: '2.4.5'
 
 .pup_6: &pup_6
   image: 'ruby:2.5'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
-* Mon Apr 15 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.8.0-0
+* Thu Apr 18 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.8.0-0
+- Refactor the simp::mountpoints::tmp to use systemd's tmp.mount target if
+  the system supports systemd.
 - Added net.ipv6.conf.all.accept_ra to simp::sysctl management
 - Fixed a bug where the root password field was attempting to set an 'undef'
   value as Sensitive.
@@ -8,6 +10,7 @@
 * Tue Apr 09 2019 Joseph Sharkey <shark.bruhaha@gmail.com> - 4.8.0-0
 - Remove Elasticsearch and Grafana GPG Keys
 - Added missing simp::sysctl value simp::sysctl::net__ipv4__conf__default__log_martians
+- Remove Elasticsearch and Grafana GPG Keys
 - Standardized cron datatypes to use the Simplib::Cron::### types.  This
   allows more flexibility in cron scheduling.
 

--- a/functions/yum/repo/sanitize_simp_release_slug.pp
+++ b/functions/yum/repo/sanitize_simp_release_slug.pp
@@ -9,6 +9,8 @@ function simp::yum::repo::sanitize_simp_release_slug(
   Variant[String,Undef] $simp_release_slug = undef
 ) {
 
+  inspect(simplib::simp_version())
+
   if defined('$simp_release_slug') and !empty($simp_release_slug) {
     $_release_slug = $simp_release_slug
   }

--- a/functions/yum/repo/sanitize_simp_release_slug.pp
+++ b/functions/yum/repo/sanitize_simp_release_slug.pp
@@ -8,23 +8,22 @@
 function simp::yum::repo::sanitize_simp_release_slug(
   Variant[String,Undef] $simp_release_slug = undef
 ) {
+    inspect(simplib::simp_version())
 
-  inspect(simplib::simp_version())
-
-  if defined('$simp_release_slug') and !empty($simp_release_slug) {
-    $_release_slug = $simp_release_slug
-  }
-  else {
-    $simp_version = simplib::simp_version()
-    $_simp_maj_version = (split($simp_version,'\.'))[0]
-
-    if $_simp_maj_version in ['6', '5'] {
-      $_release_slug = "${_simp_maj_version}_X"
+    if defined('$simp_release_slug') and !empty($simp_release_slug) {
+      $_release_slug = $simp_release_slug
     }
     else {
-      fail("SIMP version ${simp_version} does not map to a known yum repository slug")
+      $simp_version = simplib::simp_version()
+      $_simp_maj_version = (split($simp_version,'\.'))[0]
+
+      if $_simp_maj_version in ['6', '5'] {
+        $_release_slug = "${_simp_maj_version}_X"
+      }
+      else {
+        fail("SIMP version ${simp_version} does not map to a known yum repository slug")
+      }
     }
+    err "XXX release_slug [${_release_slug}]"
+    $_release_slug
   }
-  err "XXX release_slug [${_release_slug}]"
-  $_release_slug
-}

--- a/manifests/mountpoints/tmp.pp
+++ b/manifests/mountpoints/tmp.pp
@@ -230,4 +230,14 @@ class simp::mountpoints::tmp (
       }
     }
   }
+
+  # This is a kludge at the end based on the fact that the 'if secure' code up
+  # above would be far too complex to understand easily if this were woven in.
+  #
+  # Specifically, this meets the requirement to start the tmp.mount service but
+  # understands that the ``systemd::unit_file`` resource above will also
+  # attempt to manage the tmp.mount service.
+  if $tmp_service and ('systemd' in $facts['init_systems']) {
+    ensure_resources('service', { 'tmp.mounts' => { 'ensure' => 'running', 'enable' => true }})
+  }
 }

--- a/manifests/mountpoints/tmp.pp
+++ b/manifests/mountpoints/tmp.pp
@@ -28,11 +28,15 @@
 # @param dev_shm_opts
 #   Works the same way as ``$tmp_opts``
 #
+# @param tmp_service
+#   If on systemd system, enable and activate the tmp.mount service
+#
 class simp::mountpoints::tmp (
   Boolean       $secure       = true,
   Array[String] $tmp_opts     = ['noexec','nodev','nosuid'],
   Array[String] $var_tmp_opts = ['noexec','nodev','nosuid'],
-  Array[String] $dev_shm_opts = ['noexec','nodev','nosuid']
+  Array[String] $dev_shm_opts = ['noexec','nodev','nosuid'],
+  Boolean       $tmp_service  = true
 ) {
 
   simplib::assert_metadata( $module_name )
@@ -63,21 +67,64 @@ class simp::mountpoints::tmp (
 
   # If we decide to secure the tmp mounts....
   if $secure {
-    # If /tmp is mounted
-    if $facts['tmp_mount_tmp'] and !empty($facts['tmp_mount_tmp']) {
-      $_tmp_mount_tmp_opts = split($facts['tmp_mount_tmp'],',')
+    if 'systemd' in $facts['init_systems'] {
+      # Systemd adds appropriate extra sets of options and is authoritative so
+      # everything should be set via $tmp_opts instead of reverse mapped like
+      # we do if it's a regular partition.
+      $_tmp_opts = simplib::join_mount_opts($tmp_opts, ['mode=1777'])
 
-      # If /tmp is not a bind mount and doesn't contain the required options
-      # then mount it properly.
-      if !member($_tmp_mount_tmp_opts,'bind') {
-        mount { '/tmp':
-          ensure   => 'mounted',
-          target   => '/etc/fstab',
-          fstype   => $facts['tmp_mount_fstype_tmp'],
-          options  => simplib::join_mount_opts($_tmp_mount_tmp_opts,$tmp_opts),
-          device   => $facts['tmp_mount_path_tmp'],
-          pass     => '1',
-          remounts => true
+      $_unit_file_content = @("END")
+        [Mount]
+        What=tmpfs
+        Where=/tmp
+        Type=tmpfs
+        Options=${_tmp_opts}
+        | END
+
+      systemd::unit_file { 'tmp.mount':
+        enable  => true,
+        active  => true,
+        content => $_unit_file_content
+      }
+
+      File['/tmp'] -> Systemd::Unit_file['tmp.mount']
+    }
+    else {
+      # If /tmp is mounted
+      if $facts['tmp_mount_tmp'] and !empty($facts['tmp_mount_tmp']) {
+        $_tmp_mount_tmp_opts = split($facts['tmp_mount_tmp'],',')
+
+        # If /tmp is not a bind mount and doesn't contain the required options
+        # then mount it properly.
+        if !member($_tmp_mount_tmp_opts,'bind') {
+          mount { '/tmp':
+            ensure   => 'mounted',
+            target   => '/etc/fstab',
+            fstype   => $facts['tmp_mount_fstype_tmp'],
+            options  => simplib::join_mount_opts($_tmp_mount_tmp_opts,$tmp_opts),
+            device   => $facts['tmp_mount_path_tmp'],
+            pass     => '1',
+            remounts => true
+          }
+        }
+        else {
+          mount { '/tmp':
+            ensure   => 'mounted',
+            target   => '/etc/fstab',
+            fstype   => 'none',
+            options  => simplib::join_mount_opts(['bind'],$tmp_opts),
+            device   => $facts['tmp_mount_path_tmp'],
+            remounts => true
+          }
+
+          if !empty(difference($tmp_opts,$_tmp_mount_tmp_opts)) {
+            $_remount_tmp_opts = join($tmp_opts,',')
+
+            exec { 'remount /tmp':
+              command => "/bin/mount -o remount,${_remount_tmp_opts} /tmp",
+              require => Mount['/tmp']
+            }
+          }
         }
       }
       else {
@@ -86,42 +133,20 @@ class simp::mountpoints::tmp (
           target   => '/etc/fstab',
           fstype   => 'none',
           options  => simplib::join_mount_opts(['bind'],$tmp_opts),
-          device   => $facts['tmp_mount_path_tmp'],
-          remounts => true
+          device   => '/tmp',
+          remounts => true,
+          notify   => Exec['remount /tmp']
         }
 
-        if !empty(difference($tmp_opts,$_tmp_mount_tmp_opts)) {
-          $_remount_tmp_opts = join($tmp_opts,',')
-
-          exec { 'remount /tmp':
-            command => "/bin/mount -o remount,${_remount_tmp_opts} /tmp",
-            require => Mount['/tmp']
-          }
+        $_remount_tmp_opts = join($tmp_opts,',')
+        exec { 'remount /tmp':
+          command     => "/bin/mount -o remount,${_remount_tmp_opts} /tmp",
+          refreshonly => true
         }
       }
-    }
-    # Otherwise, bind mount it to itself with the correct options.
-    # We thought about mounting it to tmpfs but that was just too dangerous
-    # without knowing the target environment.
-    else {
-      mount { '/tmp':
-        ensure   => 'mounted',
-        target   => '/etc/fstab',
-        fstype   => 'none',
-        options  => simplib::join_mount_opts(['bind'],$tmp_opts),
-        device   => '/tmp',
-        remounts => true,
-        notify   => Exec['remount /tmp']
-      }
 
-      $_remount_tmp_opts = join($tmp_opts,',')
-      exec { 'remount /tmp':
-        command     => "/bin/mount -o remount,${_remount_tmp_opts} /tmp",
-        refreshonly => true
-      }
+      File['/tmp'] -> Mount['/tmp']
     }
-
-    File['/tmp'] -> Mount['/tmp']
 
     # If /var/tmp is mounted
     if $facts['tmp_mount_var_tmp'] and !empty($facts['tmp_mount_var_tmp']) {
@@ -196,5 +221,4 @@ class simp::mountpoints::tmp (
       }
     }
   }
-
 }

--- a/manifests/mountpoints/tmp.pp
+++ b/manifests/mountpoints/tmp.pp
@@ -238,6 +238,8 @@ class simp::mountpoints::tmp (
   # understands that the ``systemd::unit_file`` resource above will also
   # attempt to manage the tmp.mount service.
   if $tmp_service and ('systemd' in $facts['init_systems']) {
-    ensure_resources('service', { 'tmp.mounts' => { 'ensure' => 'running', 'enable' => true }})
+    unless defined(Systemd::Unit_file['tmp.mount']) {
+      ensure_resources('service', { 'tmp.mount' => { 'ensure' => 'running', 'enable' => true }})
+    }
   }
 }

--- a/spec/classes/mountpoints/tmp_spec.rb
+++ b/spec/classes/mountpoints/tmp_spec.rb
@@ -2,53 +2,97 @@ require 'spec_helper'
 
 describe 'simp::mountpoints::tmp' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts
+          os_facts
         end
 
-        context 'with default parameters' do
-          it { is_expected.to contain_mount('/tmp').with({
-            :options => 'bind,nodev,noexec,nosuid',
-            :device  => '/tmp'
-          }) }
-          it { is_expected.to contain_mount('/var/tmp').with({
-            :options => 'bind,nodev,noexec,nosuid',
-            :device  => '/tmp'
-          }) }
-          it { is_expected.to create_file('/tmp').with_mode('u+rwx,g+rwx,o+rwxt') }
-          it { is_expected.to create_file('/var/tmp').with_mode('u+rwx,g+rwx,o+rwxt') }
-          it { is_expected.to create_file('/usr/tmp').with_ensure('symlink') }
-        end
-
-        context 'tmp_is_partition' do
-          let(:facts) do facts.merge({
-              :tmp_mount_tmp        => 'rw,seclabel,relatime,data=ordered',
-              :tmp_mount_fstype_tmp => 'ext4',
-              :tmp_mount_path_tmp   => '/dev/sda3',
-            })
+        if os_facts[:init_systems].include?('systemd')
+          context 'with default parameters' do
+            it { is_expected.to create_file('/tmp').with_mode('u+rwx,g+rwx,o+rwxt') }
+            it { is_expected.to create_file('/var/tmp').with_mode('u+rwx,g+rwx,o+rwxt') }
+            it { is_expected.to create_file('/usr/tmp').with_ensure('symlink') }
+            it { is_expected.to contain_systemd__unit_file('tmp.mount').with_enable(true) }
+            it { is_expected.to contain_systemd__unit_file('tmp.mount').with_active(true) }
+            it {
+              is_expected.to contain_systemd__unit_file('tmp.mount').
+                with_content(
+                  <<-EOM
+[Mount]
+What=tmpfs
+Where=/tmp
+Type=tmpfs
+Options=mode=1777,nodev,noexec,nosuid
+                  EOM
+                )
+            }
           end
-          it { is_expected.to contain_mount('/tmp').with({
-            :options => 'data=ordered,nodev,noexec,nosuid,relatime,rw,seclabel',
-            :device  => '/dev/sda3'
-          })}
-        end
 
-        context 'tmp_is_already_bind_mounted' do
-          let(:facts) { facts.merge({
-              :tmp_mount_tmp        => 'bind,foo',
-              :tmp_mount_fstype_tmp => 'ext4',
-              :tmp_mount_path_tmp   => '/tmp',
-          })}
-          it { is_expected.to contain_mount('/tmp').with({
-            :options => "bind,nodev,noexec,nosuid",
-            :device  => '/tmp'
-          })}
+          context 'tmp_is_partition' do
+            let(:facts) do os_facts.merge({
+                :tmp_mount_tmp        => 'rw,seclabel,relatime,data=ordered',
+                :tmp_mount_fstype_tmp => 'ext4',
+                :tmp_mount_path_tmp   => '/dev/sda3',
+              })
+            end
+
+            it {
+              is_expected.to contain_systemd__unit_file('tmp.mount').
+                with_content(
+                  <<-EOM
+[Mount]
+What=tmpfs
+Where=/tmp
+Type=tmpfs
+Options=mode=1777,nodev,noexec,nosuid
+                  EOM
+                )
+            }
+          end
+        else
+          context 'with default parameters' do
+            it { is_expected.to contain_mount('/tmp').with({
+              :options => 'bind,nodev,noexec,nosuid',
+              :device  => '/tmp'
+            }) }
+            it { is_expected.to contain_mount('/var/tmp').with({
+              :options => 'bind,nodev,noexec,nosuid',
+              :device  => '/tmp'
+            }) }
+            it { is_expected.to create_file('/tmp').with_mode('u+rwx,g+rwx,o+rwxt') }
+            it { is_expected.to create_file('/var/tmp').with_mode('u+rwx,g+rwx,o+rwxt') }
+            it { is_expected.to create_file('/usr/tmp').with_ensure('symlink') }
+          end
+
+          context 'tmp_is_partition' do
+            let(:facts) do os_facts.merge({
+                :tmp_mount_tmp        => 'rw,seclabel,relatime,data=ordered',
+                :tmp_mount_fstype_tmp => 'ext4',
+                :tmp_mount_path_tmp   => '/dev/sda3',
+              })
+            end
+            it { is_expected.to contain_mount('/tmp').with({
+              :options => 'data=ordered,nodev,noexec,nosuid,relatime,rw,seclabel',
+              :device  => '/dev/sda3'
+            })}
+          end
+
+          context 'tmp_is_already_bind_mounted' do
+            let(:facts) { os_facts.merge({
+                :tmp_mount_tmp        => 'bind,foo',
+                :tmp_mount_fstype_tmp => 'ext4',
+                :tmp_mount_path_tmp   => '/tmp',
+            })}
+            it { is_expected.to contain_mount('/tmp').with({
+              :options => "bind,nodev,noexec,nosuid",
+              :device  => '/tmp'
+            })}
+          end
         end
 
         context 'var_tmp_is_partition' do
-          let(:facts) { facts.merge({
+          let(:facts) { os_facts.merge({
               :tmp_mount_var_tmp        => 'rw,seclabel,relatime,data=ordered',
               :tmp_mount_fstype_var_tmp => 'ext4',
               :tmp_mount_path_var_tmp   => '/dev/sda3',
@@ -60,7 +104,7 @@ describe 'simp::mountpoints::tmp' do
         end
 
         context 'var_tmp_is_already_bind_mounted' do
-          let(:facts) { facts.merge({
+          let(:facts) { os_facts.merge({
               :tmp_mount_var_tmp        => 'bind,foo',
               :tmp_mount_fstype_var_tmp => 'ext4',
               :tmp_mount_path_var_tmp   => '/var/tmp',
@@ -72,7 +116,7 @@ describe 'simp::mountpoints::tmp' do
         end
 
         context 'tmp_mount_dev_shm_mounted' do
-          let(:facts) { facts.merge({
+          let(:facts) { os_facts.merge({
               :tmp_mount_dev_shm        => 'rw,seclabel,nosuid,nodev',
               :tmp_mount_fstype_dev_shm => 'tmpfs',
               :tmp_mount_path_dev_shm   => 'tmpfs',
@@ -82,7 +126,6 @@ describe 'simp::mountpoints::tmp' do
             :device  => 'tmpfs'
           })}
         end
-
       end
     end
   end

--- a/spec/classes/mountpoints/tmp_spec.rb
+++ b/spec/classes/mountpoints/tmp_spec.rb
@@ -54,8 +54,8 @@ describe 'simp::mountpoints::tmp' do
             it { is_expected.to_not create_file('/tmp') }
             it { is_expected.to create_file('/var/tmp').with_mode('u+rwx,g+rwx,o+rwxt') }
             it { is_expected.to create_file('/usr/tmp').with_ensure('symlink') }
-            it { is_expected.to create_service('tmp.mounts').with_ensure('running') }
-            it { is_expected.to create_service('tmp.mounts').with_enable(true) }
+            it { is_expected.to_not create_service('tmp.mounts').with_ensure('running') }
+            it { is_expected.to_not create_service('tmp.mounts').with_enable(true) }
             it { is_expected.to contain_systemd__unit_file('tmp.mount').with_enable(true) }
             it { is_expected.to contain_systemd__unit_file('tmp.mount').with_active(true) }
             it {

--- a/spec/classes/mountpoints_spec.rb
+++ b/spec/classes/mountpoints_spec.rb
@@ -14,7 +14,6 @@ describe 'simp::mountpoints' do
           it { is_expected.to contain_mount('/sys').with_options('rw,nodev,noexec') }
           if os_facts[:init_systems].include?('systemd')
             it { is_expected.to contain_systemd__unit_file('tmp.mount') }
-            it { is_expected.to contain_file('/tmp').that_comes_before('Systemd::Unit_file[tmp.mount]') }
           else
             it { is_expected.to contain_file('/tmp').that_comes_before('Mount[/tmp]') }
           end

--- a/spec/classes/mountpoints_spec.rb
+++ b/spec/classes/mountpoints_spec.rb
@@ -2,30 +2,37 @@ require 'spec_helper'
 
 describe 'simp::mountpoints' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          # facts[:selinux_mode] = 'disabled'
-          facts
+          os_facts
         end
 
         context 'with default parameters' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_mount('/dev/pts').with_options('rw,gid=5,mode=620,noexec') }
           it { is_expected.to contain_mount('/sys').with_options('rw,nodev,noexec') }
-          it { is_expected.to contain_file('/tmp').that_comes_before('Mount[/tmp]') }
+          if os_facts[:init_systems].include?('systemd')
+            it { is_expected.to contain_systemd__unit_file('tmp.mount') }
+            it { is_expected.to contain_file('/tmp').that_comes_before('Systemd::Unit_file[tmp.mount]') }
+          else
+            it { is_expected.to contain_file('/tmp').that_comes_before('Mount[/tmp]') }
+          end
           it { is_expected.to contain_file('/var/tmp').that_comes_before('Mount[/var/tmp]') }
         end
 
         context 'and manage_tmp_perms => false' do
           let(:params) {{ :manage_tmp_perms => false }}
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.not_to contain_mount('/tmp') }
+          if os_facts[:init_systems].include?('systemd')
+            it { is_expected.not_to contain_systemd__unit_file('tmp.mount') }
+          else
+            it { is_expected.not_to contain_mount('/tmp') }
+          end
           it { is_expected.not_to contain_mount('/var/tmp') }
           it { is_expected.not_to contain_file('/tmp') }
           it { is_expected.not_to contain_file('/var/tmp') }
         end
-
       end
     end
   end


### PR DESCRIPTION
- Refactor the simp::mountpoints::tmp to use systemd's tmp.mount target if
  the system supports systemd.

SIMP-4663 #close