### PR TITLE
(SIMP-8075) Update Dependencies for 6.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,6 @@
 * Tue Aug 04 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.11.1-0
 - Align OpenLDAP terminology with vendor changes
 
->>>>>>> (SIMP-8075) Update dependencies for SIMP
 * Mon Mar 30 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.11.0-0
 - The following applications have been removed from the base os applications
   installed automatically by simp:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
+* Tue Aug 18 2020 Jeanne Greulich  <jeannegreulich@onyxpoint.com> - 4.11.1-0
+- changed the upper bounds for dependencies for simp_apache and pupmod
+- corrected version numbering for chrony
+
 * Tue Aug 04 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.11.1-0
 - Align OpenLDAP terminology with vendor changes
 
+>>>>>>> (SIMP-8075) Update dependencies for SIMP
 * Mon Mar 30 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.11.0-0
 - The following applications have been removed from the base os applications
   installed automatically by simp:

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
+  gem 'beaker-windows'
   gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.18.7', '< 2']
 end
 

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": [
     {
-      "name": "aboe76/chrony",
+      "name": "aboe/chrony",
       "version_requirement": ">= 0.3.1 < 1.0.0"
     },
     {
@@ -109,7 +109,7 @@
     },
     {
       "name": "simp/pupmod",
-      "version_requirement": ">= 7.1.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/resolv",
@@ -129,7 +129,7 @@
     },
     {
       "name": "simp/simp_apache",
-      "version_requirement": ">= 6.0.1 < 7.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     },
     {
       "name": "simp/simp_openldap",

--- a/spec/acceptance/suites/default/00_simp_spec.rb
+++ b/spec/acceptance/suites/default/00_simp_spec.rb
@@ -31,6 +31,7 @@ describe 'simp class' do
         apply_manifest_on(host, manifest, :accept_all_exit_codes => true)
         apply_manifest_on(host, manifest, :accept_all_exit_codes => true)
         host.reboot
+        sleep(20)
         apply_manifest_on(host, manifest, :catch_failures => true)
       end
 

--- a/spec/acceptance/suites/netconsole/netconsole_spec.rb
+++ b/spec/acceptance/suites/netconsole/netconsole_spec.rb
@@ -59,6 +59,11 @@ describe 'simp::netconsole class' do
 
       it "should unconfigure the shipper (#{shipper.name})" do
         apply_manifest_on(shipper, remove_manifest, catch_failures: true)
+        # host.reboot checks the previous and current boot times to see if reboot
+        # was successful.  It uses who -b which only is only accurate to 1 minute.
+        # Need to make sure that this  reboot happens at least 60 seconds after the previous
+        # one because  spiffy fast machines will do the tests an reboot too quickly.
+        sleep 40
         shipper.reboot
       end
     end


### PR DESCRIPTION
    - update the upper bounds for simp module dependencies.  These included
       - pupmod
       - simp_apache
    - correct the version number for chrony module dependency.
    - add beaker-windows to the gem file for windows tests.
    - netconsole test was rebooting to quickly.  beaker checks
      to see that boot time has changed using who -b which is only accurate
      to the minute.  Had to put a sleep in to make sure boot time changed.
      https://www.rubydoc.info/github/puppetlabs/beaker/Unix%2FExec:reboot
    
    SIMP-8075 #comment updated boundaries simp
