### PR TITLE
(SIMP-7113) Remove Clamav from default class list.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Oct 28 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.11.0-0
+- Removed clamav from the list of modules installed by default.
+
 * Thu Aug 15 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.10.2-0
 - Add Windows acceptance tests
 - Remove broken tasks directory

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 * Mon Oct 28 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.11.0-0
 - Removed clamav from the list of modules installed by default.
+  Note:  This will not remove clamav from a system it is installed on, it
+  will stop managing it.  To continue managing ClamAV on a system add
+  clamav to the simp::classes in the appropriate heira file.  See
+  the pupmod-simp-clamav for information on configuring or removing
+  ClamAV on a system.
 
 * Thu Aug 15 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.10.2-0
 - Add Windows acceptance tests

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,19 @@
 * Mon Oct 28 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.11.0-0
-- Removed clamav from the list of modules installed by default.
-  Note:  This will not remove clamav from a system it is installed on, it
-  will stop managing it.  To continue managing ClamAV on a system add
-  clamav to the simp::classes in the appropriate heira file.  See
-  the pupmod-simp-clamav for information on configuring or removing
-  ClamAV on a system.
+- Removed `clamav` from the list of classes included by default in the
+  SIMP scenarios.
+  * This will not remove ClamAV from a system it is installed on, it
+    will stop managing it.
+  * To continue managing ClamAV on a system add `clamav` to `simp::classes`
+    in the appropriate hiera file for that SIMP client.
+  * See the `simp-clamav` module for information on configuring or removing
+    ClamAV on a system.
+- Deprecated `simp::server::clamav`.
+  * This parameter will be removed in a future SIMP release.
+  * Once removed, if you want to manage ClamAV on the SIMP server, you will
+    have to manually add the `clamav` class to `simp::classes` in the
+    SIMP server's hiera file.
 
-* Thu Aug 15 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.10.2-0
+* Thu Aug 15 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.11.0-0
 - Add Windows acceptance tests
 - Remove broken tasks directory
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1909,15 +1909,20 @@ Data type: `Boolean`
 
 Enable SIMP management of the PAM stack
 
-Default value: simplib::lookup('simp_options::pam', { 'default_value'     => false })
+Default value: simplib::lookup('simp_options::pam', { 'default_value' => false })
 
 ##### `clamav`
 
 Data type: `Boolean`
 
-Enable SIMP management of Antivirus
+Deprecated. Enable SIMP management of Antivirus
 
-Default value: simplib::lookup('simp_options::clamav', { 'default_value'  => false })
+This parameter and the simp_options::clamav catalyst are deprecated and
+both will be removed in a future SIMP release. Once removed, if you want
+to manage ClamAV, you will have to manually include the `clamav` class
+from the `simp-clamav` module in the server's class list.
+
+Default value: simplib::lookup('simp_options::clamav', { 'default_value' => false })
 
 ##### `auditd`
 

--- a/data/os/CentOS.yaml
+++ b/data/os/CentOS.yaml
@@ -26,7 +26,6 @@ simp::scenario_map:
     - aide
     - at
     - auditd
-    - clamav
     - cron
     - deferred_resources
     - incron
@@ -58,7 +57,6 @@ simp::scenario_map:
     - aide
     - at
     - auditd
-    - clamav
     - cron
     - deferred_resources
     - incron
@@ -93,7 +91,6 @@ simp::scenario_map:
     - aide
     - at
     - auditd
-    - clamav
     - cron
     - deferred_resources
     - incron
@@ -150,7 +147,6 @@ simp::server::data:
   - useradd
   - '--simp::scenario::base'
   - '--auditd'
-  - '--clamav'
   # These classes are only in 'simp'
   - fips
   - pam::wheel

--- a/data/os/OracleLinux.yaml
+++ b/data/os/OracleLinux.yaml
@@ -26,7 +26,6 @@ simp::scenario_map:
     - aide
     - at
     - auditd
-    - clamav
     - cron
     - deferred_resources
     - incron
@@ -58,7 +57,6 @@ simp::scenario_map:
     - aide
     - at
     - auditd
-    - clamav
     - cron
     - deferred_resources
     - incron
@@ -93,7 +91,6 @@ simp::scenario_map:
     - aide
     - at
     - auditd
-    - clamav
     - cron
     - deferred_resources
     - incron
@@ -150,7 +147,6 @@ simp::server::data:
   - useradd
   - '--simp::scenario::base'
   - '--auditd'
-  - '--clamav'
   # These classes are only in 'simp'
   - fips
   - pam::wheel

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -26,7 +26,6 @@ simp::scenario_map:
     - aide
     - at
     - auditd
-    - clamav
     - cron
     - deferred_resources
     - incron
@@ -58,7 +57,6 @@ simp::scenario_map:
     - aide
     - at
     - auditd
-    - clamav
     - cron
     - deferred_resources
     - incron
@@ -93,7 +91,6 @@ simp::scenario_map:
     - aide
     - at
     - auditd
-    - clamav
     - cron
     - deferred_resources
     - incron
@@ -150,7 +147,6 @@ simp::server::data:
   - useradd
   - '--simp::scenario::base'
   - '--auditd'
-  - '--clamav'
   # These classes are only in 'simp'
   - fips
   - pam::wheel

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -8,6 +8,10 @@
 #   Enable SIMP management of the PAM stack
 #
 # @param clamav
+#   The simp_options::clamav catalyst has been deprecated and will be removed
+#   from future releases of simp.  To manage ClamAV use the pupmod-simp-clamav
+#   module.  It has been left here for backwards compatibility.
+#
 #   Enable SIMP management of Antivirus
 #
 # @param auditd
@@ -51,7 +55,10 @@ class simp::server (
     fail("ERROR - Invalid scenario '${scenario}' for the given scenario map.")
   }
 
+  # This setting will be removed from future releases of simp.
+  # See the  pupmod-simp-clamav module for information on how manage ClamAV
   if $clamav  { include 'clamav' }
+
   if $auditd  { include 'auditd' }
 
   if $allow_simp_user {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -8,11 +8,12 @@
 #   Enable SIMP management of the PAM stack
 #
 # @param clamav
-#   The simp_options::clamav catalyst has been deprecated and will be removed
-#   from future releases of simp.  To manage ClamAV use the pupmod-simp-clamav
-#   module.  It has been left here for backwards compatibility.
+#   Deprecated. Enable SIMP management of Antivirus
 #
-#   Enable SIMP management of Antivirus
+#   This parameter and the simp_options::clamav catalyst are deprecated and
+#   both will be removed in a future SIMP release. Once removed, if you want
+#   to manage ClamAV, you will have to manually include the `clamav` class
+#   from the `simp-clamav` module in the server's class list.
 #
 # @param auditd
 #   Enable SIMP management of auditing
@@ -56,7 +57,7 @@ class simp::server (
   }
 
   # This setting will be removed from future releases of simp.
-  # See the  pupmod-simp-clamav module for information on how manage ClamAV
+  # See the simp-clamav module for information on how manage ClamAV
   if $clamav  { include 'clamav' }
 
   if $auditd  { include 'auditd' }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.10.2",
+  "version": "4.11.0",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Remove clamav from the list of classes included by simp in
  it scenarios by default.  To manage clamav it should be added
  to the class list in hiera.
- The catalyst clamav will be removed from simp_options in future
  releases.  It is still here for backwards compatability.
- See the clamav module README for more information on how to use clamav.

SIMP-7113 #close