### PR TITLE
(SIMP-6506) Out of memory Error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu May 09 2019 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 4.8.1-0
+- Set permission on /etc/simp and /etc/simp/simp.version to world readable.
+  Puppet needs to be able to read it for simp_version fact.
+
 * Mon May 06 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.8.0-0
 - Fixed a bug on el6 systems in which the 'puppetdb-dlo-cleanup' cron
   job from the puppetdb module could not be created. Cron rejected this

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -12,12 +12,12 @@ class simp::version () {
     # Windows permission model is different then *nix,
     # so 770 is the only one that can be translated without
     # also pulling in windows_acl
-    $simp_root_dir_mode = '0770'
+    $simp_root_dir_mode = '0775'
   } else {
     $simp_root_dir = '/etc/simp'
     $simp_root_dir_group = 'root'
     $simp_root_dir_user = 'root'
-    $simp_root_dir_mode = '0640'
+    $simp_root_dir_mode = '0644'
     file { '/usr/local/sbin/simp':
       ensure => 'directory',
       owner  => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",
@@ -134,7 +134,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.15.0 < 4.0.0"
+      "version_requirement": ">= 3.15.1 < 4.0.0"
     },
     {
       "name": "simp/ssh",


### PR DESCRIPTION
- Puppet could not read the /etc/simp/simp.version file because
  the world writable permissions set in simp.spec during install
  were being overriden.  Change them to world readable, as set in
  the install.
-Updated the version of simplib so it calls the simp_version function
 which uses Puppet::Util::Execition so it does not crash the system.

SIMP-6506 #close