### PR TITLE
(SIMP-7848) Add PE2019.8 to pupmod-simp-simp GL pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,14 +3,14 @@
 # ------------------------------------------------------------------------------
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
-# https://puppet.com/docs/pe/2019.5/component_versions_in_recent_pe_releases.html
+# https://puppet.com/docs/pe/2019.8/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
-# Release       Puppet   Ruby   EOL
-# SIMP 6.4      5.5      2.4.5  TBD
-# PE 2018.1     5.5      2.4.5  2020-11 (LTS)
-# PE 2019.5     6.14     2.5.7  Quarterly
+# Release       Puppet   Ruby    EOL
+# SIMP 6.4      5.5      2.4.10  TBD
+# PE 2018.1     5.5      2.4.10  2021-01 (LTS overlap)
+# PE 2019.8     6.16     2.5.7   2021-11 (LTS)
 ---
 stages:
   - 'sanity'
@@ -80,6 +80,13 @@ variables:
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '~> 6.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet6'
+    MATRIX_RUBY_VERSION: '2.5'
+
+.pup_6_16_0: &pup_6_16_0
+  image: 'ruby:2.5'
+  variables:
+    PUPPET_VERSION: '6.16.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
@@ -155,6 +162,10 @@ pup5.5.17-unit:
 
 pup6-unit:
   <<: *pup_6
+  <<: *unit_tests
+
+pup6.16.0-unit:
+  <<: *pup_6_16_0
   <<: *unit_tests
 
 # Repo-specific content
@@ -280,3 +291,40 @@ pup6-win:
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[win_client]'
+
+pup6.16.0:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default]'
+
+pup6.16.0-base-apps:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[base_apps]'
+
+pup6.16.0-fips:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
+
+pup6.16.0-netconsole:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[netconsole]'
+
+pup6.16.0-oel:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,oel]'
+
+pup6.16.0-oel-fips:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  <<: *only_with_SIMP_FULL_MATRIX
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,57 @@
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+# Release       Puppet   Ruby   EOL
+# SIMP 6.4      5.5      2.4    TBD
+# PE 2018.1     5.5      2.4    2020-11 (LTS)
+# PE 2019.2     6.10     2.5    2019-08 (STS)
 #
 # https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
-# ------------------------------------------------------------------------------
-# Release       Puppet   Ruby   EOL
-# PE 2017.3     5.3      2.4.5  2018-12-31
-# SIMP 6.3      5.5      2.4.5  TBD***
-# PE 2018.1     5.5      2.4.5  2020-05 (LTS)***
-# PE 2019.0     6.0      2.5.1  2019-08-31^^^
+# ==============================================================================
 #
-# *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-
+# Travis CI Repo options for this pipeline:
+#
+#   Travis CI Env Var      Type      Notes
+#   ---------------------  --------  -------------------------------------------
+#   GITHUB_OAUTH_TOKEN     Secure    Required for automated GitHub releases
+#   PUPPETFORGE_API_TOKEN  Secure    Required for automated Forge releases
+#   SKIP_GITHUB_PUBLISH    Optional  Skips publishing GitHub releases if "true"
+#   SKIP_FORGE_PUBLISH     Optional  Skips publishing to Puppet Forge if "true"
+#
+#   The secure env vars will be filtered in Travis CI log output, and aren't
+#   provided to untrusted builds (i.e, triggered by PR from another repository)
+#
+# ------------------------------------------------------------------------------
+#
+# Travis CI Trigger options for this pipeline:
+#
+#   To validate if $GITHUB_OAUTH_TOKEN is able to publish a GitHub release,
+#   trigger a custom Travis CI build for this branch using the CUSTOM CONFIG:
+#
+#     env: VALIDATE_TOKENS=yes
+#
+# ------------------------------------------------------------------------------
+#
+# Release Engineering notes:
+#
+#   To automagically publish a release to GitHub and PuppetForge:
+#
+#   - Set GITHUB_OAUTH_TOKEN and PUPPETFORGE_API_TOKEN as secure env variables
+#     in this repo's Travis CI settings
+#   - Push a git tag that matches the version in the module's `metadata.json`
+#   - The tag SHOULD be annotated with release notes, but nothing enforces this
+#     convention at present
+#
+# ------------------------------------------------------------------------------
+# NOTE: Unlike most SIMP Puppet modules, which use a standardized .travis.yml,
+#       this pipeline contains steps that are specific to testing simp-simp
+# ------------------------------------------------------------------------------
 ---
 language: ruby
 cache: bundler
-sudo: false
-
-stages:
-  - check
-  - spec
-  - slow_spec
-  - name: deploy
-    if: 'tag IS present'
+version: ~> 1.0
+os: linux
 
 bundler_args: --without development system_tests --path .vendor
 
@@ -35,18 +64,31 @@ addons:
       - rpm
 
 before_install:
-  - rm -f Gemfile.lock
   - for x in ${HOME}/.rvm/gems/*; do gem uninstall -I -x -i "${x}" -v '>= 1.17' bundler || true; gem uninstall -I -x -i "${x}@global" -v '>= 1.17' bundler || true; done
   - gem install -v '~> 1.17' bundler
+  - rm -f Gemfile.lock
 
-global:
-  - STRICT_VARIABLES=yes
+env:
+  global:
+    - 'FORGE_USER_AGENT="TravisCI-ForgeReleng-Script/0.3.3 (Purpose/forge-ops-for-${TRAVIS_REPO_SLUG})"'
+
+stages:
+  - name: 'validate tokens'
+    if: 'env(VALIDATE_TOKENS) = yes'
+  - name: check
+    if: 'NOT env(VALIDATE_TOKENS) = yes'
+  - name: spec
+    if: 'NOT env(VALIDATE_TOKENS) = yes'
+  - name: slow_spec
+    if: 'NOT env(VALIDATE_TOKENS) = yes'
+  - name: deploy
+    if: 'tag IS present AND NOT env(VALIDATE_TOKENS) = yes'
 
 jobs:
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
@@ -59,76 +101,29 @@ jobs:
         - bundle exec puppet module build
 
     - stage: spec
-      name: 'Puppet 5.3 (PE 2017.3) - Classes - 00'
-      rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.3.0"
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/classes/00_classes
-
-    - stage: slow_spec
-      name: 'Puppet 5.3 (PE 2017.3) - Classes - 10'
-      rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.3.0"
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/classes/10_classes
-
-    - stage: slow_spec
-      name: 'Puppet 5.3 (PE 2017.3) - Classes - 20'
-      rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.3.0"
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/classes/20_classes
-
-    - stage: spec
-      name: 'Puppet 5.3 (PE 2017.3) - Compliance Engine EL6'
-      rvm: 2.4.5
-      env:
-        - PUPPET_VERSION="~> 5.3.0"
-        - RSPEC_COMPLIANCE_ENGINE_OS='centos-6'
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/unit
-
-    - stage: spec
-      name: 'Puppet 5.3 (PE 2017.3) - Compliance Engine EL7'
-      rvm: 2.4.5
-      env:
-        - PUPPET_VERSION="~> 5.3.0"
-        - RSPEC_COMPLIANCE_ENGINE_OS='centos-7'
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/unit
-
-    - stage: spec
-      name: 'Puppet 5.3 (PE 2017.3) - Fast'
-      rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.3.0"
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/facter
-        - bundle exec rspec spec/functions
-
-    - stage: spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Classes - 00'
+      rvm: 2.4.9
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1) - Classes - 00'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/00_classes
 
     - stage: slow_spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Classes - 10'
+      rvm: 2.4.9
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1) - Classes - 10'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/10_classes
 
     - stage: slow_spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Classes - 20'
+      rvm: 2.4.9
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1) - Classes - 20'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/20_classes
 
     - stage: spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Compliance Engine EL6'
+      rvm: 2.4.9
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1) - Compliance Engine EL6'
       env:
         - PUPPET_VERSION="~> 5.5.0"
         - RSPEC_COMPLIANCE_ENGINE_OS='centos-6'
@@ -136,8 +131,8 @@ jobs:
         - bundle exec rake spec_prep && bundle exec rspec spec/unit
 
     - stage: spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Compliance Engine EL7'
+      rvm: 2.4.9
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1) - Compliance Engine EL7'
       env:
         - PUPPET_VERSION="~> 5.5.0"
         - RSPEC_COMPLIANCE_ENGINE_OS='centos-7'
@@ -145,84 +140,84 @@ jobs:
         - bundle exec rake spec_prep && bundle exec rspec spec/unit
 
     - stage: spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Fast'
+      rvm: 2.4.9
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1) - Fast'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/facter
         - bundle exec rspec spec/functions
 
-    - stage: spec
-      name: 'Latest Puppet 5.x Classes - 00'
-      rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.0"
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/classes/00_classes
-
-    - stage: slow_spec
-      name: 'Latest Puppet 5.x Classes - 10'
-      rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.0"
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/classes/10_classes
-
-    - stage: slow_spec
-      name: 'Latest Puppet 5.x Classes - 20'
-      rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.0"
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/classes/20_classes
-
-    - stage: spec
-      name: 'Latest Puppet 5.x - Compliance Engine EL6'
-      rvm: 2.4.5
-      env:
-        - PUPPET_VERSION="~> 5.0"
-        - RSPEC_COMPLIANCE_ENGINE_OS='centos-6'
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/unit
-
-    - stage: spec
-      name: 'Latest Puppet 5.x - Compliance Engine EL7'
-      rvm: 2.4.5
-      env:
-        - PUPPET_VERSION="~> 5.0"
-        - RSPEC_COMPLIANCE_ENGINE_OS='centos-7'
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/unit
-
-    - stage: spec
-      name: 'Latest Puppet 5.x - Fast'
-      rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.0"
-      script:
-        - bundle exec rake spec_prep && bundle exec rspec spec/facter
-        - bundle exec rspec spec/functions
-
+          ###    - stage: spec
+          ###      name: 'Latest Puppet 5.x Classes - 00'
+          ###      rvm: 2.4.9
+          ###      env: PUPPET_VERSION="~> 5.0"
+          ###      script:
+          ###        - bundle exec rake spec_prep && bundle exec rspec spec/classes/00_classes
+          ###
+          ###    - stage: slow_spec
+          ###      name: 'Latest Puppet 5.x Classes - 10'
+          ###      rvm: 2.4.9
+          ###      env: PUPPET_VERSION="~> 5.0"
+          ###      script:
+          ###        - bundle exec rake spec_prep && bundle exec rspec spec/classes/10_classes
+          ###
+          ###    - stage: slow_spec
+          ###      name: 'Latest Puppet 5.x Classes - 20'
+          ###      rvm: 2.4.9
+          ###      env: PUPPET_VERSION="~> 5.0"
+          ###      script:
+          ###        - bundle exec rake spec_prep && bundle exec rspec spec/classes/20_classes
+          ###
+          ###    - stage: spec
+          ###      name: 'Latest Puppet 5.x - Compliance Engine EL6'
+          ###      rvm: 2.4.9
+          ###      env:
+          ###        - PUPPET_VERSION="~> 5.0"
+          ###        - RSPEC_COMPLIANCE_ENGINE_OS='centos-6'
+          ###      script:
+          ###        - bundle exec rake spec_prep && bundle exec rspec spec/unit
+          ###
+          ###    - stage: spec
+          ###      name: 'Latest Puppet 5.x - Compliance Engine EL7'
+          ###      rvm: 2.4.9
+          ###      env:
+          ###        - PUPPET_VERSION="~> 5.0"
+          ###        - RSPEC_COMPLIANCE_ENGINE_OS='centos-7'
+          ###      script:
+          ###        - bundle exec rake spec_prep && bundle exec rspec spec/unit
+          ###
+          ###    - stage: spec
+          ###      name: 'Latest Puppet 5.x - Fast'
+          ###      rvm: 2.4.9
+          ###      env: PUPPET_VERSION="~> 5.0"
+          ###      script:
+          ###        - bundle exec rake spec_prep && bundle exec rspec spec/facter
+          ###        - bundle exec rspec spec/functions
+          ###
     - stage: spec
       name: 'Latest Puppet 6.x - Classes - 00'
-      rvm: 2.5.1
+      rvm: 2.5.7
       env: PUPPET_VERSION="~> 6.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/00_classes
 
     - stage: slow_spec
       name: 'Latest Puppet 6.x - Classes - 10'
-      rvm: 2.5.1
+      rvm: 2.5.7
       env: PUPPET_VERSION="~> 6.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/10_classes
 
     - stage: slow_spec
       name: 'Latest Puppet 6.x - Classes - 20'
-      rvm: 2.5.1
+      rvm: 2.5.7
       env: PUPPET_VERSION="~> 6.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/classes/20_classes
 
     - stage: spec
       name: 'Latest Puppet 6.x - Compliance Engine EL6'
-      rvm: 2.5.1
+      rvm: 2.5.7
       env:
         - PUPPET_VERSION="~> 6.0"
         - RSPEC_COMPLIANCE_ENGINE_OS='centos-6'
@@ -231,7 +226,7 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 6.x - Compliance Engine EL7'
-      rvm: 2.5.1
+      rvm: 2.5.7
       env:
         - PUPPET_VERSION="~> 6.0"
         - RSPEC_COMPLIANCE_ENGINE_OS='centos-7'
@@ -240,31 +235,56 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 6.x - Fast'
-      rvm: 2.5.1
+      rvm: 2.5.7
       env: PUPPET_VERSION="~> 6.0"
       script:
         - bundle exec rake spec_prep && bundle exec rspec spec/facter
         - bundle exec rspec spec/functions
 
     - stage: deploy
-      rvm: 2.4.5
+      rvm: 2.4.9
+      env: PUPPET_VERSION="~> 5.5.0"
       script:
         - true
       before_deploy:
         - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
         - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+        - 'gem install -v "~> 5.5.0" puppet'
+        - 'git clean -f -x -d'
+        - 'puppet module build'
+        - 'find pkg -name ''*.tar.gz'''
       deploy:
-        - provider: releases
-          api_key:
-            secure: "Xu84X+7tUMAzO2qCw53d2Gq2tcg99+oTqAuIuSlB0gDxQL7lkWcjPWPf3CE9jmgu4C4fw56R4ZX2oYW3m0+mtcPCKDoJAFKwFswMImDbdYcfTLCr4Hn3I+yxqjw7ls6Zlr7XL4o9mfWbZhM/1eF2iWdDdcBzMhlzHxe7eD0J+K/N0VSWgJTRFhHercyUsOgr2aXZz0CwQPU4zHzd2uZaTGUUoX9nK9nSb6Ro64sefzaviUBuLJjt9T2v6YuKibXHKwXYCgpHG3anwOwS/SuGPMszOoGuR0KtGCF6McLtAOtsHYGn4CXL3CbB03rYYZ4TRHX7Av9qGwS79LcY+bDVEnCs5Hebim14W0t4N+rk5hB7uglvYP/X/BeBp40SvEzhNiT/o2k80Q+toUN17avyjBm5knvRmlzFBSXT8aI75FDv8/LJ5Mdq+N6c3QrUoGOayNWtjeabC0alGLC9mAPLyiR47SeniumrkndLkRPqw8iWqDoe7jSPTbeK4T5IebqhwWg8bCXDUCA6iMNHOXzy74enRuoPXUVl+zM64d5ISwHDN8O59TZrqU6MSzPeYWm+hCeB+MhuulubiNlwLe+UkKQLTh8CqvNBX/6DdWPuYvEDjW/gK644Bh9TcpWH6x0oP8SkihZKSrXBNF3eenYhU4ph7kwkxxX86HE24aasU7c="
+        - provider: script
           skip_cleanup: true
+          script: 'curl -sS --fail -A "$FORGE_USER_AGENT" -H "Authorization: Bearer ${PUPPETFORGE_API_TOKEN}" -X POST -F "file=@$(find $PWD/pkg -name ''*.tar.gz'')" https://forgeapi.puppet.com/v3/releases'
           on:
             tags: true
             condition: '($SKIP_FORGE_PUBLISH != true)'
-        - provider: puppetforge
-          user: simp
-          password:
-            secure: "NR5lPHTfp142XIW5nowolBMFitPaaXpLiO9IvNXU3u00cZCOQmdU8fKWZPqKcUf8izV8EK9p5KCOSd956XxwrCyuwNEq6Z26WAydU6MN8qMKW7ucfm+xcURWQPKQ19MX5pNSaLOXemFvva2kuZF1rkwCYoSHJeBXDfLusBau56b9cIbX8BxNfkqPVzbNu1LioQkXTJ8Qt0u/hmRZy4593E6O5I6Hblh2lPKugNv+LpsUqwCGll1hvnTu0SJJEPZBYlKuC34qfsnqErT+eSOjLNGhxkPy3JVfwP4GRQbw2rFWNMzaPC/i6LGuB9GMPuUNjJHpZyl2+k33f9vFwfZiWoqIwJTRQTnXsbSa/amgtlaFX//43n9NMMPrI9WryoiYHTWQGiDxNuzqN6qjtthUlNfPBovsaqSsmcW9XELhsMxoo/t1G6LQWqEiCq5FB/bsnEig24CJeRELHL42A3bii+VWiBl/kgMEd/ju3J0VIqbLKIJcPQWhcomW5YGMf8Q9+FNZPyA4i3ebwwehh+etfND6+d3DOeXE84ZGLtJppELRwbgvJO/JWE/qxCdNSO4Nh3No+rRqXal3IESQBkfawuQoLIMBod7MCrRzo5d4J1asyoFJU+FMLRYjCcgaMUudUNViux6g86Cfav9rTDmhs7zdIZxaCOSNgLv9gfNu6AY="
+        - provider: releases
+          token: $GITHUB_OAUTH_TOKEN
           on:
             tags: true
-            condition: '($SKIP_FORGE_PUBLISH != true)'
+            condition: '($SKIP_GITHUB_PUBLISH != true)'
+
+    - stage: 'validate tokens'
+      language: shell
+      before_install: skip
+      install: skip
+      name:  'validate CI GitHub OAuth token has sufficient scope to release'
+      script:
+      - 'echo; echo "===== GITHUB_OAUTH_TOKEN validation";echo "  (TRAVIS_SECURE_ENV_VARS=$TRAVIS_SECURE_ENV_VARS)"; echo'
+      - 'OWNER="$(echo $TRAVIS_REPO_SLUG | cut -d/ -f1)"'
+      - 'curl -H "Authorization: token ${GITHUB_OAUTH_TOKEN}"
+          "https://api.github.com/users/$OWNER"
+          -I | grep ^X-OAuth-Scopes | egrep -w "repo|public_repo"'
+
+    - stage: 'validate tokens'
+      name:  'validate CI Puppet Forge token authenticates with API'
+      language: shell
+      before_install: skip
+      install: skip
+      script:
+      - 'echo; echo "===== PUPPETFORGE_API_TOKEN validation"; echo "  (TRAVIS_SECURE_ENV_VARS=$TRAVIS_SECURE_ENV_VARS)"; echo'
+      - 'curl -sS --fail -A "$FORGE_USER_AGENT"
+         -H "Authorization: Bearer ${PUPPETFORGE_API_TOKEN:-default_content_to_cause_401_response}"
+         https://forgeapi.puppet.com/v3/users > /dev/null'

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,14 @@
-# ------------------------------------------------------------------------------
-# NOTE: SIMP Puppet rake tasks support ruby 2.1.9
-# ------------------------------------------------------------------------------
 gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
+
+ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 5.5'
+  major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
-  gem 'puppet', ENV.fetch('PUPPET_VERSION', '~> 5.5')
+  gem 'puppet', puppet_version
   gem 'rspec'
   gem 'rspec-puppet'
   gem 'hiera-puppet-helper'
@@ -16,20 +17,32 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', ['>= 3.1.1', '< 4.0.0'])
-
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.10.2', '< 6.0.0'])
-  gem 'facterdb'
+  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['> 5.11', '< 6']
+  gem( 'pdk', ENV['PDK_VERSION'] || '~> 1.0', :require => false) if major_puppet_version > 5
 end
 
 group :development do
   gem 'pry'
+  gem 'pry-byebug'
   gem 'pry-doc'
 end
 
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'beaker-windows'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.18.2', '< 2.0.0'])
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.18.7', '< 2']
+end
+
+# Evaluate extra gemfiles if they exist
+extra_gemfiles = [
+  ENV['EXTRA_GEMFILE'] || '',
+  "#{__FILE__}.project",
+  "#{__FILE__}.local",
+  File.join(Dir.home, '.gemfile'),
+]
+extra_gemfiles.each do |gemfile|
+  if File.file?(gemfile) && File.readable?(gemfile)
+    eval(File.read(gemfile), binding)
+  end
 end


### PR DESCRIPTION
This patch updates the puppet and ruby versions in the Gitlab CI
pipeline to reflect the latest PE LTS releases.  Most notably, it adds
specific tests for PE2019.8 LTS.

SIMP-7921 #close
[SIMP-7848] #comment Add PE2019.8 to GL CI in pupmod-simp-simp
[SIMP-7855] #comment Update GL CI to PE2018.1.15 in pupmod-simp-simp

[SIMP-7848]: https://simp-project.atlassian.net/browse/SIMP-7848
[SIMP-7855]: https://simp-project.atlassian.net/browse/SIMP-7855