### PR TITLE
(SIMP-8228) Manage a group for /proc by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Wed Sep 09 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.12.0-0
+- Updated simp::mountpoints::proc
+  - Due to updates to polkit that require being added to the /proc gid group
+    - Assign a group and gid by default
+    - Create a group by default
+    - Discover these values from the system if possible
+
 * Wed Aug 19 2020 Jeanne Greulich  <jeannegreulich@onyxpoint.com> - 4.11.1-0
 - changed the ssh settings for the wnidows node in the
   win_client acceptance test

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -787,8 +787,8 @@ The following parameters are available in the `simp::mountpoints::proc` class.
 
 Data type: `Integer[0,2]`
 
-* 0: This is the default setting and gives you the default
-     behavior
+* 0: This is the system default setting and provides no access restrictions
+     on /proc
 
 * 1: With this option an normal user would not see other processes but
      their own about ``ps``, ``top`` , etc..., but they are still able to
@@ -797,18 +797,38 @@ Data type: `Integer[0,2]`
 * 2 (default): Users are only able to see their own processes (like with
     ``hidepid=1``), and process IDs are also hidden in ``/proc``!
 
-* **NOTE:** This option has no effect if ``$manage_proc`` is not ``true``
-
 Default value: `2`
+
+##### `manage_proc_group`
+
+Data type: `Boolean`
+
+Enable management of the group that allows access to ``/proc``
+
+* This was added, and enabled by default, to fix issue with updates to
+``polkit`` per the vendor recommended guidance
+
+Default value: ``true``
+
+##### `proc_group`
+
+Data type: `String[1]`
+
+The group name to be associated with ``$proc_gid``
+
+Default value: `pick($facts.dig('simplib__mountpoints', '/proc', 'options_hash', '_gid__group'), 'simp_proc_read')`
 
 ##### `proc_gid`
 
-Data type: `Optional[Integer]`
+Data type: `Integer[0]`
 
 This group will be able to see all processes on the system regardless of
 the ``$proc_hidepid`` setting
 
-Default value: ``undef``
+* If this is set to ``0`` then the ``gid`` option will be removed from the
+  option string
+
+Default value: `pick($facts.dig('simplib__mountpoints', '/proc', 'options_hash', 'gid'), 231)`
 
 ### `simp::mountpoints::tmp`
 

--- a/manifests/mountpoints/proc.pp
+++ b/manifests/mountpoints/proc.pp
@@ -1,8 +1,8 @@
 # @summary Mount ``/proc``
 #
 # @param proc_hidepid
-#   * 0: This is the default setting and gives you the default
-#        behavior
+#   * 0: This is the system default setting and provides no access restrictions
+#        on /proc
 #
 #   * 1: With this option an normal user would not see other processes but
 #        their own about ``ps``, ``top`` , etc..., but they are still able to
@@ -11,24 +11,46 @@
 #   * 2 (default): Users are only able to see their own processes (like with
 #       ``hidepid=1``), and process IDs are also hidden in ``/proc``!
 #
-#   * **NOTE:** This option has no effect if ``$manage_proc`` is not ``true``
+# @param manage_proc_group
+#   Enable management of the group that allows access to ``/proc``
+#
+#   * This was added, and enabled by default, to fix issue with updates to
+#   ``polkit`` per the vendor recommended guidance
+#
+# @param proc_group
+#   The group name to be associated with ``$proc_gid``
 #
 # @param proc_gid
 #   This group will be able to see all processes on the system regardless of
 #   the ``$proc_hidepid`` setting
 #
+#   * If this is set to ``0`` then the ``gid`` option will be removed from the
+#     option string
+#
 class simp::mountpoints::proc (
-  Integer[0,2]      $proc_hidepid = 2,
-  Optional[Integer] $proc_gid     = undef
+  Integer[0,2]      $proc_hidepid      = 2,
+  Boolean           $manage_proc_group = true,
+  String[1]         $proc_group        = pick($facts.dig('simplib__mountpoints', '/proc', 'options_hash', '_gid__group'), 'simp_proc_read'),
+  Integer[0]        $proc_gid          = pick($facts.dig('simplib__mountpoints', '/proc', 'options_hash', 'gid'), 231)
 ) {
 
   simplib::module_metadata::assert($module_name, { 'blacklist' => ['Windows'] })
 
-  if $proc_gid {
-    $_proc_options = "hidepid=${proc_hidepid},gid=${proc_gid}"
+  if $proc_gid == 0 {
+    $_proc_options = "hidepid=${proc_hidepid}"
   }
   else {
-    $_proc_options = "hidepid=${proc_hidepid}"
+    $_proc_options = "hidepid=${proc_hidepid},gid=${proc_gid}"
+  }
+
+  if ( $proc_gid > 0 ) and $manage_proc_group {
+    group { $proc_group:
+      ensure     => 'present',
+      allowdupe  => false,
+      forcelocal => true,
+      gid        => $proc_gid,
+      notify     => Mount['/proc']
+    }
   }
 
   mount { '/proc':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.11.1",
+  "version": "4.12.0",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",
@@ -141,7 +141,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.5.0 < 5.0.0"
     },
     {
       "name": "simp/ssh",

--- a/spec/acceptance/suites/default/50_mountpoints_spec.rb
+++ b/spec/acceptance/suites/default/50_mountpoints_spec.rb
@@ -29,6 +29,13 @@ describe 'simplib::secure_mountpoints class' do
         apply_manifest_on(host, manifest, :catch_changes => true)
       end
 
+      it 'should have /proc mounted with hidepid=2 and gid=231' do
+        proc_mount = on(host, 'mount | grep " /proc "').output.strip
+
+        expect(proc_mount).to match(/gid=231/)
+        expect(proc_mount).to match(/hidepid=2/)
+      end
+
       it 'should prevent running applications in the noexec mounts' do
         tmp_dirs.each do |dir|
           on(host,%(cp /bin/ls #{dir}))


### PR DESCRIPTION
- Updated simp::mountpoints::proc
  - Due to updates to polkit that require being added to the /proc gid group
    - Assign a group and gid by default
    - Create a group by default
    - Discover these values from the system if possible

SIMP-8228 #comment Manage a group for /proc by default