### PR TITLE
(SIMP-8958) Standardize assets in pupmod-simp-simp

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 *.erb eol=lf
 *.pp eol=lf
 *.sh eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-# NOTE: This file is managed by puppetsync.  Make sure any changes are
-#       reflected in the control repo.
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 .*.sw?
 .yardoc
 .idea/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,11 +45,13 @@ variables:
   BUNDLE_NO_PRUNE:   'true'
 
 
-# bundler dependencies + caching, optional RVM setup, with diagnostic output
-# --------------------------------------------------------------------------
+# bundler dependencies and caching
+#
+# - Cache bundler gems between pipelines foreach Ruby version
+# - Try to use cached and local resources before downloading dependencies
+# --------------------------------------
 .setup_bundler_env: &setup_bundler_env
   cache:
-    # Cache bundler gems between pipelines for each Ruby version
     key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
     paths:
       - '.vendor'
@@ -91,29 +93,26 @@ variables:
 
 # Assign a matrix level when your test will run.  Heavier jobs get higher numbers
 # NOTE: To skip all jobs with a SIMP_MATRIX_LEVEL, set SIMP_MATRIX_LEVEL=0
-# ------------------------------------------------------------------------------
 
 .relevant_file_conditions_trigger_spec_tests: &relevant_file_conditions_trigger_spec_tests
   changes:
     - .gitlab-ci.yml
     - .fixtures.yml
-    - .rspec
-    - metadata.json
     - "spec/spec_helper.rb"
     - "spec/{classes,unit,defines,type_aliases,types,hosts,lib}/**/*.rb"
-    - "{SIMP,data,manifests,files,types,lib}/**/*"
+    - "{SIMP,data,manifests,files,types,lib,functions}/**/*"
     - "templates/**/*.{erb,epp}"
     - "Gemfile"
   exists:
-    - "spec/{classes,unit,defines,type_aliases,types,hosts,lib}/**/*_spec.rb"
+    - "spec/{classes,unit,defines,type_aliases,types,hosts}/**/*_spec.rb"
 
 .relevant_file_conditions_trigger_acceptance_tests: &relevant_file_conditions_trigger_acceptance_tests
   changes:
     - .gitlab-ci.yml
-    - .fixtures.yml
     - "spec/spec_helper_acceptance.rb"
     - "spec/{helpers,acceptance}/**/*"
-    - "{SIMP,data,manifests,files,types,lib}/**/*"
+    - "spec/inspec_*/**/*"
+    - "{SIMP,data,manifests,files,types,lib,functions}/**/*"
     - "templates/**/*.{erb,epp}"
     - "Gemfile"
   exists:
@@ -216,28 +215,35 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_5: &pup_5
+.pup_5_x: &pup_5_x
   image: 'ruby:2.4'
   variables:
     PUPPET_VERSION: '~> 5.0'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_6: &pup_6
+.pup_5_pe: &pup_5_pe
+  image: 'ruby:2.4'
+  variables:
+    PUPPET_VERSION: '5.5.22'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+    MATRIX_RUBY_VERSION: '2.4'
+
+.pup_6_x: &pup_6_x
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '~> 6.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
-.pup_6_18_0: &pup_6_18_0
+.pup_6_pe: &pup_6_pe
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '6.18.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
-.pup_7: &pup_7
+.pup_7_x: &pup_7_x
   image: 'ruby:2.7'
   variables:
     PUPPET_VERSION: '~> 7.0'
@@ -281,7 +287,7 @@ variables:
 #=======================================================================
 
 releng_checks:
-  <<: *pup_5
+  <<: *pup_5_x
   <<: *setup_bundler_env
   stage: 'validation'
   tags: ['docker']
@@ -297,31 +303,39 @@ releng_checks:
 # Linting
 #-----------------------------------------------------------------------
 
+# NOTE: Don't add more lint checks here.
+#       puppet-lint is a validator, not a parser; it includes its own lexer and
+#       doesn't use the Puppet gem at all.  Running multiple lint tests against
+#       different Puppet versions won't accomplish anything.
+
 pup-lint:
-  <<: *pup_6
+  <<: *pup_6_x
   <<: *lint_tests
 
 # Unit Tests
 #-----------------------------------------------------------------------
 
-pup5-unit:
-  <<: *pup_5
+pup5.x-unit:
+  <<: *pup_5_x
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup6-unit:
-  <<: *pup_6
+pup5.pe-unit:
+  <<: *pup_5_pe
+  <<: *unit_tests
+
+pup6.x-unit:
+  <<: *pup_6_x
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup6.18.0-unit:
-  <<: *pup_6_18_0
+pup6.pe-unit:
+  <<: *pup_6_pe
   <<: *unit_tests
 
-pup7-unit:
-  <<: *pup_7
+pup7.x-unit:
+  <<: *pup_7_x
   <<: *unit_tests
-  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
 # ------------------------------------------------------------------------------
 #             NOTICE: **This file is maintained with puppetsync**
@@ -333,113 +347,163 @@ pup7-unit:
 # Repo-specific content
 # ==============================================================================
 
-pup5:
-  <<: *pup_5
+pup5.pe:
+  <<: *pup_5_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default]'
 
-pup6:
-  <<: *pup_6
+pup5.pe-base-apps:
+  <<: *pup_5_pe
   <<: *acceptance_base
-  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
-  script:
-    - 'bundle exec rake beaker:suites[default]'
-
-pup6-base-apps:
-  <<: *pup_6
-  <<: *acceptance_base
-  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'bundle exec rake beaker:suites[base_apps]'
 
-pup6-fips:
-  <<: *pup_6
+pup5.pe-fips:
+  <<: *pup_5_pe
   <<: *acceptance_base
-  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
 
-pup6-no_simp_server:
-  <<: *pup_6
+pup5.pe-no_simp_server:
+  <<: *pup_5_pe
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[no_simp_server]'
 
-pup6-netconsole:
-  <<: *pup_6
+pup5.pe-netconsole:
+  <<: *pup_5_pe
   <<: *acceptance_base
-  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[netconsole]'
 
-pup6-one_shot_scenario:
-  <<: *pup_6
+pup5.pe-one_shot_scenario:
+  <<: *pup_5_pe
   <<: *acceptance_base
-  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[scenario_one_shot]'
 
-pup6-poss_scenario:
-  <<: *pup_6
+pup5.pe-poss_scenario:
+  <<: *pup_5_pe
   <<: *acceptance_base
-  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[scenario_poss]'
 
-pup6-remote_access_scenario:
-  <<: *pup_6
+pup5.pe-remote_access_scenario:
+  <<: *pup_5_pe
   <<: *acceptance_base
-  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[scenario_remote_access]'
 
-pup6.18.0-win:
-  <<: *pup_6_18_0
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites[win_client]'
-
-pup6.18.0:
-  <<: *pup_6_18_0
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites[default]'
-
-pup6.18.0-base-apps:
-  <<: *pup_6_18_0
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites[base_apps]'
-
-pup6.18.0-fips:
-  <<: *pup_6_18_0
-  <<: *acceptance_base
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
-
-pup6.18.0-netconsole:
-  <<: *pup_6_18_0
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites[netconsole]'
-
-pup6.18.0-oel:
-  <<: *pup_6_18_0
+pup5.pe-oel:
+  <<: *pup_5_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup6.18.0-oel-fips:
-  <<: *pup_6_18_0
+pup5.pe-oel-fips:
+  <<: *pup_5_pe
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
 
-pup7:
-  <<: *pup_7
+pup6.x:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
+  script:
+    - 'bundle exec rake beaker:suites[default]'
+
+pup6.x-base-apps:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
+  script:
+    - 'bundle exec rake beaker:suites[base_apps]'
+
+pup6.x-fips:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
+
+pup6.x-no_simp_server:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
+  script:
+    - 'bundle exec rake beaker:suites[no_simp_server]'
+
+pup6.x-netconsole:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
+  script:
+    - 'bundle exec rake beaker:suites[netconsole]'
+
+pup6.x-one_shot_scenario:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
+  script:
+    - 'bundle exec rake beaker:suites[scenario_one_shot]'
+
+pup6.x-poss_scenario:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
+  script:
+    - 'bundle exec rake beaker:suites[scenario_poss]'
+
+pup6.x-remote_access_scenario:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
+  script:
+    - 'bundle exec rake beaker:suites[scenario_remote_access]'
+
+pup6.pe-win:
+  <<: *pup_6_pe
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[win_client]'
+
+pup6.pe:
+  <<: *pup_6_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default]'
+
+pup6.pe-base-apps:
+  <<: *pup_6_pe
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[base_apps]'
+
+pup6.pe-fips:
+  <<: *pup_6_pe
+  <<: *acceptance_base
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
+
+pup6.pe-netconsole:
+  <<: *pup_6_pe
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[netconsole]'
+
+pup6.pe-oel:
+  <<: *pup_6_pe
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,oel]'
+
+pup6.pe-oel-fips:
+  <<: *pup_6_pe
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'

--- a/.pmtignore
+++ b/.pmtignore
@@ -1,8 +1,10 @@
 # .pmtignore is required to mask symlinks from the `puppet module build` test
 # In the module's pipeline sanity checks
 # ------------------------------------------------------------------------------
-# NOTE: This file is managed by puppetsync.  Make sure any changes are
-#       reflected in the control repo.
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
 # ------------------------------------------------------------------------------
 .*.sw?
 .yardoc

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
 --no-class_inherits_from_params_class-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,11 @@
-* Thu Dec 24 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.15.0-0
+* Wed Jan 13 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.15.0
+- Removed EL6 from supported OSes
+
+* Thu Dec 24 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.15.0
 - Drop support for EL 6 due to EOL
 - Add support for Puppet 7
 
-* Mon Dec 21 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.15.0-0
+* Mon Dec 21 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.15.0
 - Fix bootstrap_simp_client to use fully qualified path on call to
   puppet.
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
 
 ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
@@ -10,7 +16,7 @@ group :test do
   gem 'rake'
   gem 'puppet', puppet_version
   gem 'rspec'
-  gem 'rspec-puppet', '~> 2.8.0'
+  gem 'rspec-puppet'
   gem 'hiera-puppet-helper'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
@@ -31,8 +37,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'beaker-windows'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.21.2', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.21.4', '< 2']
 end
 
 # Evaluate extra gemfiles if they exist

--- a/spec/acceptance/suites/scenario_poss/nodesets/default.yml
+++ b/spec/acceptance/suites/scenario_poss/nodesets/default.yml
@@ -12,6 +12,25 @@ HOSTS:
     platform:   el-7-x86_64
     box:        generic/oracle7
     hypervisor: <%= hypervisor %>
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
+        gpgkeys:
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+      simp:
+        baseurl: 'https://packagecloud.io/simp-project/6_X/el/$releasever/$basearch'
+        gpgkeys:
+          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
+      simp_dependencies:
+        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/$releasever/$basearch'
+        gpgkeys:
+          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
+          - https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
+          - https://yum.puppetlabs.com/RPM-GPG-KEY-puppet
+          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-94
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 
 CONFIG:
   log_level: verbose

--- a/spec/classes/01_classes/sssd/client_spec.rb
+++ b/spec/classes/01_classes/sssd/client_spec.rb
@@ -16,7 +16,11 @@ describe 'simp::sssd::client' do
         else
           context 'with default parameters' do
             it_should_behave_like 'sssd client'
-            it { is_expected.to_not contain_sssd__domain('LOCAL')}
+            if os_facts[:os][:release][:major] < '8'
+              it { is_expected.to contain_sssd__domain('LOCAL')}
+            else
+              it { is_expected.to_not contain_sssd__domain('LOCAL')}
+            end
             it { is_expected.to_not contain_sssd__domain('LDAP')}
           end
 

--- a/spec/classes/01_classes/sssd/client_spec.rb
+++ b/spec/classes/01_classes/sssd/client_spec.rb
@@ -16,11 +16,7 @@ describe 'simp::sssd::client' do
         else
           context 'with default parameters' do
             it_should_behave_like 'sssd client'
-            if os_facts[:os][:release][:major] == '7'
-              it { is_expected.to contain_sssd__domain('LOCAL')}
-            else
-              it { is_expected.to_not contain_sssd__domain('LOCAL')}
-            end
+            it { is_expected.to_not contain_sssd__domain('LOCAL')}
             it { is_expected.to_not contain_sssd__domain('LDAP')}
           end
 


### PR DESCRIPTION
This patch baselines the latest standardized assets for Puppet modules.

SIMP-9076 #close
[SIMP-8958] #comment Standardized assets in pupmod-simp-simp
[SIMP-8839] #comment Removed EL6 from supported OSes in pupmod-simp-simp
[SIMP-8489] #comment Updated pupmod-simp-simp GLCI pipeline to Puppet 6.18
[SIMP-8923] #comment Renamed 'sanity' to 'releng' in pupmod-simp-simp
[SIMP-8984] #comment Updated pupmod-simp-simp to new GLCI conventions

[SIMP-8958]: https://simp-project.atlassian.net/browse/SIMP-8958
[SIMP-8839]: https://simp-project.atlassian.net/browse/SIMP-8839
[SIMP-8489]: https://simp-project.atlassian.net/browse/SIMP-8489
[SIMP-8923]: https://simp-project.atlassian.net/browse/SIMP-8923
[SIMP-8984]: https://simp-project.atlassian.net/browse/SIMP-8984