### PR TITLE
(SIMP-8589) Fix ssldir sudoers with bolt

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -40,7 +40,6 @@ fixtures:
     fips: https://github.com/simp/pupmod-simp-fips
     firewalld:
       repo: https://github.com/simp/pupmod-voxpupuli-firewalld
-      ref: v4.2.2
     haveged: https://github.com/simp/pupmod-simp-haveged
     hocon: https://github.com/simp/pupmod-puppetlabs-hocon
     host_core:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,15 @@
-* Thu Oct 15 2020  Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.14.0-0
+* Wed Oct 28 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.14.1-0
+- Fixed:
+  - Ensure that the sudoers rule for removing the puppet ssldir is not created
+    when running from bolt since the directory target is changed at each bolt
+    run and will result in non-idempotency.
+  - Un-pinned the firewalld module version in .fixtures.yml because that no
+    longer appears to cause issues.
+  - Allow the local yum repos to optionally specify gpgkey or baseurl strings
+    since, technically, both are optional in the `yumrepo` type if they already
+    exist on disk.
+
+* Thu Oct 15 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.14.0-0
 - Added:
   - New parameters to `simp::yum::repo::local_simp` and
     `simp::yum::repo::local_os_updates`:

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ group :test do
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['> 5.11', '< 6']
   gem( 'pdk', ENV['PDK_VERSION'] || '~> 1.0', :require => false) if major_puppet_version > 5
+  # Remove when rspec-puppet 2.8.0 is released
+  gem 'rspec-expectations', '~> 3.9.0'
 end
 
 group :development do

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3509,7 +3509,7 @@ Default value: `"${facts['os']['name']}/${facts['os']['release']['major']}/${fac
 
 ##### `baseurl`
 
-Data type: `String[1]`
+Data type: `Optional[String[1]]`
 
 The URL for this repository. Set this to absent to remove it from the file completely.
 Set this parameter directly to completely skip all automated URL logic.
@@ -3518,7 +3518,7 @@ Default value: `simp::yum::repo::baseurl_string($servers, "${relative_repo_path}
 
 ##### `gpgkey`
 
-Data type: `String[1]`
+Data type: `Optional[String[1]]`
 
 The URL for the GPG key with which packages from this repository are signed.
 Set this parameter directly to completely skip default URL/path logic.
@@ -3623,7 +3623,7 @@ Default value: `'SIMP'`
 
 ##### `baseurl`
 
-Data type: `String[1]`
+Data type: `Optional[String[1]]`
 
 The URL for this repository. Set this to absent to remove it from the file completely.
 Set this parameter directly to completely skip all automated URL logic.
@@ -3632,7 +3632,7 @@ Default value: `simp::yum::repo::baseurl_string($servers, "${relative_repo_path}
 
 ##### `gpgkey`
 
-Data type: `String[1]`
+Data type: `Optional[String[1]]`
 
 The URL for the GPG key with which packages from this repository are signed.
 Set this parameter directly to completely skip default URL/path logic.
@@ -3773,7 +3773,7 @@ The simp::yum::repo::baseurl_string function.
 
 The simp::yum::repo::baseurl_string function.
 
-Returns: `String`
+Returns: `Variant[Undef,String]`
 
 ##### `servers`
 
@@ -3799,7 +3799,7 @@ build. Of limited use outside of an ISO install.
 A function to return a proper set of SIMP YUM repositories for the default
 build. Of limited use outside of an ISO install.
 
-Returns: `String`
+Returns: `Variant[Undef,String]`
 
 ##### `servers`
 

--- a/functions/yum/repo/baseurl_string.pp
+++ b/functions/yum/repo/baseurl_string.pp
@@ -1,4 +1,4 @@
-# @return [String]
+# @return [Variant[Undef,String]]
 function simp::yum::repo::baseurl_string(
   Array[Simp::HostOrURL] $servers,
   String                 $simp_baseurl_path,
@@ -11,5 +11,8 @@ function simp::yum::repo::baseurl_string(
       "https://${_server}/yum/${simp_baseurl_path}"
     }
   }
-  $_server_urls.join("\n    ")
+
+  unless empty($_server_urls) {
+    $_server_urls.unique.join("\n    ")
+  }
 }

--- a/functions/yum/repo/gpgkey_string.pp
+++ b/functions/yum/repo/gpgkey_string.pp
@@ -13,7 +13,7 @@
 # @param extra_gpgkey_urls
 #   Additional GPG keys that need to be included
 #
-# @return [String]
+# @return [Variant[Undef,String]]
 function simp::yum::repo::gpgkey_string(
   Array[Simp::HostOrURL] $servers,
   Array[String]          $simp_gpgkeys,
@@ -26,6 +26,10 @@ function simp::yum::repo::gpgkey_string(
     $simp_gpgkeys.map |$_gpgkey| { "https://${_server}/yum/${simp_baseurl_path}/${_gpgkey}" }
   }
 
-  # smoosh everything into a `yumrepo`-compatible String
-  join(concat($_standard_gpgkey_urls, $extra_gpgkey_urls), "\n    ")
+  $_gpgkey_urls = concat($_standard_gpgkey_urls, $extra_gpgkey_urls).flatten.unique
+
+  unless empty($_gpgkey_urls) {
+    # smoosh everything into a `yumrepo`-compatible String
+    $_gpgkey_urls.join("\n    ")
+  }
 }

--- a/manifests/yum/repo/local_os_updates.pp
+++ b/manifests/yum/repo/local_os_updates.pp
@@ -72,8 +72,8 @@ class simp::yum::repo::local_os_updates (
   Boolean                $enable_repo        = true,
   Simp::Urls             $extra_gpgkey_urls  = [],
   String[1]              $relative_repo_path = "${facts['os']['name']}/${facts['os']['release']['major']}/${facts['architecture']}",
-  String[1]              $baseurl            = simp::yum::repo::baseurl_string($servers, "${relative_repo_path}/Updates"),
-  String[1]              $gpgkey             = simp::yum::repo::gpgkey_string(
+  Optional[String[1]]    $baseurl            = simp::yum::repo::baseurl_string($servers, "${relative_repo_path}/Updates"),
+  Optional[String[1]]    $gpgkey             = simp::yum::repo::gpgkey_string(
       $servers,
       simp::yum::repo::gpgkeys::os_updates(),
       $relative_repo_path,

--- a/manifests/yum/repo/local_simp.pp
+++ b/manifests/yum/repo/local_simp.pp
@@ -80,8 +80,8 @@ class simp::yum::repo::local_simp (
   Boolean                $enable_repo        = true,
   Simp::Urls             $extra_gpgkey_urls  = [],
   String[1]              $relative_repo_path = 'SIMP',
-  String[1]              $baseurl            = simp::yum::repo::baseurl_string($servers, "${relative_repo_path}/${facts['architecture']}"),
-  String[1]              $gpgkey             = simp::yum::repo::gpgkey_string(
+  Optional[String[1]]    $baseurl            = simp::yum::repo::baseurl_string($servers, "${relative_repo_path}/${facts['architecture']}"),
+  Optional[String[1]]    $gpgkey             = simp::yum::repo::gpgkey_string(
     $servers,
     simp::yum::repo::gpgkeys::simp(),
     "${relative_repo_path}/GPGKEYS",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixed:
  - Ensure that the sudoers rule for removing the puppet ssldir is not created
    when running from bolt since the directory target is changed at each bolt
    run and will result in non-idempotency.
  - Un-pinned the firewalld module version in .fixtures.yml because that no
    longer appears to cause issues.
  - Allow the local yum repos to optionally specify gpgkey or baseurl strings
    since, technically, both are optional in the `yumrepo` type if they already
    exist on disk.
Workarounds:
  - Pinned the rspec-expectations gem to `~> 3.9.0` until rspec-puppet
    2.8.0 can be released.

SIMP-8589 #close