### PR TITLE
(SIMP-6911) Set simp::server::data to empty array on windows.

### DIFF
--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -1,3 +1,4 @@
+simp::server::data: []
 simp::vardir_owner: 'Administrators'
 simp::vardir_group: 'Administrators'
 simp::vardir_mode: '0770'


### PR DESCRIPTION
Fixes: [SIMP-6911](https://simp-project.atlassian.net/browse/SIMP-6911)

Setting `simp::server::data` to an empty array on windows prevents it from being set to `['yum']`.