### PR TITLE
(SIMP-8582) Add params to override default gpgkey

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Thu Oct 15 2020  Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.14.0-0
+- Added:
+  - New parameters to `simp::yum::repo::local_simp` and
+    `simp::yum::repo::local_os_updates`:
+      `relative_repo_path`, `baseurl`, and `gpgkey`
+  - `baseurl` and `gpgkey` allow complete yumrepo overrides
+
 * Wed Oct 14 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 4.14.0-0
 - Added:
   - ``simp::puppetdb::cipher_suites`` parameter to manage the

--- a/manifests/yum/repo/local_os_updates.pp
+++ b/manifests/yum/repo/local_os_updates.pp
@@ -1,7 +1,7 @@
 # @summary Configure yum to use a (SIMP-managed) OS Updates repository for
 #   network-isolated environments.
 #
-# Generally, this is used by the ISO installation's SIMP server and agents.
+# Generally, this is used by the ISO installation's SIMP agents.
 #
 # * By default, baseurl and GPG key URLs will work with repositories managed
 #   with `simp::server::yum`.
@@ -15,7 +15,7 @@
 #  @example Describing a single server with specific URLs
 #    # This explicitly sets the `baseurl` and `gpgkey` keys in os_updates.repo.
 #    # (This overrides all other parameters and automagic URL logic.)
-#    simp::yum::repo::os_updates_local {
+#    simp::yum::repo::local_os_updates {
 #      baseurl => 'https://yum.test.simp/yum/CentOS/8/x86_64/Updates',
 #      gpgkey  => 'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-8',
 #    }
@@ -23,14 +23,14 @@
 #  @example Describing a single server by FQDN
 #    # When classified to an CentOS 7 x86_64 host, this creates an os_updates
 #    # yumrepo with the `baseurl` "https://yum.test.simp/yum/CentOS/7/x86_64/Updates"
-#    simp::yum::repo::os_updates_local {
+#    simp::yum::repo::local_os_updates {
 #      servers => ['yum.test.simp']
 #    }
 #
 #  @example Describing a single server by FQDN
 #    # When classified to an CentOS 7 x86_64 host, this creates an os_updates
 #    # yumrepo with a 3-entry `baseurl` and a 3-entry `gpgkey`
-#    simp::yum::repo::os_updates_local {
+#    simp::yum::repo::local_os_updates {
 #      servers => [
 #        'yum.test.simp',
 #        'yum2.test.simp',

--- a/manifests/yum/repo/local_os_updates.pp
+++ b/manifests/yum/repo/local_os_updates.pp
@@ -1,77 +1,95 @@
-# @summary Configure yum to use a (simp-managed) OS Updates repository
+# @summary Configure yum to use a (SIMP-managed) OS Updates repository for
+#   network-isolated environments.
 #
-# Generally, this is used by the ISO installation.
+# Generally, this is used by the ISO installation's SIMP server and agents.
 #
 # * By default, baseurl and GPG key URLs will work with repositories managed
-#   with ``simp::server::yum``.
+#   with `simp::server::yum`.
 #
-# * Multiple yum servers and arbitrary URLs are accepted; see the ``servers``
+# * Multiple yum servers and arbitrary URLs are accepted; see the `servers`
 #   parameter for details.
 #
 # * For more complex scenarios, create a site-specific profile and use the native
 #   `yumrepo` type directly.
 #
+#  @example Describing a single server with specific URLs
+#    # This explicitly sets the `baseurl` and `gpgkey` keys in os_updates.repo.
+#    # (This overrides all other parameters and automagic URL logic.)
+#    simp::yum::repo::os_updates_local {
+#      baseurl => 'https://yum.test.simp/yum/CentOS/8/x86_64/Updates',
+#      gpgkey  => 'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-8',
+#    }
+#
 #  @example Describing a single server by FQDN
-#    # When classified to an CentOS 6 x86_64 host, this creates an os_updates
-#    # yumrepo with the ``baseurl`` "https://yum.test.simp/yum/CentOS/6/x86_64/Updates"
+#    # When classified to an CentOS 7 x86_64 host, this creates an os_updates
+#    # yumrepo with the `baseurl` "https://yum.test.simp/yum/CentOS/7/x86_64/Updates"
 #    simp::yum::repo::os_updates_local {
 #      servers => ['yum.test.simp']
 #    }
 #
 #  @example Describing a single server by FQDN
-#    # When classified to an CentOS 6 x86_64 host, this creates an os_updates
-#    # yumrepo with a 3-entry ``baseurl`` and a 3-entry ``gpgkey``
+#    # When classified to an CentOS 7 x86_64 host, this creates an os_updates
+#    # yumrepo with a 3-entry `baseurl` and a 3-entry `gpgkey`
 #    simp::yum::repo::os_updates_local {
 #      servers => [
 #        'yum.test.simp',
 #        'yum2.test.simp',
-#        'https://yum.updates.url/full/path/to/repo/c6-64-u'
+#        'https://yum.updates.url/specific/path/to/repo/c7-64-u'
 #      ],
-#      extra_gpgkey_urls => [
-#        'https://yum.updates.url/full/path/to/repo/c6-64-u/RPM-GPG-KEY-CentOS-6'
-#      ]
+#      gpgkey => 'https://yum.updates.url/full/path/to/repo/c6-64-u/RPM-GPG-KEY-CentOS-7',
 #    }
 #
 # @param servers
 #   An Array of FQDNs, IPs, or URLs containing the yum server(s) to use.
 #
 #   * An FQDN or IP will be assumed to host it yum repository and GPG keys at
-#     the URLs established by ``simp::server::yum``.
+#     the URLs established by `simp::server::yum`.
 #
 #   * A URL will be used as-is, and should point directly to its yum repository.
+#
+#   This parameter has no effect if the `baseurl` parameter is set directly.
 #
 # @param enable_repo
 #   Enables or disables the Yum repo
 #
 # @param extra_gpgkey_urls
-#   An optional Array of Urls to include additional GPG key files
+#   An optional Array of Urls to include additional GPG key files.
+#   This parameter has no effect if the `gpgkey` parameter is set directly.
 #
+# @param relative_repo_path
+#   The relative path to the yum repo relative to the URL(s) set in `$servers`.
+#   This parameter has no effect if the `baseurl` parameter is set directly.
+#
+# @param baseurl
+#   The URL for this repository. Set this to absent to remove it from the file completely.
+#   Set this parameter directly to completely skip all automated URL logic.
+#
+# @param gpgkey
+#   The URL for the GPG key with which packages from this repository are signed.
+#   Set this parameter directly to completely skip default URL/path logic.
 class simp::yum::repo::local_os_updates (
-  Array[Simp::HostOrURL]   $servers,
-  Boolean                  $enable_repo       = true,
-  Simp::Urls               $extra_gpgkey_urls = [],
-){
-
-  simplib::module_metadata::assert($module_name, { 'blacklist' => ['Windows'] })
-
-  $_repo_base = "${facts['os']['name']}/${facts['os']['release']['major']}/${facts['architecture']}"
-
-  $_enable_repo    = $enable_repo ? { true => 1, default => 0 }
-  $_baseurl_string = simp::yum::repo::baseurl_string($servers, "${_repo_base}/Updates")
-  $_gpgkeys_string = simp::yum::repo::gpgkey_string(
-    $servers,
-    simp::yum::repo::gpgkeys::os_updates(),
-    $_repo_base,
-    $extra_gpgkey_urls
+  Array[Simp::HostOrURL] $servers,
+  Boolean                $enable_repo        = true,
+  Simp::Urls             $extra_gpgkey_urls  = [],
+  String[1]              $relative_repo_path = "${facts['os']['name']}/${facts['os']['release']['major']}/${facts['architecture']}",
+  String[1]              $baseurl            = simp::yum::repo::baseurl_string($servers, "${relative_repo_path}/Updates"),
+  String[1]              $gpgkey             = simp::yum::repo::gpgkey_string(
+      $servers,
+      simp::yum::repo::gpgkeys::os_updates(),
+      $relative_repo_path,
+      $extra_gpgkey_urls
   )
+){
+  simplib::module_metadata::assert($module_name, { 'blacklist' => ['Windows'] })
+  $_enable_repo    = $enable_repo ? { true => 1, default => 0 }
 
   yumrepo { 'os_updates':
-    baseurl         => $_baseurl_string,
+    baseurl         => $baseurl,
     descr           => "All ${facts['os']['name']} ${facts['os']['release']['major']} ${facts['architecture']} base packages and updates",
     enabled         => $_enable_repo,
     enablegroups    => 0,
     gpgcheck        => 1,
-    gpgkey          => $_gpgkeys_string,
+    gpgkey          => $gpgkey,
     sslverify       => 0,
     keepalive       => 0,
     metadata_expire => 3600,

--- a/manifests/yum/repo/local_simp.pp
+++ b/manifests/yum/repo/local_simp.pp
@@ -1,7 +1,7 @@
 # @summary Set up the local SIMP repositiories for network-isolated
 #   environments.
 #
-# Generally, this is used by the ISO installation's SIMP server and agents.
+# Generally, this is used by the ISO installation's SIMP agents.
 #
 # * By default, baseurl and GPG key URLs will work with repositories managed
 #   with ``simp::server::yum``.

--- a/manifests/yum/repo/local_simp.pp
+++ b/manifests/yum/repo/local_simp.pp
@@ -1,6 +1,7 @@
-# @summary Set up the local SIMP repositiories for disconnected environments.
+# @summary Set up the local SIMP repositiories for network-isolated
+#   environments.
 #
-# Generally, this is used by the ISO installation.
+# Generally, this is used by the ISO installation's SIMP server and agents.
 #
 # * By default, baseurl and GPG key URLs will work with repositories managed
 #   with ``simp::server::yum``.
@@ -12,24 +13,37 @@
 #   `yumrepo` type directly.
 #
 #  @example Describing a single server by FQDN
-#    # When classified to an CentOS 6 x86_64 host, this creates an os_updates
-#    # yumrepo with the ``baseurl`` "https://yum.test.simp/yum/CentOS/6/x86_64/Updates"
-#    simp::yum::repo::os_updates_local {
+#    # When classified to an CentOS 7 x86_64 host, this creates a `simp`
+#    # yumrepo with the ``baseurl`` "https://yum.test.simp/yum/CentOS/7/x86_64/Updates"
+#    simp::yum::repo::simp_local {
 #      servers => ['yum.test.simp']
 #    }
 #
 #  @example Describing a single server by FQDN
-#    # When classified to an CentOS 6 x86_64 host, this creates an os_updates
-#    # yumrepo with a 3-entry ``baseurl`` and a 3-entry ``gpgkey``
-#    simp::yum::repo::os_updates_local {
+#    # When classified to an CentOS 7 x86_64 host, this creates a `simp`
+#    # yumrepo with a 3-entry ``baseurl`` and a multiple ``gpgkey`` entries
+#    simp::yum::repo::simp_local {
 #      servers => [
 #        'yum.test.simp',
 #        'yum2.test.simp',
 #        'https://yum.updates.url/full/path/to/repo/c6-64-u'
 #      ],
-#      extra_gpgkey_urls => [
-#        'https://yum.updates.url/full/path/to/repo/c6-64-u/RPM-GPG-KEY-CentOS-6'
-#      ]
+#    }
+#
+#  @example Describing a single server with specific URLs
+#    # This explicitly sets the `baseurl` and `gpgkey` keys in simp.repo
+#    # (This overrides all other parameters and automagic URL logic.)
+#    simp::yum::repo::local_simp {
+#      baseurl => 'https://yum.test.simp/yum/SIMP/CentOS/8/x86_64',
+#      gpgkey  => [
+#        'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-8',
+#        'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-94',
+#        'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-96',
+#        'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP',
+#        'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP-6',
+#        'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet',
+#        'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs',
+#      ].join("\n    ")
 #    }
 #
 # @param servers
@@ -40,37 +54,50 @@
 #
 #   * A URL will be used as-is, and should point directly to its yum repository.
 #
+#   This parameter has no effect if the `baseurl` parameter is set directly.
+#
 # @param enable_repo
 #   Enables or disables the Yum repo
 #
 # @param extra_gpgkey_urls
-#   An optional Array of Urls to include additional GPG key files
+#   An optional Array of Urls to include additional GPG key files.
+#   This parameter has no effect if the `gpgkey` parameter is set directly.
 #
+# @param relative_repo_path
+#   The relative path to the yum repo relative to the URL(s) set in `$servers`.
+#   In simp repos
+#   This parameter has no effect if the `baseurl` parameter is set directly.
+#
+# @param baseurl
+#   The URL for this repository. Set this to absent to remove it from the file completely.
+#   Set this parameter directly to completely skip all automated URL logic.
+#
+# @param gpgkey
+#   The URL for the GPG key with which packages from this repository are signed.
+#   Set this parameter directly to completely skip default URL/path logic.
 class simp::yum::repo::local_simp (
-  Array[Simp::HostOrURL]   $servers,
-  Boolean                  $enable_repo       = true,
-  Simp::Urls               $extra_gpgkey_urls = [],
-){
-
-  simplib::module_metadata::assert($module_name, { 'blacklist' => ['Windows'] })
-
-  $_repo_base = 'SIMP'
-
-  $_enable_repo    = $enable_repo ? { true => 1, default => 0 }
-  $_baseurl_string = simp::yum::repo::baseurl_string($servers, "${_repo_base}/${facts['architecture']}")
-  $_gpgkeys_string = simp::yum::repo::gpgkey_string(
+  Array[Simp::HostOrURL] $servers,
+  Boolean                $enable_repo        = true,
+  Simp::Urls             $extra_gpgkey_urls  = [],
+  String[1]              $relative_repo_path = 'SIMP',
+  String[1]              $baseurl            = simp::yum::repo::baseurl_string($servers, "${relative_repo_path}/${facts['architecture']}"),
+  String[1]              $gpgkey             = simp::yum::repo::gpgkey_string(
     $servers,
     simp::yum::repo::gpgkeys::simp(),
-    "${_repo_base}/GPGKEYS",
+    "${relative_repo_path}/GPGKEYS",
     $extra_gpgkey_urls
   )
+){
+  simplib::module_metadata::assert($module_name, { 'blacklist' => ['Windows'] })
+  $_enable_repo    = $enable_repo ? { true => 1, default => 0 }
+
   yumrepo { 'simp':
-    baseurl         => $_baseurl_string,
-    descr           => "All ${facts['os']['name']} ${facts['os']['release']['major']} ${facts['architecture']} base packages and updates",
+    baseurl         => $baseurl,
+    descr           => "SIMP ${facts['os']['name']} ${facts['os']['release']['major']} ${facts['architecture']} base packages and updates",
     enabled         => $_enable_repo,
     enablegroups    => 0,
     gpgcheck        => 1,
-    gpgkey          => $_gpgkeys_string,
+    gpgkey          => $gpgkey,
     sslverify       => 0,
     keepalive       => 0,
     metadata_expire => 3600,

--- a/spec/classes/00_classes/yum/repo/local_os_updates_spec.rb
+++ b/spec/classes/00_classes/yum/repo/local_os_updates_spec.rb
@@ -8,80 +8,121 @@ describe 'simp::yum::repo::local_os_updates' do
 
       if os_facts[:kernel] == 'windows'
         it { expect{ is_expected.to compile.with_all_deps }.to raise_error(/'windows .+' is not supported/) }
-      else
-        context 'with a single server name' do
-          let(:params) {{ :servers => ['puppet.example.simp'] }}
+        next
+      end
 
+      context 'with a single server name' do
+        let(:params) {{ :servers => ['puppet.example.simp'] }}
+        let(:os_name){ facts[:os][:name] }
+        let(:os_maj_rel){ facts[:os][:release][:major] }
+
+        it { is_expected.to compile.with_all_deps }
+        it {
+          os_yum_path =  "#{os_name}/#{os_maj_rel}/#{facts[:architecture]}"
+
+          if os_name  == 'RedHat'
+            gpgkey = "https://puppet.example.simp/yum/#{os_yum_path}/RPM-GPG-KEY-redhat-release"
+          elsif os_name  == 'OracleLinux'
+            gpgkey = "https://puppet.example.simp/yum/#{os_yum_path}/RPM-GPG-KEY-oracle"
+          elsif  os_name == 'CentOS' and os_maj_rel  >= '8'
+            gpgkey = "https://puppet.example.simp/yum/#{os_yum_path}/RPM-GPG-KEY-#{os_name}-Official"
+          else
+            gpgkey = "https://puppet.example.simp/yum/#{os_yum_path}/RPM-GPG-KEY-#{os_name}-#{os_maj_rel}"
+          end
+
+          is_expected.to contain_yumrepo('os_updates').with(
+            :baseurl => "https://puppet.example.simp/yum/#{os_yum_path}/Updates",
+            :gpgkey  => gpgkey
+          )
+        }
+
+        context 'with relative_repo_path = x/y/z' do
+          let(:params){super().merge( relative_repo_path: 'x/y/z')}
           it { is_expected.to compile.with_all_deps }
           it {
-            os_maj_rel  = facts[:os][:release][:major]
-            os_name     = facts[:os][:name]
-            os_yum_path =  "#{os_name}/#{os_maj_rel}/#{facts[:architecture]}"
-
             if os_name  == 'RedHat'
-              gpgkey = "https://puppet.example.simp/yum/#{os_yum_path}/RPM-GPG-KEY-redhat-release"
+              gpgkey = "https://puppet.example.simp/yum/x/y/z/RPM-GPG-KEY-redhat-release"
             elsif os_name  == 'OracleLinux'
-              gpgkey = "https://puppet.example.simp/yum/#{os_yum_path}/RPM-GPG-KEY-oracle"
+              gpgkey = "https://puppet.example.simp/yum/x/y/z/RPM-GPG-KEY-oracle"
             elsif  os_name == 'CentOS' and os_maj_rel  >= '8'
-                gpgkey = "https://puppet.example.simp/yum/#{os_yum_path}/RPM-GPG-KEY-#{os_name}-Official"
+              gpgkey = "https://puppet.example.simp/yum/x/y/z/RPM-GPG-KEY-#{os_name}-Official"
             else
-                gpgkey = "https://puppet.example.simp/yum/#{os_yum_path}/RPM-GPG-KEY-#{os_name}-#{os_maj_rel}"
+              gpgkey = "https://puppet.example.simp/yum/x/y/z/RPM-GPG-KEY-#{os_name}-#{os_maj_rel}"
             end
 
             is_expected.to contain_yumrepo('os_updates').with(
-              :baseurl => "https://puppet.example.simp/yum/#{os_yum_path}/Updates",
+              :baseurl => "https://puppet.example.simp/yum/x/y/z/Updates",
               :gpgkey  => gpgkey
             )
           }
         end
+      end
 
-        context 'with multiple servers and extra gpgkey URLs' do
-          let(:params) {
-            arbitrary_url = 'https://yum.test.simp:4433/repos/' +
-                            "#{facts[:os][:name]}_#{facts[:os][:release][:major]}" +
-                            "_#{facts[:architecture]}"
-            {
-            :servers => [
-              'puppet.example.simp',
-              '192.0.2.5',
-              arbitrary_url,
-            ],
-            :extra_gpgkey_urls => [
-              "#{arbitrary_url}/RPM-GPG-KEY-#{facts[:os][:name]}-#{facts[:os][:release][:major]}"
-            ]
-          }}
+      context 'with multiple servers and extra gpgkey URLs' do
+        let(:params) {
+          arbitrary_url = 'https://yum.test.simp:4433/repos/' +
+                          "#{facts[:os][:name]}_#{facts[:os][:release][:major]}" +
+                          "_#{facts[:architecture]}"
+          {
+          :servers => [
+            'puppet.example.simp',
+            '192.0.2.5',
+            arbitrary_url,
+          ],
+          :extra_gpgkey_urls => [
+            "#{arbitrary_url}/RPM-GPG-KEY-#{facts[:os][:name]}-#{facts[:os][:release][:major]}"
+          ]
+        }}
 
-          it { is_expected.to compile.with_all_deps }
-          it {
-            os_maj_rel  = facts[:os][:release][:major]
-            os_name     = facts[:os][:name]
-            os_yum_path =  "#{os_name}/#{os_maj_rel}/#{facts[:architecture]}"
-            arbitrary_url = 'https://yum.test.simp:4433/repos/' +
-                            "#{facts[:os][:name]}_#{facts[:os][:release][:major]}" +
-                            "_#{facts[:architecture]}"
+        it { is_expected.to compile.with_all_deps }
+        it {
+          os_maj_rel  = facts[:os][:release][:major]
+          os_name     = facts[:os][:name]
+          os_yum_path =  "#{os_name}/#{os_maj_rel}/#{facts[:architecture]}"
+          arbitrary_url = 'https://yum.test.simp:4433/repos/' +
+                          "#{facts[:os][:name]}_#{facts[:os][:release][:major]}" +
+                          "_#{facts[:architecture]}"
 
-            gpg_prefixes = ['puppet.example.simp', '192.0.2.5']
-              .map{|x| "https://#{x}/yum/#{os_yum_path}" }
+          gpg_prefixes = ['puppet.example.simp', '192.0.2.5']
+            .map{|x| "https://#{x}/yum/#{os_yum_path}" }
 
-            if os_name  == 'RedHat'
-              gpgkey = gpg_prefixes.map{|x| "#{x}/RPM-GPG-KEY-redhat-release" }.join("\n    ")
-            elsif os_name  == 'OracleLinux'
-              gpgkey = gpg_prefixes.map{|x| "#{x}/RPM-GPG-KEY-oracle" }.join("\n    ")
-            elsif os_name == 'CentOS' and  os_maj_rel >= '8'
-              gpgkey = gpg_prefixes.map{|x| "#{x}/RPM-GPG-KEY-#{os_name}-Official" }.join("\n    ")
-            else
-              gpgkey = gpg_prefixes.map{|x| "#{x}/RPM-GPG-KEY-#{os_name}-#{os_maj_rel}" }.join("\n    ")
-            end
-            gpgkey += "\n    #{arbitrary_url}/RPM-GPG-KEY-#{os_name}-#{os_maj_rel}"
+          if os_name  == 'RedHat'
+            gpgkey = gpg_prefixes.map{|x| "#{x}/RPM-GPG-KEY-redhat-release" }.join("\n    ")
+          elsif os_name  == 'OracleLinux'
+            gpgkey = gpg_prefixes.map{|x| "#{x}/RPM-GPG-KEY-oracle" }.join("\n    ")
+          elsif os_name == 'CentOS' and  os_maj_rel >= '8'
+            gpgkey = gpg_prefixes.map{|x| "#{x}/RPM-GPG-KEY-#{os_name}-Official" }.join("\n    ")
+          else
+            gpgkey = gpg_prefixes.map{|x| "#{x}/RPM-GPG-KEY-#{os_name}-#{os_maj_rel}" }.join("\n    ")
+          end
+          gpgkey += "\n    #{arbitrary_url}/RPM-GPG-KEY-#{os_name}-#{os_maj_rel}"
 
-            is_expected.to contain_yumrepo('os_updates').with(
-              :baseurl => "https://puppet.example.simp/yum/#{os_yum_path}/Updates\n    " +
-                          "https://192.0.2.5/yum/#{os_yum_path}/Updates\n    " +
-                          arbitrary_url,
-              :gpgkey  => gpgkey
-            )
-          }
-        end
+          is_expected.to contain_yumrepo('os_updates').with(
+            :baseurl => "https://puppet.example.simp/yum/#{os_yum_path}/Updates\n    " +
+                        "https://192.0.2.5/yum/#{os_yum_path}/Updates\n    " +
+                        arbitrary_url,
+            :gpgkey  => gpgkey
+          )
+        }
+      end
+
+      context 'with baseurl and gpgkey overrides' do
+        # No matter what OS we're testing, setting 'baseurl' and 'gpgkey'
+        # directly should result in exactly the string that was specified
+        # (in this case, repos for CentOS 8).
+        let(:params) {{
+            servers: ['puppet.example.simp'],
+            baseurl: 'https://yum.test1.simp/yum/CentOS/8/x86_64/Updates',
+            gpgkey:  'https://yum.test2.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-8',
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_yumrepo('os_updates').with(
+            :baseurl => 'https://yum.test1.simp/yum/CentOS/8/x86_64/Updates',
+            :gpgkey  => 'https://yum.test2.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-8',
+          )
+        }
       end
     end
   end

--- a/spec/classes/00_classes/yum/repo/local_simp_spec.rb
+++ b/spec/classes/00_classes/yum/repo/local_simp_spec.rb
@@ -7,91 +7,138 @@ describe 'simp::yum::repo::local_simp' do
       let(:facts) { os_facts }
 
       if os_facts[:kernel] == 'windows'
-        it { expect{ is_expected.to compile.with_all_deps }.to raise_error(/'windows .+' is not supported/) }
-      else
-        let(:base_gpgkeys){
-          [
-            'RPM-GPG-KEY-puppet',
-            'RPM-GPG-KEY-puppetlabs',
-            'RPM-GPG-KEY-SIMP',
-            'RPM-GPG-KEY-SIMP-6',
-            'RPM-GPG-KEY-PGDG-94',
-            'RPM-GPG-KEY-PGDG-96'
-          ]
+        it { expect{ is_expected.to compile.with_all_deps }.to raise_error(
+            /'windows .+' is not supported|There are no Yumrepo GPG keys for OS 'windows'/
+          )
         }
-        let(:other_gpgkeys){
-          {
-             'RedHat-6'      => ['RPM-GPG-KEY-EPEL-6','RPM-GPG-KEY-redhat-release'],
-             'OracleLinux-6' => ['RPM-GPG-KEY-EPEL-6','RPM-GPG-KEY-oracle'],
-             'CentOS-6'      => ['RPM-GPG-KEY-EPEL-6'],
-             'RedHat-7'      => ['RPM-GPG-KEY-EPEL-7','RPM-GPG-KEY-redhat-release'],
-             'OracleLinux-7' => ['RPM-GPG-KEY-EPEL-7','RPM-GPG-KEY-oracle'],
-             'CentOS-7'      => ['RPM-GPG-KEY-EPEL-7'],
-             'RedHat-8'      => ['RPM-GPG-KEY-EPEL-8','RPM-GPG-KEY-redhat-release'],
-             'OracleLinux-8' => ['RPM-GPG-KEY-EPEL-8','RPM-GPG-KEY-oracle'],
-             'CentOS-8'      => ['RPM-GPG-KEY-EPEL-8']
-          }
+        next
+      end
+
+      let(:base_gpgkeys){
+        [
+          'RPM-GPG-KEY-puppet',
+          'RPM-GPG-KEY-puppetlabs',
+          'RPM-GPG-KEY-SIMP',
+          'RPM-GPG-KEY-SIMP-6',
+          'RPM-GPG-KEY-PGDG-94',
+          'RPM-GPG-KEY-PGDG-96'
+        ]
+      }
+      let(:other_gpgkeys){
+        {
+           'RedHat-6'      => ['RPM-GPG-KEY-EPEL-6','RPM-GPG-KEY-redhat-release'],
+           'OracleLinux-6' => ['RPM-GPG-KEY-EPEL-6','RPM-GPG-KEY-oracle'],
+           'CentOS-6'      => ['RPM-GPG-KEY-EPEL-6'],
+           'RedHat-7'      => ['RPM-GPG-KEY-EPEL-7','RPM-GPG-KEY-redhat-release'],
+           'OracleLinux-7' => ['RPM-GPG-KEY-EPEL-7','RPM-GPG-KEY-oracle'],
+           'CentOS-7'      => ['RPM-GPG-KEY-EPEL-7'],
+           'RedHat-8'      => ['RPM-GPG-KEY-EPEL-8','RPM-GPG-KEY-redhat-release'],
+           'OracleLinux-8' => ['RPM-GPG-KEY-EPEL-8','RPM-GPG-KEY-oracle'],
+           'CentOS-8'      => ['RPM-GPG-KEY-EPEL-8']
+        }
+      }
+
+      context 'with a single server name' do
+        let(:params) {{ :servers => ['puppet.example.simp'] }}
+        let(:os_yum_path){ 'SIMP' }
+        let(:os_baseurl){ "#{os_yum_path}/#{facts[:architecture]}" }
+        let(:os_gpgkey){ "#{os_yum_path}/GPGKEYS" }
+
+        it { is_expected.to compile.with_all_deps }
+        it {
+          _keys = base_gpgkeys + other_gpgkeys.fetch( "#{facts[:os][:name]}-#{facts[:os][:release][:major]}" )
+          gpgkey = _keys.map{|x| "https://puppet.example.simp/yum/#{os_gpgkey}/#{x}"}.join("\n    ")
+
+          is_expected.to contain_yumrepo('simp').with(
+            :baseurl => "https://puppet.example.simp/yum/#{os_baseurl}",
+            :gpgkey  => gpgkey,
+          )
         }
 
-        context 'with a single server name' do
-          let(:params) {{ :servers => ['puppet.example.simp'] }}
-
+        context 'with relative_repo_path = x/y/z' do
+          let(:params){super().merge( relative_repo_path: 'x/y/z')}
           it { is_expected.to compile.with_all_deps }
           it {
-            os_yum_path =  'SIMP'
-            os_baseurl  = "#{os_yum_path}/#{facts[:architecture]}"
-            os_gpgkey   = "#{os_yum_path}/GPGKEYS"
             _keys = base_gpgkeys + other_gpgkeys.fetch( "#{facts[:os][:name]}-#{facts[:os][:release][:major]}" )
-            gpgkey = _keys.map{|x| "https://puppet.example.simp/yum/#{os_gpgkey}/#{x}"}.join("\n    ")
+            gpgkey = _keys.map{|x| "https://puppet.example.simp/yum/x/y/z/GPGKEYS/#{x}"}.join("\n    ")
 
             is_expected.to contain_yumrepo('simp').with(
-              :baseurl => "https://puppet.example.simp/yum/#{os_baseurl}",
+              :baseurl => "https://puppet.example.simp/yum/x/y/z/x86_64",
               :gpgkey  => gpgkey,
             )
           }
         end
+      end
 
-        context 'with multiple servers and extra gpgkey URLs' do
-          let(:params) {
-            arbitrary_url = 'https://yum.test.simp:4433/repos/' +
-                            "SIMP/6/#{facts[:architecture]}"
-            {
-            :servers => [
-              'puppet.example.simp',
-              '192.0.2.5',
-              arbitrary_url,
-            ],
-            :extra_gpgkey_urls => [
-              "#{arbitrary_url}/RPM-GPG-KEY-#{facts[:os][:name]}-#{facts[:os][:release][:major]}"
-            ]
-          }}
+      context 'with multiple servers and extra gpgkey URLs' do
+        let(:params) {
+          arbitrary_url = 'https://yum.test.simp:4433/repos/' +
+                          "SIMP/6/#{facts[:architecture]}"
+          {
+          :servers => [
+            'puppet.example.simp',
+            '192.0.2.5',
+            arbitrary_url,
+          ],
+          :extra_gpgkey_urls => [
+            "#{arbitrary_url}/RPM-GPG-KEY-#{facts[:os][:name]}-#{facts[:os][:release][:major]}"
+          ]
+        }}
 
-          it { is_expected.to compile.with_all_deps }
-          it {
-            os_maj_rel  = facts[:os][:release][:major]
-            os_name     = facts[:os][:name]
-            os_yum_path =  'SIMP'
-            os_baseurl  = "#{os_yum_path}/#{facts[:architecture]}"
-            arbitrary_url = 'https://yum.test.simp:4433/repos/' +
-                            "SIMP/6/#{facts[:architecture]}"
+        it { is_expected.to compile.with_all_deps }
+        it {
+          os_maj_rel  = facts[:os][:release][:major]
+          os_name     = facts[:os][:name]
+          os_yum_path =  'SIMP'
+          os_baseurl  = "#{os_yum_path}/#{facts[:architecture]}"
+          arbitrary_url = 'https://yum.test.simp:4433/repos/' +
+                          "SIMP/6/#{facts[:architecture]}"
 
-            os_baseurl  = "#{os_yum_path}/#{facts[:architecture]}"
-            os_gpgkey   = "#{os_yum_path}/GPGKEYS"
-            _keys = base_gpgkeys + other_gpgkeys.fetch( "#{facts[:os][:name]}-#{facts[:os][:release][:major]}" )
-            _gpgkey = ['puppet.example.simp', '192.0.2.5']
-              .map{ |y|  _keys.map{|x| "https://#{y}/yum/#{os_gpgkey}/#{x}"} }
-            gpgkey = _gpgkey.join("\n    ")
-            gpgkey += "\n    #{arbitrary_url}/RPM-GPG-KEY-#{os_name}-#{os_maj_rel}"
+          os_baseurl  = "#{os_yum_path}/#{facts[:architecture]}"
+          os_gpgkey   = "#{os_yum_path}/GPGKEYS"
+          _keys = base_gpgkeys + other_gpgkeys.fetch( "#{facts[:os][:name]}-#{facts[:os][:release][:major]}" )
+          _gpgkey = ['puppet.example.simp', '192.0.2.5']
+            .map{ |y|  _keys.map{|x| "https://#{y}/yum/#{os_gpgkey}/#{x}"} }
+          gpgkey = _gpgkey.join("\n    ")
+          gpgkey += "\n    #{arbitrary_url}/RPM-GPG-KEY-#{os_name}-#{os_maj_rel}"
 
-            is_expected.to contain_yumrepo('simp').with(
-              :baseurl => "https://puppet.example.simp/yum/#{os_baseurl}\n    " +
-                          "https://192.0.2.5/yum/#{os_baseurl}\n    " +
-                          arbitrary_url,
-              :gpgkey  => gpgkey
-            )
-          }
+          is_expected.to contain_yumrepo('simp').with(
+            :baseurl => "https://puppet.example.simp/yum/#{os_baseurl}\n    " +
+                        "https://192.0.2.5/yum/#{os_baseurl}\n    " +
+                        arbitrary_url,
+            :gpgkey  => gpgkey
+          )
+        }
+      end
+
+      context 'with baseurl and gpgkey overrides' do
+        # No matter what OS we're testing, setting 'baseurl' and 'gpgkey'
+        # directly should result in exactly the string that was specified
+        # (in this case, repos for CentOS 8).
+        let(:gpgkey_string) do
+          [
+            'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-8',
+            'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-94',
+            'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-96',
+            'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP',
+            'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP-6',
+            'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet',
+            'https://yum.test.simp/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs',
+          ].join("\n    ")
         end
+        let(:params) {{
+            servers: ['puppet.example.simp'],
+            baseurl: 'https://yum.test.simp/yum/CentOS/8/x86_64/Updates',
+            gpgkey:  gpgkey_string,
+        }}
 
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_yumrepo('simp').with(
+            :baseurl => 'https://yum.test.simp/yum/CentOS/8/x86_64/Updates',
+            :gpgkey  => gpgkey_string,
+          )
+        }
       end
     end
   end


### PR DESCRIPTION
This patch introduces the new parameters `baseurl` and `gpgkey` to
`simp::yum::repo::local_simp` and `simp::yum::repo::local_os_updates`.

These parameters provide a way to completely override ther respective
yumrepo settings, which makes it possible to host the packages' GPG key
in a non-repo location, as CentOS 8 now requires.

[SIMP-8582] #close
[SIMP-8470] #close

[SIMP-8582]: https://simp-project.atlassian.net/browse/SIMP-8582
[SIMP-8470]: https://simp-project.atlassian.net/browse/SIMP-8470