### PR TITLE
(SIMP-9698) Remove LOCAL sssd config

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -37,6 +37,7 @@ fixtures:
     crypto_policy: https://github.com/simp/pupmod-simp-crypto_policy.git
     deferred_resources: https://github.com/simp/pupmod-simp-deferred_resources.git
     dhcp: https://github.com/simp/pupmod-simp-dhcp.git
+    ds389: https://github.com/simp/pupmod-simp-ds389.git
     fips: https://github.com/simp/pupmod-simp-fips.git
     firewalld:
       repo: https://github.com/simp/pupmod-voxpupuli-firewalld.git
@@ -92,6 +93,7 @@ fixtures:
     simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap.git
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git
     simp_rsyslog: https://github.com/simp/pupmod-simp-simp_rsyslog.git
+    simp_ds389: https://github.com/simp/pupmod-simp-simp_ds389.git
     ssh: https://github.com/simp/pupmod-simp-ssh.git
     sshkeys_core:
       repo: https://github.com/simp/pupmod-puppetlabs-sshkeys_core.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -262,7 +262,24 @@ variables:
   <<: *setup_bundler_env
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_1
   script:
-    - 'bundle exec rake spec'
+    - 'bundle exec rake spec_prep'
+    - 'bundle exec rspec spec/classes/00_classes'
+    - 'bundle exec rspec spec/defines'
+    - 'bundle exec rspec spec/facter'
+    - 'bundle exec rspec spec/functions'
+    - 'bundle exec rspec spec/type_aliases'
+    - 'bundle exec rspec spec/unit'
+
+.slow_unit_tests: &slow_unit_tests
+  stage: 'validation'
+  tags: ['docker']
+  <<: *setup_bundler_env
+  <<: *with_SIMP_SPEC_MATRIX_LEVEL_1
+  script:
+    - 'bundle exec rake spec_prep'
+    - 'bundle exec rspec spec/classes/01_classes'
+    - 'bundle exec rspec spec/classes/10_classes'
+    - 'bundle exec rspec spec/classes/20_classes'
 
 .acceptance_base: &acceptance_base
   stage: 'acceptance'
@@ -315,13 +332,26 @@ pup6.x-unit:
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
+pup6.x-unit_slow:
+  <<: *pup_6_x
+  <<: *slow_unit_tests
+  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
+
 pup6.pe-unit:
   <<: *pup_6_pe
   <<: *unit_tests
 
+pup6.pe-unit_slow:
+  <<: *pup_6_pe
+  <<: *slow_unit_tests
+
 pup7.x-unit:
   <<: *pup_7_x
   <<: *unit_tests
+
+pup7.x-unit_slow:
+  <<: *pup_7_x
+  <<: *slow_unit_tests
 
 # ------------------------------------------------------------------------------
 #             NOTICE: **This file is maintained with puppetsync**

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Tue Jun 08 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.15.0
+* Tue Jun 08 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.15.1
 - sssd::client no longer creates a local provider.
 - The version of pupmud-simp-sssd required by this module was updated to 7.0
   because the version of sssd installed does not require a provider.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+* Tue Jun 08 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.15.0
+- sssd::client no longer creates a local provider.
+- The version of pupmud-simp-sssd required by this module was updated to 7.0
+  because the version of sssd installed does not require a provider.
+  If you require a local provider use the  sssd module to create one.
+- NOTES FOR UPGRADE: The local domain was configured by default in earlier versions of SIMP because
+  sssd would not start without a domain. A "LOCAL" entry was added to the list
+  of sssd domains to create in hiera.   You will need to remove this domain from
+  the list of domains in hiera unless you are configuring a "LOCAL" domain
+  somewhere else in your puppet code. The hiera variable is sssd::domains.
+  If you do not remove this domain from the list of domains in hiera
+  and are not configuring it yourself sssd will fail to start because it will
+  not find a provider for the "LOCAL" domain.
+- Updated the the acceptance tests that use an LDAP server to also test against
+  an instance of 389ds on el8.
+
 * Tue Jun 08 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 4.15.0
 - Removed
   - Drop support for Puppet 5

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,16 +1,18 @@
 * Tue Jun 08 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.15.1
 - sssd::client no longer creates a local provider.
-- The version of pupmod-simp-sssd required by this module was updated to 7.0
-  because the version of sssd installed does not require a provider.
-  If you require a local provider use the  sssd module to create one.
-- NOTES FOR UPGRADE: The local domain was configured by default in earlier versions of SIMP because
-  sssd would not start without a domain. A "LOCAL" entry was added to the list
-  of sssd domains to create in hiera.   You will need to remove this domain from
-  the list of domains in hiera unless you are configuring a "LOCAL" domain
-  somewhere else in your puppet code. The hiera variable is sssd::domains.
-  If you do not remove this domain from the list of domains in hiera
-  and are not configuring it yourself sssd will fail to start because it will
-  not find a provider for the "LOCAL" domain.
+  - The version of pupmod-simp-sssd required by this module was updated to 7.0
+    because the version of sssd installed does not require a provider.
+    If you require a local provider use the  sssd module to create one.
+  - NOTES FOR UPGRADE: The local domain was configured by default in earlier versions of SIMP because
+    sssd would not start without a domain. A "LOCAL" entry was added to the list
+    of sssd domains to create in hiera.   You will need to remove this domain from
+    the list of domains in hiera unless you are configuring a "LOCAL" domain
+    somewhere else in your puppet code. The hiera variable is sssd::domains.
+    If you do not remove this domain from the list of domains in hiera
+    and are not configuring it yourself sssd will fail to start because it will
+    not find a provider for the "LOCAL" domain.
+  - Added warning if LOCAL domain was found in sssd::domains. Also added ability
+    to disable the warning.
 - Updated the the acceptance tests that use an LDAP server to also test against
   an instance of 389ds on el8.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * Tue Jun 08 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.15.1
 - sssd::client no longer creates a local provider.
-- The version of pupmud-simp-sssd required by this module was updated to 7.0
+- The version of pupmod-simp-sssd required by this module was updated to 7.0
   because the version of sssd installed does not require a provider.
   If you require a local provider use the  sssd module to create one.
 - NOTES FOR UPGRADE: The local domain was configured by default in earlier versions of SIMP because

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -128,5 +128,3 @@ simp::nsswitch::ldap_options:
     - 'files [!NOTFOUND=return]'
     - 'ldap'
 
-simp::sssd::client::local_domain: false
-

--- a/data/os/CentOS-7.yaml
+++ b/data/os/CentOS-7.yaml
@@ -14,8 +14,6 @@ simp::server::scenario_map:
 # Most EL7 systems point at OpenLDAP and we don't want to cause user issues
 simp::sssd::client::ldap_server_type: 'plain'
 
-simp::sssd::client::local_domain: true
-
 simp::puppetdb::cipher_suites:
   - TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
   - TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384

--- a/data/os/OracleLinux-7.yaml
+++ b/data/os/OracleLinux-7.yaml
@@ -13,7 +13,6 @@ simp::server::scenario_map:
 
 # Most EL7 systems point at OpenLDAP and we don't want to cause user issues
 simp::sssd::client::ldap_server_type: 'plain'
-simp::sssd::client::local_domain: true
 
 simp::puppetdb::cipher_suites:
   - TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384

--- a/data/os/RedHat-7.yaml
+++ b/data/os/RedHat-7.yaml
@@ -14,8 +14,6 @@ simp::server::scenario_map:
 # Most EL7 systems point at OpenLDAP and we don't want to cause user issues
 simp::sssd::client::ldap_server_type: 'plain'
 
-simp::sssd::client::local_domain: true
-
 simp::puppetdb::cipher_suites:
   - TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
   - TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384

--- a/manifests/sssd/client.pp
+++ b/manifests/sssd/client.pp
@@ -59,7 +59,7 @@ class simp::sssd::client (
   Hash                  $ldap_domain_options   = {},
   Enum['plain','389ds'] $ldap_server_type,
   Hash                  $ldap_provider_options = {},
-  Boolean               $autofs                = true, #deprecateddd
+  Boolean               $autofs                = true, #deprecated
   Boolean               $sudo                  = true, #deprecated
   Boolean               $ssh                   = true, #deprecated
   Boolean               $enumerate_users       = false,

--- a/manifests/sssd/client.pp
+++ b/manifests/sssd/client.pp
@@ -4,12 +4,10 @@
 # as an example of what you can do to make it work for your environment.
 #
 # @param local_domain
-#   Configure the 'LOCAL' domain
-#
-#   To use the local domain you must include 'LOCAL'  in sssd::domains via hiera
+#   DEPRECATED:  This param does nothing.  It will be removed in the next version
 #
 # @param local_domain_options
-#   A Hash of options to pass directly into the `sssd::domain` defined type
+#   DEPRECATED:  This param does nothing.  It will be removed in the next version
 #
 # @param ldap_domain
 #   Configure the LDAP domain
@@ -55,13 +53,13 @@
 # @author https://github.com/simp/pupmod-simp-simp/graphs/contributors
 #
 class simp::sssd::client (
-  Boolean               $local_domain,
-  Hash                  $local_domain_options  = {},
+  Boolean               $local_domain          = false, #deprecated
+  Hash                  $local_domain_options  = {},    #deprecated
   Boolean               $ldap_domain           = simplib::lookup('simp_options::ldap', { 'default_value' => false }),
   Hash                  $ldap_domain_options   = {},
   Enum['plain','389ds'] $ldap_server_type,
   Hash                  $ldap_provider_options = {},
-  Boolean               $autofs                = true, #deprecated
+  Boolean               $autofs                = true, #deprecateddd
   Boolean               $sudo                  = true, #deprecated
   Boolean               $ssh                   = true, #deprecated
   Boolean               $enumerate_users       = false,
@@ -72,21 +70,6 @@ class simp::sssd::client (
   simplib::module_metadata::assert($module_name, { 'blacklist' => ['Windows'] })
 
   include 'sssd'
-
-  if $local_domain {
-    $_local_domain_defaults = {
-      'description' => 'LOCAL Users Domain',
-      'min_id'      => $min_id
-    }
-
-    sssd::domain { 'LOCAL':
-      access_provider   => 'permit',
-      enumerate         => false,
-      cache_credentials => false,
-      id_provider       => 'files',
-      *                 => $_local_domain_defaults + $local_domain_options
-    }
-  }
 
   if $ldap_domain {
     $_ldap_domain_defaults = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -149,7 +149,7 @@
     },
     {
       "name": "simp/sssd",
-      "version_requirement": ">= 6.1.3 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     },
     {
       "name": "simp/sudo",

--- a/spec/acceptance/suites/default/files/default_hiera.yaml
+++ b/spec/acceptance/suites/default/files/default_hiera.yaml
@@ -9,7 +9,6 @@ simp_options::ldap::bind_hash: '{SSHA}foobarbaz!!!!'
 simp_options::ldap::sync_pw: 's00per sekr3t!'
 simp_options::ldap::sync_hash: '{SSHA}foobarbaz!!!!'
 simp_options::ldap::root_hash: '{SSHA}foobarbaz!!!!'
-sssd::domains: ['LOCAL']
 simp::scenario: simp
 simp_options::ldap: false
 simp_options::rsync: false
@@ -20,6 +19,8 @@ simp_options::trusted_nets: ['0.0.0.0/0']
 # the below line might fix issues on el6
 # auditd::enable_auditing: false
 
+# Without this sssd fails to start.
+sssd::enable_files_domain: true
 # YUM Settings
 simp::yum::repo::simp::servers:
   - "%{facts.fqdn}"

--- a/spec/acceptance/suites/scenario_one_shot/00_simp_spec.rb
+++ b/spec/acceptance/suites/scenario_one_shot/00_simp_spec.rb
@@ -43,7 +43,6 @@ describe 'simp "one_shot" scenario' do
 simp_options::dns::servers: ['8.8.8.8']
 simp_options::puppet::server: #{host_fqdn}
 simp_options::puppet::ca: #{host_fqdn}
-sssd::domains: ['LOCAL']
 
 # Settings required for acceptance test, some may be required
 simp::scenario: one_shot
@@ -76,6 +75,8 @@ simp_options::trusted_nets: ['ALL']
 # Settings to make beaker happy
 ssh::server::conf::permitrootlogin: true
 ssh::server::conf::authorizedkeysfile: .ssh/authorized_keys
+
+sssd::enable_files_domain: true
 
 pam::access::users:
   vagrant:

--- a/spec/acceptance/suites/scenario_remote_access/00_remote_access_spec.rb
+++ b/spec/acceptance/suites/scenario_remote_access/00_remote_access_spec.rb
@@ -9,14 +9,19 @@ test_name 'remote_access scenario'
 # for a user to 'log into' a client (and nothing more!).  The test
 # procedure is as follows:
 #   1. Create an ldap server on a server node
-#   2. Add an LDAP 'test.user'
+#   2. Add an LDAP 'testuser'
 #   3. Apply the remote_access scenario on client nodes.
-#   4. Attempt to ssh as 'test.user' to the client nodes.
+#   4. Attempt to ssh as 'testuser' to the client nodes.
 
 describe 'remote_access scenario' do
-  let(:server_manifest) {
+  let(:plain_server_manifest) {
     <<-EOS
       include 'simp_openldap::server'
+    EOS
+  }
+  let(:ds389_server_manifest) {
+    <<-EOS
+      include 'simp_ds389::instances::accounts'
     EOS
   }
   let(:client_manifest) {
@@ -25,89 +30,128 @@ describe 'remote_access scenario' do
       include 'simp'
     EOS
   }
+  let(:root_pw) { 'suP3rP@ssw0r!'}
 
-  ldap_server = only_host_with_role(hosts, 'ldap_server')
+
+  ldap_servers = hosts_with_role(hosts, 'ldap_server')
   clients = hosts_with_role(hosts, 'client')
 
   # Both client and server need these
-  let(:server_fqdn) { fact_on(ldap_server, 'fqdn') }
-  let(:base_dn) { fact_on(ldap_server, 'domain').split('.').map{ |d| "dc=#{d}" }.join(',') }
-  # For now default to openldap server until test includes a 389DS server
-  let(:ldap_type) { if fact_on(ldap_server,'operatingsystemmajrelease') == '7'
-                     'plain'
-                   else
-                     '389ds'
-                   end
-  }
-  context "set up simp_openldap::server on #{ldap_server}" do
-    let(:server_hieradata)      { File.read(File.expand_path('templates/server_hieradata.yaml.erb', File.dirname(__FILE__))) }
-    let(:add_testuser)          { File.read(File.expand_path('templates/add_testuser.ldif.erb', File.dirname(__FILE__))) }
-    let(:add_testuser_to_admin) { File.read(File.expand_path('templates/add_testuser_to_admin.ldif.erb', File.dirname(__FILE__))) }
+  ldap_servers.each do |ldap_server|
 
-    # FIXME: SIMP-9136
-    # Required for simp ldap password policy
-    it 'should set up needed repositories' do
-      on(ldap_server, 'curl -s https://packagecloud.io/install/repositories/simp-project/6_X_Dependencies/script.rpm.sh | bash')
-    end
+    context 'Test running on current LDAP server #{ldap_server}' do
+      let(:server_fqdn) { fact_on(ldap_server, 'fqdn') }
+      let(:base_dn) { fact_on(ldap_server, 'domain').split('.').map{ |d| "dc=#{d}" }.join(',') }
+      # For now default to openldap server until test includes a 389DS server
+      let(:ldap_type) {
+        if fact_on(ldap_server,'operatingsystemmajrelease') == '7'
+          'plain'
+        else
+          '389ds'
+        end
+      }
+      let(:common_hieradata)      { File.read(File.expand_path('templates/common_hieradata.yaml.erb', File.dirname(__FILE__))) }
+      let(:server_hieradata)      { File.read(File.expand_path("templates/#{ldap_type}/server_hieradata.yaml.erb", File.dirname(__FILE__))) }
+      let(:hieradata)             { "#{common_hieradata}" + "\n#{server_hieradata}" }
+      let(:add_testuser)          { File.read(File.expand_path("templates/#{ldap_type}/add_testuser.erb", File.dirname(__FILE__))) }
+      let(:root_pw)               { 'suP3rP@ssw0r!' }
+      # The instance name from simp_ds389
+      let(:ds_root_name)          { 'accounts' }
+      let(:test_user) { 'test.user' }
 
-    it 'should configure hiera' do
-       set_hieradata_on(ldap_server, ERB.new(server_hieradata).result(binding))
-    end
-    it 'should set up an ldap server' do
-      apply_manifest_on(ldap_server, server_manifest, :catch_failures => true)
-      apply_manifest_on(ldap_server, server_manifest, :acceptable_exit_codes => [0,2])
-    end
-    it 'should be able to connect and use ldapsearch' do
-      on(ldap_server, "ldapsearch -Z -LLL -D cn=LDAPAdmin,ou=People,#{base_dn} -H ldap://#{server_fqdn} -w suP3rP@ssw0r!")
-    end
-    it 'should be able to add a user' do
-      create_remote_file(ldap_server, '/tmp/add_testuser.ldif', ERB.new(add_testuser).result(binding))
-
-      on(ldap_server, "ldapadd -Z -D cn=LDAPAdmin,ou=People,#{base_dn} -H ldap://#{server_fqdn} -w suP3rP@ssw0r! -x -f /tmp/add_testuser.ldif")
-
-      result = on(ldap_server, "ldapsearch -Z -LLL -D cn=LDAPAdmin,ou=People,#{base_dn} -H ldap://#{server_fqdn} -w suP3rP@ssw0r! -x uid=test.user")
-      expect(result.stdout).to include("dn: uid=test.user,ou=People,#{base_dn}")
-    end
-    it 'should be able to add user to group' do
-      create_remote_file(ldap_server, '/tmp/add_testuser_to_admin.ldif', ERB.new(add_testuser_to_admin).result(binding))
-
-      on(ldap_server, "ldapmodify -Z -D cn=LDAPAdmin,ou=People,#{base_dn} -H ldap://#{server_fqdn} -w suP3rP@ssw0r! -x -f /tmp/add_testuser_to_admin.ldif")
-
-      result = on(ldap_server, "ldapsearch -Z -LLL -D cn=LDAPAdmin,ou=People,#{base_dn} -H ldap://#{server_fqdn} -w suP3rP@ssw0r! -x cn=test.user")
-      expect(result.stdout).to include("dn: cn=test.user,ou=Group,#{base_dn}")
-    end
-    # Copy in the password-less key
-    it 'should copy the test.user private key' do
-      scp_to(ldap_server, './spec/acceptance/suites/scenario_remote_access/files/id_rsa.example', '/tmp/testkey')
-      on(ldap_server, 'chmod 600 /tmp/testkey')
-    end
-  end
-
-  clients.each do |client|
-    context "set up remote_access scenario on #{client}" do
-      let(:client_hieradata)      { File.read(File.expand_path('templates/client_hieradata.yaml.erb', File.dirname(__FILE__))) }
-      let(:client_fqdn) { fact_on(client, 'fqdn') }
-
-      # FIXME: SIMP-9136
-      # Need this for sudosh2
-      it 'should set up needed repositories' do
-        on(client, 'curl -s https://packagecloud.io/install/repositories/simp-project/6_X_Dependencies/script.rpm.sh | bash')
-      end
 
       it 'should configure hiera' do
-        set_hieradata_on(client, ERB.new(client_hieradata).result(binding))
+         set_hieradata_on(ldap_server, ERB.new(hieradata).result(binding))
       end
-      it 'should apply the remote_access scenario without error' do
-        apply_manifest_on(client, client_manifest, :catch_failures => true)
-        apply_manifest_on(client, client_manifest, :catch_failures => true)
+
+      if fact_on(ldap_server,'operatingsystemmajrelease') == '7'
+        context 'on el7 install openldap server and create users' do
+          let(:add_testuser_to_admin) { File.read(File.expand_path("templates/#{ldap_type}/add_testuser_to_admin.erb", File.dirname(__FILE__))) }
+
+          # Needed for ppassword policy
+          it 'should set up needed repositories' do
+            on(ldap_server, 'yum -y install https://download.simp-project.com/simp-release-community.rpm')
+          end
+
+          it 'should set up an openldap ldap server' do
+            apply_manifest_on(ldap_server, plain_server_manifest, :catch_failures => true)
+            apply_manifest_on(ldap_server, plain_server_manifest, :acceptable_exit_codes => [0,2])
+          end
+          it 'should be able to connect and use ldapsearch' do
+            on(ldap_server, "ldapsearch -Z -LLL -D cn=LDAPAdmin,ou=People,#{base_dn} -H ldap://#{server_fqdn} -w #{root_pw}")
+          end
+          it 'should be able to add a user' do
+            create_remote_file(ldap_server, '/tmp/add_testuser.ldif', ERB.new(add_testuser).result(binding))
+
+            on(ldap_server, "ldapadd -Z -D cn=LDAPAdmin,ou=People,#{base_dn} -H ldap://#{server_fqdn} -w #{root_pw} -x -f /tmp/add_testuser.ldif")
+
+            result = on(ldap_server, "ldapsearch -Z -LLL -D cn=LDAPAdmin,ou=People,#{base_dn} -H ldap://#{server_fqdn} -w #{root_pw} -x uid=#{test_user}")
+            expect(result.stdout).to include("dn: uid=#{test_user},ou=People,#{base_dn}")
+          end
+          it 'should be able to add user to group' do
+            create_remote_file(ldap_server, '/tmp/add_testuser_to_admin.ldif', ERB.new(add_testuser_to_admin).result(binding))
+
+            on(ldap_server, "ldapmodify -Z -D cn=LDAPAdmin,ou=People,#{base_dn} -H ldap://#{server_fqdn} -w #{root_pw} -x -f /tmp/add_testuser_to_admin.ldif")
+
+            result = on(ldap_server, "ldapsearch -Z -LLL -D cn=LDAPAdmin,ou=People,#{base_dn} -H ldap://#{server_fqdn} -w #{root_pw} -x cn=#{test_user}")
+            expect(result.stdout).to include("dn: cn=#{test_user},ou=Group,#{base_dn}")
+          end
+        end
+      else
+        context 'on versions later than el7 install 389ds and create users' do
+          it 'should install 389ds with simp_ds389' do
+            apply_manifest_on(ldap_server, ds389_server_manifest, :catch_failures => true)
+            apply_manifest_on(ldap_server, ds389_server_manifest, :acceptable_exit_codes => [0,2])
+          end
+          it 'should add the test user' do
+            create_remote_file(ldap_server, '/root/ldap_add_user',ERB.new(add_testuser).result(binding))
+            on(ldap_server, 'chmod +x /root/ldap_add_user')
+            on(ldap_server, '/root/ldap_add_user')
+            result = on(ldap_server, "dsidm #{ds_root_name} -b #{base_dn} user list")
+            expect(result.stdout).to include("#{test_user}")
+          end
+        end
+      end # If el7
+
+
+      # Copy in the password-less key
+      it 'should copy the testuser private key' do
+        scp_to(ldap_server, './spec/acceptance/suites/scenario_remote_access/files/id_rsa.example', '/tmp/testkey')
+        on(ldap_server, 'chmod 600 /tmp/testkey')
       end
-      it 'should id test.user' do
-        result = on(client, 'id test.user', :acceptable_exit_codes => [0])
-        expect(result.stdout).to include("uid=10000(test.user)")
-      end
-      it 'should ssh from *server* to client' do
-        on(ldap_server, "ssh -o StrictHostKeyChecking=no -i /tmp/testkey test.user@#{client} echo Logged in successfully")
-      end
-    end
-  end
+
+      clients.each do |client|
+        context "set up remote_access scenario on #{client}" do
+          let(:common_hieradata)      { File.read(File.expand_path('templates/common_hieradata.yaml.erb', File.dirname(__FILE__))) }
+          let(:client_hieradata)      { File.read(File.expand_path('templates/client_hieradata.yaml.erb', File.dirname(__FILE__))) }
+          let(:cc_hieradata)          { "#{common_hieradata}" + "\n#{client_hieradata}" }
+          let(:client_fqdn) { fact_on(client, 'fqdn') }
+
+          # FIXME: SIMP-9136
+          #  Still needed for tlog on el7.
+          if fact_on(ldap_server,'operatingsystemmajrelease') == '7'
+            it 'should set up needed repositories' do
+              on(client, 'yum -y install https://download.simp-project.com/simp-release-community.rpm')
+            end
+          end
+
+          it 'should configure hiera' do
+            set_hieradata_on(client, ERB.new(cc_hieradata).result(binding))
+          end
+          it 'should apply the remote_access scenario without error' do
+            apply_manifest_on(client, client_manifest, :catch_failures => true)
+            apply_manifest_on(client, client_manifest, :catch_failures => true)
+          end
+          it 'should id testuser' do
+            result = on(client, "id #{test_user}", :acceptable_exit_codes => [0])
+            expect(result.stdout).to include("uid=10000(#{test_user})")
+          end
+          it 'should ssh from *server* to client' do
+            on(ldap_server, "ssh -o StrictHostKeyChecking=no -i /tmp/testkey #{test_user}@#{client} echo Logged in successfully")
+          end
+        end
+      end # End client loop
+
+    end  # End the LDAP Server Context
+  end  # End server loop
 end

--- a/spec/acceptance/suites/scenario_remote_access/nodesets/default.yml
+++ b/spec/acceptance/suites/scenario_remote_access/nodesets/default.yml
@@ -11,8 +11,18 @@ HOSTS:
       - server
       - default
       - ldap_server
+      - openldap
     platform:   el-7-x86_64
     box:        centos/7
+    hypervisor: <%= hypervisor %>
+
+  server-el8.simp.beaker:
+    roles:
+      - server
+      - ldap_server
+      - ds389
+    platform:   el-8-x86_64
+    box:        centos/8
     hypervisor: <%= hypervisor %>
 
   client-el7.simp.beaker:

--- a/spec/acceptance/suites/scenario_remote_access/nodesets/oel.yml
+++ b/spec/acceptance/suites/scenario_remote_access/nodesets/oel.yml
@@ -9,10 +9,20 @@ HOSTS:
   server-oel7.simp.beaker:
     roles:
       - server
-      - default
       - ldap_server
+      - openldap
     platform:   el-7-x86_64
     box:        generic/oracle7
+    hypervisor: <%= hypervisor %>
+
+  server-oel8.simp.beaker:
+    roles:
+      - server
+      - default
+      - ldap_server
+      - ds389
+    platform:   el-8-x86_64
+    box:        generic/oracle8
     hypervisor: <%= hypervisor %>
 
   client-oel7.simp.beaker:

--- a/spec/acceptance/suites/scenario_remote_access/templates/389ds/add_testuser.erb
+++ b/spec/acceptance/suites/scenario_remote_access/templates/389ds/add_testuser.erb
@@ -1,0 +1,12 @@
+dsidm "<%= ds_root_name %>" -b "<%= base_dn %>" posixgroup create --cn <%= test_user %> --gidNumber 10000
+
+dsidm "<%= ds_root_name %>" -b "<%= base_dn %>" user create --cn <%= test_user %> --uid <%= test_user %> --displayName "Test User" --uidNumber 10000 --gidNumber 10000 --homeDirectory /home/testuser
+
+# Associated with the private key in files/
+# This key is password-less
+dsidm "<%= ds_root_name %>" -b "<%= base_dn %>" user  modify <%= test_user %> add:nsSshPublicKey:"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDI9DPUsQXNTqU2nWShmMCnGOXPDYazX4yHFrI7Xw3p/r62Li6zaSSNuJ8varX24j8NNMK9EeYcQnrkEu+PE7kO7UTnat3AQFASAlnZTkqo4F/bQjoVEvVaZHaAupiiQYMJny+8R/0VrPGQGx3IR2ORuMs0nAZjjZK3pdmMNNi284Rox3qi9qCeQY0yO3sdyygRwtKyAJvOSwTVrTuYQrMVzWbWsbBk7wO27A7bwbaCZ/nZFzjwB+t3HTJ2t9ZSxCtH0tnvPUEtswZdVN+yAKwka8dyULvhnGtfc8wcA8OJoYmb5Sqh67QU+ofBRkj1I0F33VfEyrNME9q5jT0V2/uS5WJjUNPScBZeZjR60ZA791ZrmyAw9ybK55h8SNmZWi3/PyteaZnHVY4fe0M38MtHy2qh+vBp2o/aVIhGo/cWotQpZaPMnJeNzqlvNQXm04Rz+5BeOZBAOLH/TiJFXpEoNYLYPSy7p1Y22QKPoMmgjp5MiCvBhY1v60rHnogBOTor5rebD2R+KyVK6beLb/nABCoJNvquefE+fpo/5+zVr9IfCDnnTJLKtUuNetk6D0gl76bhsfiEsWz2r1ND7ihXjcv3z3v38V4mr8m3cmAuVU7mNYHZvwM5i55VNitS1qUiSkvccKBbnxa15e0YxXUfnq8PI/Yq2Iky/K4am/XMkw=="
+
+#suP3rP@ssw0r!
+dsidm "<%= ds_root_name %>" -b "<%= base_dn %>" user modify <%= test_user %> add:userPassword:{SSHA}r2GaizHFWY8pcHpIClU0ye7vsO4uHv/y
+
+dsidm "<%= ds_root_name %>" -b "<%= base_dn %>" posixgroup modify administrators add:member:uid=<%= test_user %>,ou=People,<%= base_dn %>

--- a/spec/acceptance/suites/scenario_remote_access/templates/389ds/server_hieradata.yaml.erb
+++ b/spec/acceptance/suites/scenario_remote_access/templates/389ds/server_hieradata.yaml.erb
@@ -1,0 +1,6 @@
+# Set up LDAP
+simp_ds389::instances::accounts::root_pw: <%= root_pw %>
+simp_ds389::instances::accounts::password_policy:
+  passwordResetFailureCount: 4
+  passwordMinAge: 0
+

--- a/spec/acceptance/suites/scenario_remote_access/templates/client_hieradata.yaml.erb
+++ b/spec/acceptance/suites/scenario_remote_access/templates/client_hieradata.yaml.erb
@@ -1,20 +1,3 @@
----
-# Mock up ldap
-
-simp_options::ldap::uri:
-  - 'ldap://<%= server_fqdn %>'
-simp_options::ldap::base_dn: '<%= base_dn %>'
-simp_options::ldap::bind_dn: 'cn=hostAuth,ou=Hosts,<%= base_dn %>'
-simp_options::ldap::bind_pw: 'foobarbaz'
-simp_options::ldap::bind_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
-simp_options::ldap::sync_dn: 'cn=LDAPSync,ou=Hosts,<%= base_dn %>'
-simp_options::ldap::sync_pw: 'foobarbaz'
-simp_options::ldap::sync_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
-simp_options::ldap::root_dn: 'cn=LDAPAdmin,ou=People,<%= base_dn %>'
-simp_options::ldap::master: 'ldap://<%= server_fqdn %>'
-# suP3rP@ssw0r!
-simp_openldap::server::conf::rootpw: "{SSHA}ZcqPNbcqQhDNF5jYTLGl+KAGcrHNW9oo"
-
 # Required for simp options
 simp_options::puppet::server: <%= client_fqdn %>
 simp_options::puppet::ca: <%= client_fqdn %>
@@ -25,12 +8,12 @@ sssd::domains:
 simp_options::dns::servers: ['8.8.8.8']
 
 # Emulate remote_access hiera
+# Note:ldap settings and pki settings are in common file
+# that is merged with this file.
 simp::scenario: remote_access
 simp_options::auditd: false
-simp_options::clamav: false
 simp_options::firewall: false
 simp_options::haveged: false
-simp_options::ldap: true
 simp_options::logrotate: false
 simp_options::pam: true
 # Set to 'true' for non-puppetserver based acceptance
@@ -44,10 +27,6 @@ simp_options::kerberos: false
 
 # Extra tweaks for acceptance
 simp_options::rsync: false
-simp_options::clamav: false
-simp_options::pki: true
-simp_options::pki::source: '/etc/pki/simp-testing/pki'
-simp_options::trusted_nets: ['ALL']
 
 # Settings to make beaker happy
 pam::access::default_deny: false
@@ -58,5 +37,3 @@ sudo::user_specifications:
     user_list: ['vagrant', 'test.user']
     cmnd: ['ALL']
     passwd: false
-# Settings for the type of LDAP server
-simp::sssd::client::ldap_server_type: <%= ldap_type %>

--- a/spec/acceptance/suites/scenario_remote_access/templates/common_hieradata.yaml.erb
+++ b/spec/acceptance/suites/scenario_remote_access/templates/common_hieradata.yaml.erb
@@ -1,7 +1,4 @@
 ---
-# Set up LDAP
-simp_openldap::server::conf::default_ldif::ppolicy_pwd_min_age: 0
-simp_openldap::server::conf::default_ldif::ppolicy_pwd_failure_count_interval: 4
 simp_options::ldap: true
 simp_options::ldap::uri:
   - 'ldap://<%= server_fqdn %>'
@@ -15,7 +12,6 @@ simp_options::ldap::sync_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
 simp_options::ldap::root_dn: 'cn=LDAPAdmin,ou=People,<%= base_dn %>'
 simp_options::ldap::master: 'ldap://<%= server_fqdn %>'
 # suP3rP@ssw0r!
-simp_openldap::server::conf::rootpw: "{SSHA}ZcqPNbcqQhDNF5jYTLGl+KAGcrHNW9oo"
 
 # Extra tweaks for acceptance
 simp_options::pki: true

--- a/spec/acceptance/suites/scenario_remote_access/templates/plain/add_testuser.erb
+++ b/spec/acceptance/suites/scenario_remote_access/templates/plain/add_testuser.erb
@@ -1,16 +1,16 @@
-dn: cn=test.user,ou=Group,<%= base_dn %>
+dn: cn=<%= test_user %>,ou=Group,<%= base_dn %>
 objectClass: posixGroup
 objectClass: top
-cn: test.user
+cn: testuser
 gidNumber: 10000
 description: 'Test user'
 
-dn: uid=test.user,ou=People,<%= base_dn %>
-uid: test.user
-cn: test.user
+dn: uid=<%= test_user %>,ou=People,<%= base_dn %>
+uid: <%= test_user %>
+cn: <%= test_user %>
 givenName: Test
 sn: User
-mail: test.user@funurl.net
+mail: <%= test_user %>@funurl.net
 objectClass: inetOrgPerson
 objectClass: posixAccount
 objectClass: top
@@ -26,6 +26,6 @@ sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDI9DPUsQXNTqU2nWShmMCnGOXPDY
 loginShell: /bin/bash
 uidNumber: 10000
 gidNumber: 10000
-homeDirectory: /home/test.user
+homeDirectory: /home/<%= test_user %>
 #suP3rP@ssw0r!
 userPassword: {SSHA}r2GaizHFWY8pcHpIClU0ye7vsO4uHv/y

--- a/spec/acceptance/suites/scenario_remote_access/templates/plain/add_testuser_to_admin.erb
+++ b/spec/acceptance/suites/scenario_remote_access/templates/plain/add_testuser_to_admin.erb
@@ -1,4 +1,4 @@
 dn: cn=administrators,ou=Group,<%= base_dn %>
 changetype: modify
 add: memberUid
-memberUid: test.user
+memberUid: <%= test_user %>

--- a/spec/acceptance/suites/scenario_remote_access/templates/plain/server_hieradata.yaml.erb
+++ b/spec/acceptance/suites/scenario_remote_access/templates/plain/server_hieradata.yaml.erb
@@ -1,0 +1,5 @@
+# Set up LDAP
+simp_openldap::server::conf::default_ldif::ppolicy_pwd_min_age: 0
+simp_openldap::server::conf::default_ldif::ppolicy_pwd_failure_count_interval: 4
+# suP3rP@ssw0r!
+simp_openldap::server::conf::rootpw: "{SSHA}ZcqPNbcqQhDNF5jYTLGl+KAGcrHNW9oo"

--- a/spec/acceptance/suites/win_client/00_default_spec.rb
+++ b/spec/acceptance/suites/win_client/00_default_spec.rb
@@ -13,7 +13,6 @@ describe 'windows node' do
   let(:hieradata) {{
     'simp_options::puppet::server' => host_fqdn,
     'simp_options::puppet::ca'     => host_fqdn,
-    'sssd::domains'                => ['LOCAL'],
     'simp::classes'                => ['simp_options']
   }}
 

--- a/spec/classes/01_classes/sssd/client_spec.rb
+++ b/spec/classes/01_classes/sssd/client_spec.rb
@@ -19,6 +19,7 @@ describe 'simp::sssd::client' do
             it_should_behave_like 'sssd client'
             it { is_expected.to_not contain_sssd__domain('LOCAL')}
             it { is_expected.to_not contain_sssd__domain('LDAP')}
+            it { is_expected.to_not create_notify('SSSD LOCAL domain warning') }
           end
 
           context 'with alternate params' do
@@ -48,6 +49,14 @@ describe 'simp::sssd::client' do
                 .with_ldap_account_expire_policy('ipa')
                 .with_ldap_user_ssh_public_key('nsSshPublicKey')
             }
+          end
+          context 'with LOCAL domain set in hiera' do
+            let(:hieradata) { 'sssd_domains' }
+            it { is_expected.to create_notify('SSSD LOCAL domain warning') }
+          end
+          context 'with LOCAL not set in hiera' do
+            let(:hieradata) { 'sssd_domains_nolocal' }
+            it { is_expected.to_not create_notify('SSSD LOCAL domain warning') }
           end
         end
       end

--- a/spec/classes/01_classes/sssd/client_spec.rb
+++ b/spec/classes/01_classes/sssd/client_spec.rb
@@ -17,18 +17,12 @@ describe 'simp::sssd::client' do
         else
           context 'with default parameters' do
             it_should_behave_like 'sssd client'
-            if os_facts[:os][:release][:major] < '8'
-              it { is_expected.to contain_sssd__domain('LOCAL')}
-            else
-              it { is_expected.to_not contain_sssd__domain('LOCAL')}
-            end
+            it { is_expected.to_not contain_sssd__domain('LOCAL')}
             it { is_expected.to_not contain_sssd__domain('LDAP')}
           end
 
           context 'with alternate params' do
             let(:params) {{
-              :local_domain          => true,
-              :local_domain_options  => { 'max_id' => 12345 },
               :ldap_domain           => true,
               :ldap_domain_options   => { 'max_id' => 23456 },
               :ldap_provider_options => { 'ldap_user_name' => 'bob' },
@@ -39,14 +33,6 @@ describe 'simp::sssd::client' do
             }}
 
             it_should_behave_like 'sssd client'
-            it {
-              is_expected.to contain_sssd__domain('LOCAL')
-                .with_id_provider('files')
-                .with_min_id(501)
-                .with_max_id(12345)
-                .with_enumerate(false)
-                .with_cache_credentials(false)
-            }
 
             it {
               is_expected.to contain_sssd__domain('LDAP')

--- a/spec/fixtures/hieradata/sssd_domains.yaml
+++ b/spec/fixtures/hieradata/sssd_domains.yaml
@@ -1,0 +1,4 @@
+---
+sssd::domains:
+  - 'LOCAL'
+  - 'LDAP'

--- a/spec/fixtures/hieradata/sssd_domains_nolocal.yaml
+++ b/spec/fixtures/hieradata/sssd_domains_nolocal.yaml
@@ -1,0 +1,3 @@
+---
+sssd::domains:
+  - 'LDAP'


### PR DESCRIPTION
- removed LOCAL config from simp::sssd::client and updated
  the version of sssd.
- update the version of pupmod-simp-sssd to 7.0 to ensure
  the sssd v 1.16 or later is being used so sssd can install
  and run without a local provider.
- updated tests that used a ldap server to include tests
  against 389ds server.
- remove support for Puppet 5

SIMP-9698 #close
SIMP-9739 #close
SIMP-9737 #comment updated the tests in simp module