### PR TITLE
(SIMP-7035) Update to new Travis CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,57 @@
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+# Release       Puppet   Ruby   EOL
+# SIMP 6.4      5.5      2.4    TBD
+# PE 2018.1     5.5      2.4    2020-11 (LTS)
+# PE 2019.2     6.10     2.5    2019-08 (STS)
 #
 # https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
-# ------------------------------------------------------------------------------
-# Release       Puppet   Ruby   EOL
-# PE 2017.3     5.3      2.4.5  2018-12-31
-# SIMP 6.3      5.5      2.4.5  TBD***
-# PE 2018.1     5.5      2.4.5  2020-05 (LTS)***
-# PE 2019.0     6.0      2.5.1  2019-08-31^^^
+# ==============================================================================
 #
-# *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-
+# Travis CI Repo options for this pipeline:
+#
+#   Travis CI Env Var      Type      Notes
+#   ---------------------  --------  -------------------------------------------
+#   GITHUB_OAUTH_TOKEN     Secure    Required for automated GitHub releases
+#   PUPPETFORGE_API_TOKEN  Secure    Required for automated Forge releases
+#   SKIP_GITHUB_PUBLISH    Optional  Skips publishing GitHub releases if "true"
+#   SKIP_FORGE_PUBLISH     Optional  Skips publishing to Puppet Forge if "true"
+#
+#   The secure env vars will be filtered in Travis CI log output, and aren't
+#   provided to untrusted builds (i.e, triggered by PR from another repository)
+#
+# ------------------------------------------------------------------------------
+#
+# Travis CI Trigger options for this pipeline:
+#
+#   To validate if $GITHUB_OAUTH_TOKEN is able to publish a GitHub release,
+#   trigger a custom Travis CI build for this branch using the CUSTOM CONFIG:
+#
+#     env: VALIDATE_TOKENS=yes
+#
+# ------------------------------------------------------------------------------
+#
+# Release Engineering notes:
+#
+#   To automagically publish a release to GitHub and PuppetForge:
+#
+#   - Set GITHUB_OAUTH_TOKEN and PUPPETFORGE_API_TOKEN as secure env variables
+#     in this repo's Travis CI settings
+#   - Push a git tag that matches the version in the module's `metadata.json`
+#   - The tag SHOULD be annotated with release notes, but nothing enforces this
+#     convention at present
+#
+# ------------------------------------------------------------------------------
+# NOTE: Unlike most SIMP Puppet modules, which use a standardized .travis.yml,
+#       this pipeline contains steps that are specific to testing simp-simp
+# ------------------------------------------------------------------------------
 ---
 language: ruby
 cache: bundler
-sudo: false
-
-stages:
-  - check
-  - spec
-  - slow_spec
-  - name: deploy
-    if: 'tag IS present'
+version: ~> 1.0
+os: linux
 
 bundler_args: --without development system_tests --path .vendor
 
@@ -35,18 +64,31 @@ addons:
       - rpm
 
 before_install:
-  - rm -f Gemfile.lock
   - for x in ${HOME}/.rvm/gems/*; do gem uninstall -I -x -i "${x}" -v '>= 1.17' bundler || true; gem uninstall -I -x -i "${x}@global" -v '>= 1.17' bundler || true; done
   - gem install -v '~> 1.17' bundler
+  - rm -f Gemfile.lock
 
-global:
-  - STRICT_VARIABLES=yes
+env:
+  global:
+    - 'FORGE_USER_AGENT="TravisCI-ForgeReleng-Script/0.3.3 (Purpose/forge-ops-for-${TRAVIS_REPO_SLUG})"'
+
+stages:
+  - name: 'validate tokens'
+    if: 'env(VALIDATE_TOKENS) = yes'
+  - name: check
+    if: 'NOT env(VALIDATE_TOKENS) = yes'
+  - name: spec
+    if: 'NOT env(VALIDATE_TOKENS) = yes'
+  - name: slow_spec
+    if: 'NOT env(VALIDATE_TOKENS) = yes'
+  - name: deploy
+    if: 'tag IS present AND NOT env(VALIDATE_TOKENS) = yes'
 
 jobs:
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
@@ -59,76 +101,29 @@ jobs:
         - bundle exec puppet module build
 
     - stage: spec
-      name: 'Puppet 5.3 (PE 2017.3) - Classes - 00'
-      rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.3.0"
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/classes/00_classes
-
-    - stage: slow_spec
-      name: 'Puppet 5.3 (PE 2017.3) - Classes - 10'
-      rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.3.0"
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/classes/10_classes
-
-    - stage: slow_spec
-      name: 'Puppet 5.3 (PE 2017.3) - Classes - 20'
-      rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.3.0"
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/classes/20_classes
-
-    - stage: spec
-      name: 'Puppet 5.3 (PE 2017.3) - Compliance Engine EL6'
-      rvm: 2.4.5
-      env:
-        - PUPPET_VERSION="~> 5.3.0"
-        - RSPEC_COMPLIANCE_ENGINE_OS='centos-6'
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/unit
-
-    - stage: spec
-      name: 'Puppet 5.3 (PE 2017.3) - Compliance Engine EL7'
-      rvm: 2.4.5
-      env:
-        - PUPPET_VERSION="~> 5.3.0"
-        - RSPEC_COMPLIANCE_ENGINE_OS='centos-7'
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/unit
-
-    - stage: spec
-      name: 'Puppet 5.3 (PE 2017.3) - Fast'
-      rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.3.0"
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/facter
-        - bundle exec rspec spec/functions
-
-    - stage: spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Classes - 00'
+      rvm: 2.4.9
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1) - Classes - 00'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/00_classes
 
     - stage: slow_spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Classes - 10'
+      rvm: 2.4.9
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1) - Classes - 10'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/10_classes
 
     - stage: slow_spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Classes - 20'
+      rvm: 2.4.9
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1) - Classes - 20'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/20_classes
 
     - stage: spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Compliance Engine EL6'
+      rvm: 2.4.9
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1) - Compliance Engine EL6'
       env:
         - PUPPET_VERSION="~> 5.5.0"
         - RSPEC_COMPLIANCE_ENGINE_OS='centos-6'
@@ -136,8 +131,8 @@ jobs:
         - bundle exec rake spec_prep && bundle exec rspec spec/unit
 
     - stage: spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Compliance Engine EL7'
+      rvm: 2.4.9
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1) - Compliance Engine EL7'
       env:
         - PUPPET_VERSION="~> 5.5.0"
         - RSPEC_COMPLIANCE_ENGINE_OS='centos-7'
@@ -145,8 +140,8 @@ jobs:
         - bundle exec rake spec_prep && bundle exec rspec spec/unit
 
     - stage: spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Fast'
+      rvm: 2.4.9
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1) - Fast'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/facter
@@ -154,28 +149,28 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 5.x Classes - 00'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/00_classes
 
     - stage: slow_spec
       name: 'Latest Puppet 5.x Classes - 10'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/10_classes
 
     - stage: slow_spec
       name: 'Latest Puppet 5.x Classes - 20'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/20_classes
 
     - stage: spec
       name: 'Latest Puppet 5.x - Compliance Engine EL6'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env:
         - PUPPET_VERSION="~> 5.0"
         - RSPEC_COMPLIANCE_ENGINE_OS='centos-6'
@@ -184,7 +179,7 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 5.x - Compliance Engine EL7'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env:
         - PUPPET_VERSION="~> 5.0"
         - RSPEC_COMPLIANCE_ENGINE_OS='centos-7'
@@ -193,7 +188,7 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 5.x - Fast'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/facter
@@ -201,28 +196,28 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 6.x - Classes - 00'
-      rvm: 2.5.1
+      rvm: 2.5.7
       env: PUPPET_VERSION="~> 6.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/00_classes
 
     - stage: slow_spec
       name: 'Latest Puppet 6.x - Classes - 10'
-      rvm: 2.5.1
+      rvm: 2.5.7
       env: PUPPET_VERSION="~> 6.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/10_classes
 
     - stage: slow_spec
       name: 'Latest Puppet 6.x - Classes - 20'
-      rvm: 2.5.1
+      rvm: 2.5.7
       env: PUPPET_VERSION="~> 6.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/20_classes
 
     - stage: spec
       name: 'Latest Puppet 6.x - Compliance Engine EL6'
-      rvm: 2.5.1
+      rvm: 2.5.7
       env:
         - PUPPET_VERSION="~> 6.0"
         - RSPEC_COMPLIANCE_ENGINE_OS='centos-6'
@@ -231,7 +226,7 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 6.x - Compliance Engine EL7'
-      rvm: 2.5.1
+      rvm: 2.5.7
       env:
         - PUPPET_VERSION="~> 6.0"
         - RSPEC_COMPLIANCE_ENGINE_OS='centos-7'
@@ -240,31 +235,56 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 6.x - Fast'
-      rvm: 2.5.1
+      rvm: 2.5.7
       env: PUPPET_VERSION="~> 6.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/facter
         - bundle exec rspec spec/functions
 
     - stage: deploy
-      rvm: 2.4.5
+      rvm: 2.4.9
+      env: PUPPET_VERSION="~> 5.5.0"
       script:
         - true
       before_deploy:
         - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+        - '[[ $TRAVIS_TAG =~ ^poxvup-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+        - 'gem install -v "~> 5.5.0" puppet'
+        - 'git clean -f -x -d'
+        - 'puppet module build'
+        - 'find pkg -name ''*.tar.gz'''
       deploy:
-        - provider: releases
-          api_key:
-            secure: "Xu84X+7tUMAzO2qCw53d2Gq2tcg99+oTqAuIuSlB0gDxQL7lkWcjPWPf3CE9jmgu4C4fw56R4ZX2oYW3m0+mtcPCKDoJAFKwFswMImDbdYcfTLCr4Hn3I+yxqjw7ls6Zlr7XL4o9mfWbZhM/1eF2iWdDdcBzMhlzHxe7eD0J+K/N0VSWgJTRFhHercyUsOgr2aXZz0CwQPU4zHzd2uZaTGUUoX9nK9nSb6Ro64sefzaviUBuLJjt9T2v6YuKibXHKwXYCgpHG3anwOwS/SuGPMszOoGuR0KtGCF6McLtAOtsHYGn4CXL3CbB03rYYZ4TRHX7Av9qGwS79LcY+bDVEnCs5Hebim14W0t4N+rk5hB7uglvYP/X/BeBp40SvEzhNiT/o2k80Q+toUN17avyjBm5knvRmlzFBSXT8aI75FDv8/LJ5Mdq+N6c3QrUoGOayNWtjeabC0alGLC9mAPLyiR47SeniumrkndLkRPqw8iWqDoe7jSPTbeK4T5IebqhwWg8bCXDUCA6iMNHOXzy74enRuoPXUVl+zM64d5ISwHDN8O59TZrqU6MSzPeYWm+hCeB+MhuulubiNlwLe+UkKQLTh8CqvNBX/6DdWPuYvEDjW/gK644Bh9TcpWH6x0oP8SkihZKSrXBNF3eenYhU4ph7kwkxxX86HE24aasU7c="
+        - provider: script
           skip_cleanup: true
+          script: 'curl -sS --fail -A "$FORGE_USER_AGENT" -H "Authorization: Bearer ${PUPPETFORGE_API_TOKEN}" -X POST -F "file=@$(find $PWD/pkg -name ''*.tar.gz'')" https://forgeapi.puppet.com/v3/releases'
           on:
             tags: true
             condition: '($SKIP_FORGE_PUBLISH != true)'
-        - provider: puppetforge
-          user: simp
-          password:
-            secure: "NR5lPHTfp142XIW5nowolBMFitPaaXpLiO9IvNXU3u00cZCOQmdU8fKWZPqKcUf8izV8EK9p5KCOSd956XxwrCyuwNEq6Z26WAydU6MN8qMKW7ucfm+xcURWQPKQ19MX5pNSaLOXemFvva2kuZF1rkwCYoSHJeBXDfLusBau56b9cIbX8BxNfkqPVzbNu1LioQkXTJ8Qt0u/hmRZy4593E6O5I6Hblh2lPKugNv+LpsUqwCGll1hvnTu0SJJEPZBYlKuC34qfsnqErT+eSOjLNGhxkPy3JVfwP4GRQbw2rFWNMzaPC/i6LGuB9GMPuUNjJHpZyl2+k33f9vFwfZiWoqIwJTRQTnXsbSa/amgtlaFX//43n9NMMPrI9WryoiYHTWQGiDxNuzqN6qjtthUlNfPBovsaqSsmcW9XELhsMxoo/t1G6LQWqEiCq5FB/bsnEig24CJeRELHL42A3bii+VWiBl/kgMEd/ju3J0VIqbLKIJcPQWhcomW5YGMf8Q9+FNZPyA4i3ebwwehh+etfND6+d3DOeXE84ZGLtJppELRwbgvJO/JWE/qxCdNSO4Nh3No+rRqXal3IESQBkfawuQoLIMBod7MCrRzo5d4J1asyoFJU+FMLRYjCcgaMUudUNViux6g86Cfav9rTDmhs7zdIZxaCOSNgLv9gfNu6AY="
+        - provider: releases
+          token: $GITHUB_OAUTH_TOKEN
           on:
             tags: true
-            condition: '($SKIP_FORGE_PUBLISH != true)'
+            condition: '($SKIP_GITHUB_PUBLISH != true)'
+
+    - stage: 'validate tokens'
+      language: shell
+      before_install: skip
+      install: skip
+      name:  'validate CI GitHub OAuth token has sufficient scope to release'
+      script:
+      - 'echo; echo "===== GITHUB_OAUTH_TOKEN validation";echo "  (TRAVIS_SECURE_ENV_VARS=$TRAVIS_SECURE_ENV_VARS)"; echo'
+      - 'OWNER="$(echo $TRAVIS_REPO_SLUG | cut -d/ -f1)"'
+      - 'curl -H "Authorization: token ${GITHUB_OAUTH_TOKEN}"
+          "https://api.github.com/users/$OWNER"
+          -I | grep ^X-OAuth-Scopes | egrep -w "repo|public_repo"'
+
+    - stage: 'validate tokens'
+      name:  'validate CI Puppet Forge token authenticates with API'
+      language: shell
+      before_install: skip
+      install: skip
+      script:
+      - 'echo; echo "===== PUPPETFORGE_API_TOKEN validation"; echo "  (TRAVIS_SECURE_ENV_VARS=$TRAVIS_SECURE_ENV_VARS)"; echo'
+      - 'curl -sS --fail -A "$FORGE_USER_AGENT"
+         -H "Authorization: Bearer ${PUPPETFORGE_API_TOKEN:-default_content_to_cause_401_response}"
+         https://forgeapi.puppet.com/v3/users > /dev/null'


### PR DESCRIPTION
This patch updates the Travis Pipeline to a static, standardized format
that uses project variables for secrets. It includes an optional
diagnostic mode to test the project's variables against their respective
deployment APIs (GitHub and Puppet Forge).

[SIMP-7035] #comment Update to latest pipeline in pupmod-simp-simp
SIMP-7661 #close

[SIMP-7035]: https://simp-project.atlassian.net/browse/SIMP-7035