### PR TITLE
(SIMP-7562) Update nsswitch options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Wed Feb 26 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.11.0-0
+- Updated the simp::nsswitch class to have sane defaults
+  - Added support for mymachines and myhostname by default
+  - Removed all NIS references since NIS should not be in general usage any
+    longer and was never natively supported by SIMP
+  - Configuration files are now common cross all supported OSs since nsswitch
+    "does the right thing" when it hits a module that it does not recognize
+
 * Mon Dec 16 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.11.0-0
 - NTP is not used by default in EL8 so moved ntp to list of OS relevant apps
   for EL6 and EL7 and added chronyd for EL8.

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,7 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  #gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', ['>= 3.1.1', '< 4.0.0'])
-  gem 'simp-rspec-puppet-facts', :path => ENV['HOME'] + '/Work/SIMP/rubygem-simp-rspec-puppet-facts'
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', ['>= 3.1.1', '< 4.0.0'])
 
   gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.10.2', '< 6.0.0'])
   gem 'facterdb'

--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,10 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', ['>= 2.4.0', '< 3.0.0'])
+  #gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', ['>= 3.1.1', '< 4.0.0'])
+  gem 'simp-rspec-puppet-facts', :path => ENV['HOME'] + '/Work/SIMP/rubygem-simp-rspec-puppet-facts'
 
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.9', '< 6.0.0'])
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.10.2', '< 6.0.0'])
   gem 'facterdb'
 end
 
@@ -31,5 +32,5 @@ group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
   gem 'beaker-windows'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.17.0', '< 2.0.0'])
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.18.2', '< 2.0.0'])
 end

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -30,7 +30,6 @@
 * [`simp::scenario::poss`](#simpscenarioposs): The 'Puppet Open Source Software' Scenario
 * [`simp::server`](#simpserver): Set up a SIMP server in such a way that it will be ready to serve
 * [`simp::server::kickstart`](#simpserverkickstart): This class provides a working framework for providing a kickstart
-* [`simp::server::kickstart::runpuppet`](#simpserverkickstartrunpuppet): This class manages the runpuppet script, which is a script that can
 * [`simp::server::kickstart::simp_client_bootstrap`](#simpserverkickstartsimp_client_bootstrap): This class manages simp_client_bootstrap scripts, which are scripts
 * [`simp::server::ldap`](#simpserverldap): Sets up either a primary LDAP server or a slave LDAP server.
 * [`simp::server::rsync_shares`](#simpserverrsync_shares): Set up various rsync services that are needed by the SIMP clients
@@ -2034,16 +2033,22 @@ Default value: `true`
 
 Data type: `Boolean`
 
-If true, generate the runpuppet script in $data_dir/ks.
+Deprecated  The runpuppet script has been replaced by the
+simp_client_bootstrap script.  The runpuppet script did
+not work well on CentOS 7 and will not work on CentOS 8.
+Remember to update your kickstart scripts to call the correct
+script. See the bootstrap scripts in simp-core under build/distributions
+for examples.
+This parameter will be removed in later versions.
 
-Default value: `true`
+Default value: `false`
 
 ##### `manage_simp_client_bootstrap`
 
 Data type: `Boolean`
 
 If true, generate the simp_client_bootstrap sysv init
-script and simp_clinet_bootstrap.service systemd
+script and simp_client_bootstrap.service systemd
 service unit file in $data_dir/ks.
 
 Default value: `true`
@@ -2056,106 +2061,6 @@ Verify the certificate of the kickstart client.  One of optional, require,
 none, optional_no_ca.
 
 Default value: 'none'
-
-### simp::server::kickstart::runpuppet
-
-be run to bootstrap provisioned clients, adding them to puppet and running it
-in a fashion similar so `simp bootstrap`.
-
-#### Parameters
-
-The following parameters are available in the `simp::server::kickstart::runpuppet` class.
-
-##### `data_dir`
-
-Data type: `Stdlib::Absolutepath`
-
-The location of the web root in which the kickstart directory
-will reside.  Only used to compute the default for `location`.
-
-Default value: simplib::lookup('simp::server::kickstart::data_dir', { 'default_value' => '/var/www'})
-
-##### `location`
-
-Data type: `Stdlib::Absolutepath`
-
-The location of the runpuppet file to be placed when generated.
-
-Default value: "${data_dir}/ks/runpuppet"
-
-##### `ntp_servers`
-
-Data type: `Variant[Array, Hash]`
-
-An array of ntp servers or hash of server/value pairs that should
-be used during client kickstarts to slew the local time correctly
-prior to PKI key distribution.
-
-Failure to set the system clock will not cause the runpuppet script to fail
-to execute.
-
-Default value: simplib::lookup('simp_options::ntpd::servers', { 'default_value' => [] })
-
-##### `puppet_server`
-
-Data type: `Optional[Simplib::Host]`
-
-The FQDN of your Puppet server
-
-* If not set, will use ``$server_facts['servername']``, or the puppet
-  server set in puppet.conf if trusted_server_facts isn't set or found.
-
-Default value: simplib::lookup('simp_options::puppet::server', { 'default_value' => undef })
-
-##### `puppet_ca`
-
-Data type: `Optional[Simplib::Host]`
-
-The FQDN of your Puppet CA
-
-* If not set, will use ``$server_facts['servername']``, or the puppet
-  server set in puppet.conf if trusted_server_facts isn't set or found.
-
-Default value: simplib::lookup('simp_options::puppet::ca', { 'default_value' => undef })
-
-##### `puppet_ca_port`
-
-Data type: `Simplib::Port`
-
-The port upon which the Puppet CA is listening.
-
-Default value: simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 })
-
-##### `runpuppet_print_stats`
-
-Data type: `Boolean`
-
-If true, print statistics for each client puppet run during bootstrap.
-
-Default value: `true`
-
-##### `runpuppet_wait_for_cert`
-
-Data type: `Variant[Integer[0],Boolean]`
-
-If set to an integer, the runpuppet client script will wait for this many
-seconds between checking into the puppet master for a signed certificate.
-This will go on until a signed certificate is presented.
-
-If set to false or 0, the client will immediately timeout if a signed
-certificate is not presented.
-
-Default value: 10
-
-##### `fips`
-
-Data type: `Boolean`
-
-If true, set puppet keylength to 2048, else 4096.  This non-compliant
-setting is to work around problems with older versions of Ruby.  It
-will be fixed, when Puppet fully supports FIPS mode.
-
-Default value: simplib::lookup('simp_options::fips', { 'default_value' => false })
 
 ### simp::server::kickstart::simp_client_bootstrap
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -43,20 +43,22 @@ simp::server::scenario_map:
 simp::nsswitch::defaults:
   passwd:
     - 'files'
+    - 'mymachines'
+    - 'systemd'
   shadow:
     - 'files'
   group:
     - 'files'
+    - 'mymachines'
+    - 'systemd'
   sudoers:
     - 'files'
   hosts:
     - 'files'
-    - 'dns'
     - 'mymachines'
+    - 'dns'
     - 'myhostname'
   bootparams:
-    - 'nisplus'
-    - '[NOTFOUND=return]'
     - 'files'
   ethers:
     - 'files'
@@ -66,61 +68,57 @@ simp::nsswitch::defaults:
     - 'files'
   protocols:
     - 'files'
+  publickey:
+    - 'files'
   rpc:
     - 'files'
   services:
     - 'files'
   netgroup:
     - 'files'
-  publickey:
-    - 'nisplus'
   automount:
     - 'files'
-    - 'nisplus'
   aliases:
     - 'files'
-    - 'nisplus'
 
 simp::nsswitch::sssd_options:
-  group:
-    - 'files'
-    - '[!NOTFOUND=return]'
-    - 'sss'
-  netgroup:
-    - 'files'
-    - '[!NOTFOUND=return]'
-    - 'sss'
   passwd:
-    - 'files'
-    - '[!NOTFOUND=return]'
+    - 'files [!NOTFOUND=return]'
     - 'sss'
+    - 'mymachines'
+    - 'systemd'
   shadow:
-    - 'files'
-    - '[!NOTFOUND=return]'
+    - 'files [!NOTFOUND=return]'
+    - 'sss'
+  group:
+    - 'files [!NOTFOUND=return]'
+    - 'sss'
+    - 'mymachines'
+    - 'systemd'
+  netgroup:
+    - 'files [!NOTFOUND=return]'
     - 'sss'
   sudoers:
-    - 'files'
-    - '[!NOTFOUND=return]'
+    - 'files [!NOTFOUND=return]'
     - 'sss'
 
 simp::nsswitch::ldap_options:
-  group:
-    - 'files'
-    - '[!NOTFOUND=return]'
-    - 'ldap'
-  netgroup:
-    - 'files'
-    - '[!NOTFOUND=return]'
-    - 'ldap'
   passwd:
-    - 'files'
-    - '[!NOTFOUND=return]'
+    - 'files [!NOTFOUND=return]'
     - 'ldap'
+    - 'mymachines'
+    - 'systemd'
   shadow:
-    - 'files'
-    - '[!NOTFOUND=return]'
+    - 'files [!NOTFOUND=return]'
+    - 'ldap'
+  group:
+    - 'files [!NOTFOUND=return]'
+    - 'ldap'
+    - 'mymachines'
+    - 'systemd'
+  netgroup:
+    - 'files [!NOTFOUND=return]'
     - 'ldap'
   sudoers:
-    - 'files'
-    - '[!NOTFOUND=return]'
+    - 'files [!NOTFOUND=return]'
     - 'ldap'

--- a/data/os/CentOS-6.yaml
+++ b/data/os/CentOS-6.yaml
@@ -12,9 +12,3 @@ simp::server::scenario_map:
   poss: "%{alias('simp::scenario::data::el6')}"
   simp: "%{alias('simp::scenario::data::el6')}"
   simp_lite: "%{alias('simp::scenario::data::el6')}"
-
-simp::nsswitch::defaults:
-  hosts:
-    - 'files'
-    - 'dns'
-    - 'myhostname'

--- a/data/os/OracleLinux-6.yaml
+++ b/data/os/OracleLinux-6.yaml
@@ -12,9 +12,3 @@ simp::server::scenario_map:
   poss: "%{alias('simp::scenario::data::el6')}"
   simp: "%{alias('simp::scenario::data::el6')}"
   simp_lite: "%{alias('simp::scenario::data::el6')}"
-
-simp::nsswitch::defaults:
-  hosts:
-    - 'files'
-    - 'dns'
-    - 'myhostname'

--- a/data/os/RedHat-6.yaml
+++ b/data/os/RedHat-6.yaml
@@ -12,9 +12,3 @@ simp::server::scenario_map:
   poss: "%{alias('simp::scenario::data::el6')}"
   simp: "%{alias('simp::scenario::data::el6')}"
   simp_lite: "%{alias('simp::scenario::data::el6')}"
-
-simp::nsswitch::defaults:
-  hosts:
-    - 'files'
-    - 'dns'
-    - 'myhostname'

--- a/manifests/nsswitch.pp
+++ b/manifests/nsswitch.pp
@@ -27,7 +27,7 @@ class simp::nsswitch (
     $options = {}
   }
 
-  class { '::nsswitch':
+  class { 'nsswitch':
     * => $defaults + $options + $overrides
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -226,11 +226,12 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "Server 2008",
-        "Server 2008 R2",
-        "Server 2012",
-        "Server 2012 R2",
-        "Server 2016",
+        "2008",
+        "2008 R2",
+        "2012",
+        "2012 R2",
+        "2016",
+        "2019",
         "7",
         "8.1",
         "10"

--- a/spec/classes/00_classes/nsswitch_spec.rb
+++ b/spec/classes/00_classes/nsswitch_spec.rb
@@ -9,85 +9,81 @@ describe 'simp::nsswitch' do
         if os_facts[:kernel] == 'windows'
           it { expect{ is_expected.to compile.with_all_deps }.to raise_error(/'windows .+' is not supported/) }
         else
-          let(:hosts_line){
-            if (os_facts[:os][:family] == 'RedHat') && os_facts[:os][:release] && (os_facts[:os][:release][:major] < '7')
-              'hosts:      files dns myhostname'
-            else
-              'hosts:      files dns mymachines myhostname'
-            end
-          }
-
           context 'with default parameters' do
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to create_class('simp::nsswitch') }
-            it { is_expected.to create_file('nsswitch.conf').with_content(<<-EOM) }
-# This file is controlled by Puppet
+            it { is_expected.to create_file('nsswitch.conf').with_content(<<~EOM) }
+              # This file is controlled by Puppet
 
-passwd:     files
-shadow:     files
-group:      files
-sudoers:    files
-#{hosts_line}
-bootparams: nisplus [NOTFOUND=return] files
-ethers:     files
-netmasks:   files
-networks:   files
-protocols:  files
-rpc:        files
-services:   files
-netgroup:   files
-publickey:  nisplus
-automount:  files nisplus
-aliases:    files nisplus
-EOM
+              passwd:     files mymachines systemd
+              shadow:     files
+              group:      files mymachines systemd
+              sudoers:    files
+              hosts:      files mymachines dns myhostname
+              bootparams: files
+              ethers:     files
+              netmasks:   files
+              networks:   files
+              protocols:  files
+              rpc:        files
+              services:   files
+              netgroup:   files
+              publickey:  files
+              automount:  files
+              aliases:    files
+              EOM
           end
 
           context 'with sssd => true' do
             let(:params) {{ :sssd => true }}
-            it { is_expected.to create_file('nsswitch.conf').with_content(<<-EOM) }
-# This file is controlled by Puppet
 
-passwd:     files [!NOTFOUND=return] sss
-shadow:     files [!NOTFOUND=return] sss
-group:      files [!NOTFOUND=return] sss
-sudoers:    files [!NOTFOUND=return] sss
-#{hosts_line}
-bootparams: nisplus [NOTFOUND=return] files
-ethers:     files
-netmasks:   files
-networks:   files
-protocols:  files
-rpc:        files
-services:   files
-netgroup:   files [!NOTFOUND=return] sss
-publickey:  nisplus
-automount:  files nisplus
-aliases:    files nisplus
-EOM
+            let(:content){ <<~EOM
+              # This file is controlled by Puppet
+
+              passwd:     files [!NOTFOUND=return] sss mymachines systemd
+              shadow:     files [!NOTFOUND=return] sss
+              group:      files [!NOTFOUND=return] sss mymachines systemd
+              sudoers:    files [!NOTFOUND=return] sss
+              hosts:      files mymachines dns myhostname
+              bootparams: files
+              ethers:     files
+              netmasks:   files
+              networks:   files
+              protocols:  files
+              rpc:        files
+              services:   files
+              netgroup:   files [!NOTFOUND=return] sss
+              publickey:  files
+              automount:  files
+              aliases:    files
+              EOM
+            }
+
+            it { is_expected.to create_file('nsswitch.conf').with_content(content) }
           end
 
           context 'with ldap => true' do
             let(:params) {{ :ldap => true }}
-            it { is_expected.to create_file('nsswitch.conf').with_content(<<-EOM) }
-# This file is controlled by Puppet
+            it { is_expected.to create_file('nsswitch.conf').with_content(<<~EOM) }
+              # This file is controlled by Puppet
 
-passwd:     files [!NOTFOUND=return] ldap
-shadow:     files [!NOTFOUND=return] ldap
-group:      files [!NOTFOUND=return] ldap
-sudoers:    files [!NOTFOUND=return] ldap
-#{hosts_line}
-bootparams: nisplus [NOTFOUND=return] files
-ethers:     files
-netmasks:   files
-networks:   files
-protocols:  files
-rpc:        files
-services:   files
-netgroup:   files [!NOTFOUND=return] ldap
-publickey:  nisplus
-automount:  files nisplus
-aliases:    files nisplus
-EOM
+              passwd:     files [!NOTFOUND=return] ldap mymachines systemd
+              shadow:     files [!NOTFOUND=return] ldap
+              group:      files [!NOTFOUND=return] ldap mymachines systemd
+              sudoers:    files [!NOTFOUND=return] ldap
+              hosts:      files mymachines dns myhostname
+              bootparams: files
+              ethers:     files
+              netmasks:   files
+              networks:   files
+              protocols:  files
+              rpc:        files
+              services:   files
+              netgroup:   files [!NOTFOUND=return] ldap
+              publickey:  files
+              automount:  files
+              aliases:    files
+              EOM
           end
         end
       end

--- a/spec/unit/compliance_engine/compliance_engine_enforce_spec.rb
+++ b/spec/unit/compliance_engine/compliance_engine_enforce_spec.rb
@@ -4,41 +4,103 @@ require 'spec_helper'
 v1_profiles = './spec/fixtures/modules/compliance_markup/data/compliance_profiles'
 FileUtils.rm_rf(v1_profiles) if File.directory?(v1_profiles)
 
+# Remove any known exceptions from the specified section of the compliance report
+#
+# @param compliance_profile_data  Original compliance report
+# @param section  Section of the compliance report to normalize
+# @param exceptions  Hash of exceptions to apply
+#   - Each key is a section name and its value is a structure containing
+#     list/hash of exceptions
+#   - The exceptions for 'documented_missing_parameters' and
+#     'documented_missing_resources' are arrays of strings/regexes to match.
+#   - The exceptions for 'non_compliant' is a Hash in which the key is the
+#     catalog resource and the value is an array of parameter names.
+#
+# @return Normalized compliance report
+#
+def normalize_compliance_results(compliance_profile_data, section, exceptions)
+  normalized = Marshal.load(Marshal.dump(compliance_profile_data))
+  if section == 'non_compliant'
+    exceptions[section].each do |resource, params|
+      params.each do |param|
+        if normalized['non_compliant'].key?(resource) &&
+            normalized['non_compliant'][resource]['parameters'].key?(param)
+          normalized['non_compliant'][resource]['parameters'].delete(param)
+          if normalized['non_compliant'][resource]['parameters'].empty?
+            normalized['non_compliant'].delete(resource)
+          end
+        end
+      end
+    end
+  else
+    normalized[section].delete_if do |item|
+      rm = false
+      Array(exceptions[section]).each do |allowed|
+        if allowed.is_a?(Regexp)
+          unless allowed.match?(item)
+            rm = true
+            break
+          end
+        else
+          rm = (allowed != item)
+        end
+      end
+      rm
+    end
+  end
+
+  normalized
+end
+
 # This is the class that needs to be added to the catalog last to make the
 # reporting work.
 describe 'compliance_markup', type: :class do
 
-  compliance_profiles = [
-    'disa_stig',
-    'nist_800_53:rev4'
-  ]
-
-  # A list of classes that we expect to be included for compliance
+  # A list of classes that we expect to be included for this compliance test.
   #
   # This needs to be well defined since we can also manipulate defined type
   # defaults
   expected_classes = [
-    'simp',
-    'simp::server',
-    'simp::pam_limits::max_logins'
+    'simp'
   ]
 
-  allowed_failures = {
-    'documented_missing_parameters' => [
-    ] + expected_classes.map{|c| Regexp.new("^(?!#{c}(::.*)?)")},
-    'documented_missing_resources' => [
-    ] + expected_classes.map{|c| Regexp.new("^(?!#{c}(::.*)?)")}
+  # regex to match any resource or resource parameter NOT under test
+  not_expected_classes_regex = Regexp.new(
+    "^(?!(#{expected_classes.join("|")})(::.+)?)$"
+  )
+
+  compliance_profiles = {
+    'disa_stig'        => {
+      :percent_compliant   => 100,
+      :exceptions => {
+        'documented_missing_parameters' => [ not_expected_classes_regex ],
+        'documented_missing_resources'  => [ not_expected_classes_regex ],
+        'non_compliant'                 => {}
+      }
+    },
+    'nist_800_53:rev4' => {
+      :percent_compliant   => 100,
+      :exceptions => {
+        'documented_missing_parameters' => [ not_expected_classes_regex ],
+        'documented_missing_resources'  => [ not_expected_classes_regex ],
+        'non_compliant'                 => {
+           # compliance_engine is not smart enough, yet, to allow compliance to
+           # be determined by anything other than an exact match to parameter
+           # content. In this case, all we want to ensure is that 'EC2' appears
+           # in facts.blocklist element of pupmod::facter_options. We don't
+           # actually care what else is in that configuration Hash.  So, the
+           # 'non_compliant' report is a false alarm for pupmod::facter_options.
+          'Class[Pupmod]' => [ 'facter_options' ]
+        }
+      }
+    }
   }
 
   on_supported_os.each do |os, os_facts|
     next if os_facts[:kernel] == 'windows'
 
-    if ENV['RSPEC_COMPLIANCE_ENGINE_OS']
-      next unless os.match?(Regexp.new(ENV['RSPEC_COMPLIANCE_ENGINE_OS']))
-    end
-
     context "on #{os}" do
-      compliance_profiles.each do |target_profile|
+      compliance_profiles.each do |target_profile,info|
         context "with compliance profile '#{target_profile}'" do
           let(:facts){
             os_facts.merge({
@@ -72,51 +134,50 @@ describe 'compliance_markup', type: :class do
             expect(compliance_profile_data).to_not be_nil
           end
 
-          it 'should have a 100% compliant report' do
-            expect(compliance_profile_data['summary']['percent_compliant']).to eq(100)
+          it "should have a #{info[:percent_compliant]}% compliant report" do
+            expect(compliance_profile_data['summary']['percent_compliant'])
+              .to eq(info[:percent_compliant])
           end
 
           # The list of report sections that should not exist and if they do
           # exist, we need to know what is wrong so that we can fix them
           report_validators = [
-            # This should *always* be empty on enforcement
+            # 'non_compliant' specifies resource parameters with values that
+            # don't match what they should be for the security profile, per
+            # the compliance data. This should *always* be empty on enforcement.
             'non_compliant',
-            # If something is set here, either the upstream API changed or you
-            # have a typo in your data
+
+            # 'documented_missing_parameters' are resource parameters that have
+            # been included in the security profile, but don't actually map to
+            # resource parameters found in the catalog.  If something is set
+            # here, either the upstream API changed or you have a typo in your
+            # compliance data.
             'documented_missing_parameters',
-            # If something is set here, you have included enforcement data that
-            # you are not testing so you either need to remove it from your
-            # profile or you need to add the class/defined type for validation
+
+            # 'documented_missing_resources' are catalog resources that have
+            # been included in the security profile, but don't actually map to
+            # resources found in the catalog.  If something is set here, you
+            # have included enforcement data that you are not testing here
+            # (i.e., compliance data for other modules in your fixtures). So,
+            # you either need to remove the corresponding entries from the
+            # compliance results prior to validation, or add the missing
+            # classes/defined types to the manifest used in this test.
             #
-            # Unless this is a completely comprehensive data profile, with all
-            # classes included, this report may be useless and is disabled by
-            # default.
-            #
+            # Unless this test is for a completely comprehensive data profile,
+            # with all classes included, this report section may be useless.
             'documented_missing_resources'
           ]
 
           report_validators.each do |report_section|
             it "should have no issues with the '#{report_section}' report" do
               if compliance_profile_data[report_section]
-                # This just gets us a good print out of what went wrong
-                  compliance_profile_data[report_section].delete_if{ |item|
-                    rm = false
+                # remove any false alarms from compliance results
+                normalized = normalize_compliance_results(
+                  compliance_profile_data,
+                  report_section,
+                  info[:exceptions])
 
-                    Array(allowed_failures[report_section]).each do |allowed|
-                      if allowed.is_a?(Regexp)
-                        if allowed.match?(item)
-                          rm = true
-                          break
-                        end
-                      else
-                        rm = (allowed == item)
-                      end
-                    end
-
-                    rm
-                  }
-
-                expect(compliance_profile_data[report_section]).to eq([])
+                expect(normalized[report_section]).to be_empty
               end
             end
           end


### PR DESCRIPTION
- Updated the simp::nsswitch class to have sane defaults
  - Added support for mymachines and myhostname by default
  - Removed all NIS references since NIS should not be in general usage any
    longer and was never natively supported by SIMP
  - Configuration files are now common cross all supported OSs since nsswitch
    "does the right thing" when it hits a module that it does not recognize

SIMP-7562 #close