### PR TITLE
(SIMP-8075)simp-simp acceptance tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Aug 19 2020 Jeanne Greulich  <jeannegreulich@onyxpoint.com> - 4.11.1-0
+- changed the ssh settings for the wnidows node in the
+  win_client acceptance test
+
 * Tue Aug 18 2020 Jeanne Greulich  <jeannegreulich@onyxpoint.com> - 4.11.1-0
 - changed the upper bounds for dependencies for simp_apache and pupmod
 - corrected version numbering for chrony

--- a/spec/acceptance/suites/win_client/nodesets/default.yml
+++ b/spec/acceptance/suites/win_client/nodesets/default.yml
@@ -18,6 +18,8 @@ HOSTS:
     user: vagrant
     communicator: winrm
     is_cygwin: false
+    ssh:
+      host_key: '+ssh-dss'
 
 CONFIG:
   log_level: verbose


### PR DESCRIPTION
  - added the host_key option for ssh in the win_client
    nodeset.  Openssh has removed ssh-dss as a default in
    linux clients in it latest versions and the gitlab runner can
    cannot connect to the windows machines without this.

[SIMP-8075] #comment

[SIMP-8075]: https://simp-project.atlassian.net/browse/SIMP-8075