### PR TITLE
(SIMP-8075) Updated Dependencides for 6.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Aug 18 2020 Jeanne Greulich  <jeannegreulich@onyxpoint.com> - 4.11.1-0
+- changed the upper bounds for dependencies for simp_apache and pupmod
+- corrected version numbering for chrony
+
 * Tue Aug 04 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.11.1-0
 - Align OpenLDAP terminology with vendor changes
 

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": [
     {
-      "name": "aboe76/chrony",
+      "name": "aboe/chrony",
       "version_requirement": ">= 0.3.1 < 1.0.0"
     },
     {
@@ -109,7 +109,7 @@
     },
     {
       "name": "simp/pupmod",
-      "version_requirement": ">= 7.1.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/resolv",
@@ -129,7 +129,7 @@
     },
     {
       "name": "simp/simp_apache",
-      "version_requirement": ">= 6.0.1 < 7.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     },
     {
       "name": "simp/simp_openldap",

--- a/spec/acceptance/suites/default/00_simp_spec.rb
+++ b/spec/acceptance/suites/default/00_simp_spec.rb
@@ -31,6 +31,7 @@ describe 'simp class' do
         apply_manifest_on(host, manifest, :accept_all_exit_codes => true)
         apply_manifest_on(host, manifest, :accept_all_exit_codes => true)
         host.reboot
+        sleep(20)
         apply_manifest_on(host, manifest, :catch_failures => true)
       end
 

--- a/spec/acceptance/suites/netconsole/netconsole_spec.rb
+++ b/spec/acceptance/suites/netconsole/netconsole_spec.rb
@@ -59,6 +59,11 @@ describe 'simp::netconsole class' do
 
       it "should unconfigure the shipper (#{shipper.name})" do
         apply_manifest_on(shipper, remove_manifest, catch_failures: true)
+        # host.reboot checks the previous and current boot times to see if reboot
+        # was successful.  It uses who -b which only is only accurate to 1 minute.
+        # Need to make sure that this  reboot happens at least 60 seconds after the previous
+        # one because  spiffy fast machines will do the tests an reboot too quickly.
+        sleep 60
         shipper.reboot
       end
     end

--- a/spec/acceptance/suites/win_client/nodesets/default.yml
+++ b/spec/acceptance/suites/win_client/nodesets/default.yml
@@ -18,6 +18,8 @@ HOSTS:
     user: vagrant
     communicator: winrm
     is_cygwin: false
+    ssh:
+      host_key: +ssh-dss
 
 CONFIG:
   log_level: verbose


### PR DESCRIPTION
    - update the upper bounds for simp module dependencies.  These
      included
       - pupmod
       - simp_apache
    - correct the version number for chrony module dependency.
    - ssh to windowws machine failing because ssh-dss is disabled in
      later versions of openssl.  Had to add ssh-dss to ssh options
      in the nodeset.
    - netconsole test was rebooting to quickly.  beaker checks
      to see that boot time has changed using who -b which is only accurate
      to the minute.  Had to put a sleep in to make sure boot time changed.
      https://www.rubydoc.info/github/puppetlabs/beaker/Unix%2FExec:reboot

SIMP-8075 #comment updated boundaries