### PR TITLE
(SIMP-7592) Remove use of augeasproviders-shellvar

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -22,7 +22,6 @@ fixtures:
     augeasproviders_pam: https://github.com/simp/augeasproviders_pam
     augeasproviders_postgresql: https://github.com/simp/augeasproviders_postgresql
     augeasproviders_puppet: https://github.com/simp/augeasproviders_puppet
-    augeasproviders_shellvar: https://github.com/simp/augeasproviders_shellvar
     augeasproviders_ssh: https://github.com/simp/augeasproviders_ssh
     augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl
     autofs: https://github.com/simp/pupmod-simp-autofs
@@ -39,6 +38,9 @@ fixtures:
     datacat: https://github.com/simp/puppet-datacat
     dhcp: https://github.com/simp/pupmod-simp-dhcp
     fips: https://github.com/simp/pupmod-simp-fips
+    firewalld:
+      repo: https://github.com/simp/pupmod-voxpupuli-firewalld
+      ref: v4.2.2
     haveged: https://github.com/simp/pupmod-simp-haveged
     hocon: https://github.com/simp/pupmod-puppetlabs-hocon
     host_core:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
-* Wed Feb 26 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.11.0-0
+* Mon Mar 02 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.11.0-0
+- Replace the use of augeasproviders-shellvar with a direct augeas resource
 - Updated the simp::nsswitch class to have sane defaults
   - Added support for mymachines and myhostname by default
   - Removed all NIS references since NIS should not be in general usage any

--- a/manifests/prelink.pp
+++ b/manifests/prelink.pp
@@ -31,14 +31,14 @@ class simp::prelink (
       ensure => $ensure
     }
 
-    shellvar { 'enable prelink':
-      ensure   => present,
-      target   => '/etc/sysconfig/prelink',
-      variable => 'PRELINKING',
-      value    => 'yes'
+    augeas { 'enable prelink':
+      lens      => 'Shellvars.lns',
+      incl      => '/etc/sysconfig/prelink',
+      changes   => [
+        'set PRELINKING "yes"'
+      ],
+      subscribe => Package['prelink']
     }
-
-    Package['prelink'] ~> Shellvar['enable prelink']
   }
   else {
     if $facts['prelink'] {
@@ -47,12 +47,13 @@ class simp::prelink (
       # disable prelinking and then run /etc/cron.daily/prelink (from
       # the installed prelink package).
       if $facts['prelink']['enabled'] {
-        shellvar { 'disable prelink':
-          ensure   => present,
-          target   => '/etc/sysconfig/prelink',
-          variable => 'PRELINKING',
-          value    => 'no',
-          before   => Exec['remove prelinking']
+        augeas { 'disable prelink':
+          lens    => 'Shellvars.lns',
+          incl    => '/etc/sysconfig/prelink',
+          changes => [
+            'set PRELINKING "no"'
+          ],
+          before  => Exec['remove prelinking']
         }
       }
 

--- a/spec/classes/00_classes/prelink_spec.rb
+++ b/spec/classes/00_classes/prelink_spec.rb
@@ -52,12 +52,13 @@ describe 'simp::prelink' do
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to create_class('simp::prelink') }
             it {
-              is_expected.to contain_shellvar('disable prelink').with( {
-                :ensure   => 'present',
-                :target   => '/etc/sysconfig/prelink',
-                :variable => 'PRELINKING',
-                :value    => 'no',
-                :before   => 'Exec[remove prelinking]'
+              is_expected.to contain_augeas('disable prelink').with( {
+                :lens    => 'Shellvars.lns',
+                :incl    => '/etc/sysconfig/prelink',
+                :changes => [
+                  'set PRELINKING "no"'
+                ],
+                :before  => 'Exec[remove prelinking]'
               } )
             }
 
@@ -82,13 +83,14 @@ describe 'simp::prelink' do
 
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to create_class('simp::prelink') }
-            it { is_expected.to contain_package('prelink').that_comes_before('Shellvar[enable prelink]') }
             it {
-              is_expected.to contain_shellvar('enable prelink').with( {
-                :ensure   => 'present',
-                :target   => '/etc/sysconfig/prelink',
-                :variable => 'PRELINKING',
-                :value    => 'yes'
+              is_expected.to contain_augeas('enable prelink').with( {
+                :lens      => 'Shellvars.lns',
+                :incl      => '/etc/sysconfig/prelink',
+                :changes   => [
+                  'set PRELINKING "yes"'
+                ],
+                :subscribe => 'Package[prelink]'
               } )
              }
           end


### PR DESCRIPTION
* Replace the use of augeasproviders-shellvar with a direct augeas resource
  * This was the only location in the SIMP codebase that used it and the
    direct Augeas call is trivial

SIMP-7592 #close