### PR TITLE
(SIMP-8696) Install selinux packages before usage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Nov 19 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.14.3-0
+- Call `selinux::install` prior to using native types that require the packages
+  to be installed.
+
 * Thu Nov 12 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.14.2-0
 - Update the required version of simp/svckill to the puppet 6 safe version.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -12,7 +12,7 @@
 * [`simp::base_services`](#simpbase_services): Deprecated - This class will be removed in a future version of SIMP.
 * [`simp::ctrl_alt_del`](#simpctrl_alt_del): Manage the state of pressing ``ctrl-alt-del``
 * [`simp::kmod_blacklist`](#simpkmod_blacklist): This class provides a default set of blacklist entries per the SCAP
-* [`simp::kmod_blacklist::lock_modules`](#simpkmod_blacklistlock_modules): This class toggles the ability to load any further kernel modules
+* [`simp::kmod_blacklist::lock_modules`](#simpkmod_blacklistlock_modules): Toggles the ability to load any further kernel modules into the system until the system has been rebooted.
 * [`simp::mountpoints`](#simpmountpoints): Add security settings to several mounts on the system.
 * [`simp::mountpoints::el6_tmp_fix`](#simpmountpointsel6_tmp_fix): There is a bizarre bug where ``/tmp`` and ``/var/tmp`` will have
 * [`simp::mountpoints::proc`](#simpmountpointsproc): Mount ``/proc``
@@ -684,8 +684,6 @@ a reboot is required if necessary.
 Default value: ``true``
 
 ### `simp::kmod_blacklist::lock_modules`
-
-into the system until the system has been rebooted.
 
 This will only take effect if the system has the ``kernel.modules_disabled``
 sysctl feature.

--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -211,6 +211,8 @@ class simp::admin (
   }
 
   if $set_selinux_login {
+    include selinux::install
+
     if $facts['selinux_current_mode'] and ($facts['selinux_current_mode'] != 'disabled') {
       selinux_login { "%${admin_group}":
         seuser    => $selinux_user_context,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.14.2",
+  "version": "4.14.3",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",
@@ -125,7 +125,7 @@
     },
     {
       "name": "simp/selinux",
-      "version_requirement": ">= 2.4.1 < 3.0.0"
+      "version_requirement": ">= 2.6.1 < 3.0.0"
     },
     {
       "name": "simp/simp_apache",


### PR DESCRIPTION
Fixed:
  - Call `selinux::install` prior to using native types that require the
    packages to be installed.