### PR TITLE
(SIMP-8813) Disable puppetdb analytics

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -67,16 +67,10 @@ fixtures:
     pki: https://github.com/simp/pupmod-simp-pki.git
     polkit: https://github.com/simp/pupmod-simp-polkit.git
     postfix: https://github.com/simp/pupmod-simp-postfix.git
-    postgresql:
-      repo: https://github.com/simp/puppetlabs-postgresql.git
-      ref: v7.2.0
-    puppetdb:
-      repo: https://github.com/simp/puppetlabs-puppetdb.git
-      ref: 7.8.0
+    postgresql: https://github.com/simp/puppetlabs-postgresql.git
+    puppetdb: https://github.com/simp/puppetlabs-puppetdb.git
     pupmod: https://github.com/simp/pupmod-simp-pupmod.git
-    puppet_authorization:
-      repo: https://github.com/simp/puppetlabs-puppet_authorization.git
-      ref: 0.5.1
+    puppet_authorization: https://github.com/simp/puppetlabs-puppet_authorization.git
     resolv: https://github.com/simp/pupmod-simp-resolv.git
     rkhunter: https://github.com/simp/pupmod-simp-rkhunter.git
     rsync: https://github.com/simp/pupmod-simp-rsync.git

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,20 +1,24 @@
-* Tue Jun 08 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.15.1
-- sssd::client no longer creates a local provider.
-  - The version of pupmod-simp-sssd required by this module was updated to 7.0
-    because the version of sssd installed does not require a provider.
-    If you require a local provider use the  sssd module to create one.
-  - NOTES FOR UPGRADE: The local domain was configured by default in earlier versions of SIMP because
-    sssd would not start without a domain. A "LOCAL" entry was added to the list
-    of sssd domains to create in hiera.   You will need to remove this domain from
-    the list of domains in hiera unless you are configuring a "LOCAL" domain
-    somewhere else in your puppet code. The hiera variable is sssd::domains.
-    If you do not remove this domain from the list of domains in hiera
-    and are not configuring it yourself sssd will fail to start because it will
-    not find a provider for the "LOCAL" domain.
+* Wed Jun 16 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.16.0
+- Added
+  - simp::puppetdb::disable_update_checking to disable default analytics in
+    accordance with NIST guidance
+
+* Tue Jun 08 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.16.0
+- Changed:
+  - sssd::client no longer creates a local provider.
+    - The version of pupmod-simp-sssd required by this module was updated to 7.0
+      because the version of sssd installed does not require a provider.
+      If you require a local provider use the  sssd module to create one.
+    - NOTES FOR UPGRADE: The local domain was configured by default in earlier
+      versions of SIMP because sssd would not start without a domain. A "LOCAL"
+      entry was added to the list of sssd domains to create in hiera. You will
+      need to remove this domain from the list of domains in hiera unless you
+      are configuring a "LOCAL" domain somewhere else in your puppet code. The
+      hiera variable is sssd::domains. If you do not remove this domain from the
+      list of domains in hiera and are not configuring it yourself sssd will
+      fail to start because it will not find a provider for the "LOCAL" domain.
   - Added warning if LOCAL domain was found in sssd::domains. Also added ability
     to disable the warning.
-- Updated the the acceptance tests that use an LDAP server to also test against
-  an instance of 389ds on el8.
 
 * Tue Jun 08 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 4.15.0
 - Removed

--- a/Gemfile.project
+++ b/Gemfile.project
@@ -3,6 +3,14 @@
 #
 # It is safe to check in changes to this file.  Unlike the Gemfile, changes
 # made to this file will not be overwritten during standardized asset syncs.
+group :test do
+  gem 'rubocop'
+  gem 'rubocop-rake'
+  gem 'rubocop-rspec'
+  gem 'rubocop-i18n'
+  gem 'super_diff'
+end
+
 group :system_tests do
   gem 'beaker-windows'
 end

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -51,6 +51,7 @@
 # @param java_prefer_ipv4
 # @param automatic_dlo_cleanup
 # @param dlo_max_age
+# @param disable_update_checking
 # @param firewall
 #
 # @author https://github.com/simp/pupmod-simp-simp/graphs/contributors
@@ -83,6 +84,7 @@ class simp::puppetdb (
   Boolean                             $java_prefer_ipv4                  = true,
   Boolean                             $automatic_dlo_cleanup             = true,
   Integer                             $dlo_max_age                       = 90,
+  Boolean                             $disable_update_checking           = true,
   Boolean                             $firewall                          = simplib::lookup('simp_options::firewall', { 'default_value' => false })
 ) {
 
@@ -152,17 +154,11 @@ class simp::puppetdb (
     'manage_firewall'                   => ($manage_firewall and !($_simp_manage_firewall)),
     'java_args'                         => $_java_args,
     'automatic_dlo_cleanup'             => $automatic_dlo_cleanup,
-    'dlo_max_age'                       => 90
+    'dlo_max_age'                       => 90,
+    'disable_update_checking'           => $disable_update_checking
   }
 
   class { 'puppetdb': * => $_my_defaults }
-
-  if $automatic_dlo_cleanup {
-    unless $facts['systemd'] {
-      cron::user { $::puppetdb::puppetdb_user: }
-      Cron::User[$::puppetdb::puppetdb_user] -> Cron['puppetdb-dlo-cleanup']
-    }
-  }
 
   include 'puppetdb::master::config'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.15.1",
+  "version": "4.16.0",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/spec/classes/00_classes/puppetdb_spec.rb
+++ b/spec/classes/00_classes/puppetdb_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe 'simp::puppetdb' do
+  fips_mode_save = OpenSSL.fips_mode
+
+  before(:each) do
+    OpenSSL.fips_mode = false if OpenSSL.respond_to?(:fips_mode)
+  end
+
+  after(:each) do
+    OpenSSL.fips_mode = fips_mode_save if OpenSSL.respond_to?(:fips_mode)
+  end
+
   context 'supported operating systems' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
@@ -107,6 +117,7 @@ describe 'simp::puppetdb' do
               :manage_firewall                   => false,
   #            :java_args              => Xmx & Xms vary because of OS memory differences in facts
               :automatic_dlo_cleanup             => true,
+              :disable_update_checking           => true,
               :dlo_max_age                       => 90
             ) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet'
 require 'simp/rspec-puppet-facts'
+require 'super_diff/rspec'
 include Simp::RspecPuppetFacts
 
 require 'pathname'
@@ -142,6 +143,7 @@ RSpec.configure do |c|
     end
 
     # ensure the user running these tests has an accessible environmentpath
+    Puppet[:digest_algorithm] = 'sha256'
     Puppet[:environmentpath] = @spec_global_env_temp
     Puppet[:user] = Etc.getpwuid(Process.uid).name
     Puppet[:group] = Etc.getgrgid(Process.gid).name


### PR DESCRIPTION
- Added
  - simp::puppetdb::disable_update_checking to disable default analytics in
    accordance with NIST guidance

SIMP-8813 #close