### PR TITLE
[SIMP-MAINT] Fix broken docs formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ appropriate access to the parameters in ``simp_options``.
 
 ## Reference
 
-See the [REFERENCE.md](./REFERENCE.md) for a comprehensive overview of the
-module components.
+See the [REFERENCE.md][reference_md] for a comprehensive overview of the module
+components.
 
 ## Usage
 
@@ -77,8 +77,9 @@ These may be set via the ``simp::scenario`` parameter via Hiera.
 
 
 You may want to tweak individual module settings and should reference the
-[module documentation](https://github.com/simp/pupmod-simp-simp/docs/index.html)
-for full details.
+[module documentation][reference_md] for full details.
+
+[reference_md]: https://github.com/simp/pupmod-simp-simp/blob/master/REFERENCE.md
 
 #### SIMP Scenarios
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This module is a component of the [System Integrity Management Platform](https:/
 
 If you find any issues, please submit them via [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide] (https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 This module should be used within the SIMP ecosystem and will be of limited
 independent use
@@ -118,7 +118,7 @@ different configurations easily:
 
 ## Development
 
-Please read our [Contribution Guide] (https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ### Unit tests
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ It is recommended that you start with one of the SIMP scenarios described below.
 
 These may be set via the ``simp::scenario`` parameter via Hiera.
 
+| **NOTE** |
+| --- |
+| <ul><li>`simp::scenario` always affects SIMP **client** systems, no matter how it was set.</li><li>However: SIMP **servers** will default to the `simp` scenario unless `simp:scenario` is set _in Hiera_.</li></ul> |
+
+
 You may want to tweak individual module settings and should reference the
 [module documentation](https://github.com/simp/pupmod-simp-simp/docs/index.html)
 for full details.
@@ -79,12 +84,6 @@ for full details.
 
 The SIMP module has the following scenarios defined for getting started with
 different configurations easily:
-
-**NOTE**
-
-| SIMP scenarios always target the Puppet **client** systems. The SIMP server
-| is always kept in the safest mode by default but can be overridden explicitly
-| in Hiera if desired.
 
 * ``simp``
   * The default scenario. Enables all modules to support the default SIMP

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -126,12 +126,14 @@ to the ``scenario`` selected above.
   be **removed** from the Array
 
 @example The following list would include the `apache` class and exclude
-  the `ntpd` class.
+  the `ntpd` class:
+
   ```
   ---
   simp::classes:
       - 'apache'
       - '--ntpd'
+  ```
 
 Default value: []
 
@@ -963,6 +965,32 @@ Data type: `Boolean`
 SIMP global catalyst to enable sssd
 
 Default value: simplib::lookup('simp_options::sssd', { 'default_value' => false })
+
+##### `defaults`
+
+Data type: `Hash`
+
+
+
+##### `sssd_options`
+
+Data type: `Hash`
+
+
+
+##### `ldap_options`
+
+Data type: `Hash`
+
+
+
+##### `overrides`
+
+Data type: `Hash`
+
+
+
+Default value: {}
 
 ### simp::one_shot
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,12 +38,14 @@
 #     be **removed** from the Array
 #
 #   @example The following list would include the `apache` class and exclude
-#     the `ntpd` class.
+#     the `ntpd` class:
+#
 #     ```
 #     ---
 #     simp::classes:
 #         - 'apache'
 #         - '--ntpd'
+#     ```
 #
 # @param mail_server
 #   Install a local mail service on the system


### PR DESCRIPTION
This commit fixes minor problems in the markdown docs:

REFERENCE.md:

* Fixes syntax error that derailed all subsequent rendering
* Re-generates REFERENCE.md

README.md:

* Fixes broken syntax for Contribution Guide links
* Fixes note block formatting (broken on GitHub and Puppet Forge)
* Un-muddles note text to make clear what is actually going on
* Moves note to beef up description of `simp::scenario`