### PR TITLE
(SIMP-8488) Update SIMP repo to be OS specific

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Wed Apr 28 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.15.0
+- As of SIMP 6.6 the SIMP yum repo is expected to  OS version specific allowing the
+  yum server to hosts SIMP RPMs and it dependencies for more than one OS.
+  The SIMP repo will now be under /var/www/yum/SIMP/<osfamily>/<os major version>/<arch>
+  instead of /var/www/yum/SIMP/<arch>.
+  This updates the creation of the yum config files to point to the correct directories.
+
 * Mon Mar 29 2021 Michael Riddle <michael.riddle@onyxpoint.com> - 4.15.0
 - Added additional parameters to simp::admin to allow for more fine-grained
   control of global admin and auditor sudo rules

--- a/manifests/yum/repo/local_simp.pp
+++ b/manifests/yum/repo/local_simp.pp
@@ -79,7 +79,7 @@ class simp::yum::repo::local_simp (
   Array[Simp::HostOrURL] $servers,
   Boolean                $enable_repo        = true,
   Simp::Urls             $extra_gpgkey_urls  = [],
-  String[1]              $relative_repo_path = 'SIMP',
+  String[1]              $relative_repo_path = "SIMP/${facts['os'][name]}/${facts['os']['release']['major']}",
   Optional[String[1]]    $baseurl            = simp::yum::repo::baseurl_string($servers, "${relative_repo_path}/${facts['architecture']}"),
   Optional[String[1]]    $gpgkey             = simp::yum::repo::gpgkey_string(
     $servers,

--- a/spec/acceptance/suites/default/10_yum_spec.rb
+++ b/spec/acceptance/suites/default/10_yum_spec.rb
@@ -35,9 +35,13 @@ describe 'simp yum configuration' do
         )
 
         # Mock out the actual YUM repos
+        os_data = fact_on(host,'os')
+
+        os_name =  os_data['name']
+        os_majrel = os_data['release']['major']
         repos = [
-          '/var/www/yum/SIMP/x86_64',
-          '/var/www/yum/CentOS/7/x86_64/Updates'
+          "/var/www/yum/SIMP/#{os_name}/#{os_majrel}/x86_64",
+          "/var/www/yum/#{os_name}/#{os_majrel}/x84_64/Updates"
         ]
 
         repos.each do |repo|

--- a/spec/classes/00_classes/yum/repo/local_simp_spec.rb
+++ b/spec/classes/00_classes/yum/repo/local_simp_spec.rb
@@ -37,7 +37,7 @@ describe 'simp::yum::repo::local_simp' do
 
       context 'with a single server name' do
         let(:params) {{ :servers => ['puppet.example.simp'] }}
-        let(:os_yum_path){ 'SIMP' }
+        let(:os_yum_path){ "SIMP/#{facts[:os][:name]}/#{facts[:os][:release][:major]}"}
         let(:os_baseurl){ "#{os_yum_path}/#{facts[:architecture]}" }
         let(:os_gpgkey){ "#{os_yum_path}/GPGKEYS" }
 
@@ -86,7 +86,7 @@ describe 'simp::yum::repo::local_simp' do
         it {
           os_maj_rel  = facts[:os][:release][:major]
           os_name     = facts[:os][:name]
-          os_yum_path =  'SIMP'
+          os_yum_path =  "SIMP/#{os_name}/#{os_maj_rel}"
           os_baseurl  = "#{os_yum_path}/#{facts[:architecture]}"
           arbitrary_url = 'https://yum.test.simp:4433/repos/' +
                           "SIMP/6/#{facts[:architecture]}"


### PR DESCRIPTION
- Update the creation of the /etc/yum.repo.d/simp.repo to OS specific.

SIMP-8488 comment updated pupmod-simp-simp
SIMP-9429 close