### PR TITLE
(SIMP-10409) SSSD and sudoers fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Thu Jul 29 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.16.0
+* Wed Aug 04 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.16.0
 - Added
   - simp::puppetdb::disable_update_checking to disable default analytics in
     accordance with NIST guidance
@@ -7,6 +7,14 @@
   - Migrated from camptocamp/kmod to puppet/kmod
 - Fixed
   - Corrected the HeapDumpOnOutOfMemoryError setting for PuppetDB
+  - Ensure that nsswitch SSSD options for sudoers do not stop on files
+  - Do not include the auditors sudo user specification if the aliases have not
+    been included
+  - Add the following to sudoers defaults
+    - !visiblepw
+    - always_set_home
+    - match_group_by_gid
+    - always_query_group_plugin
 
 * Wed Jul 28 2021 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 4.16.0
 - Added the latest GPG key for Puppet RPMs (RPM-GPG-KEY-20250406) to the list

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2953,13 +2953,17 @@ Data type: `Array`
 The global default entry that should apply to **all** users
 
 Default value: `[
+    '!visiblepw',
+    'always_set_home',
+    'match_group_by_gid',
+    'always_query_group_plugin',
     'listpw=all',
     'requiretty',
     'syslog=authpriv',
     '!root_sudo',
     '!umask',
-    'env_reset',
     'secure_path = /usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+    'env_reset',
     'env_keep = "COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR \
       LS_COLORS MAIL PS1 PS2 QTDIR USERNAME \
       LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION \

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -104,7 +104,7 @@ simp::nsswitch::sssd_options:
     - 'files [!NOTFOUND=return]'
     - 'sss'
   sudoers:
-    - 'files [!NOTFOUND=return]'
+    - 'files'
     - 'sss'
 
 simp::nsswitch::ldap_options:

--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -189,12 +189,14 @@ class simp::admin (
     options   => $admin_sudo_options
   }
 
-  sudo::user_specification { 'auditors':
-    user_list => ["%${auditor_group}"],
-    runas     => $auditor_runas,
-    cmnd      => ['AUDIT'],
-    passwd    => !$passwordless_auditor_sudo,
-    options   => $auditor_sudo_options
+  if $simp::sudoers::common_aliases {
+    sudo::user_specification { 'auditors':
+      user_list => ["%${auditor_group}"],
+      runas     => $auditor_runas,
+      cmnd      => ['AUDIT'],
+      passwd    => !$passwordless_auditor_sudo,
+      options   => $auditor_sudo_options
+    }
   }
 
   # The following two are especially important if you're using sudosh.

--- a/manifests/sudoers.pp
+++ b/manifests/sudoers.pp
@@ -18,13 +18,17 @@
 class simp::sudoers (
   Boolean $common_aliases = false,
   Array $default_entry    = [
+    '!visiblepw',
+    'always_set_home',
+    'match_group_by_gid',
+    'always_query_group_plugin',
     'listpw=all',
     'requiretty',
     'syslog=authpriv',
     '!root_sudo',
     '!umask',
-    'env_reset',
     'secure_path = /usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+    'env_reset',
     'env_keep = "COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR \
       LS_COLORS MAIL PS1 PS2 QTDIR USERNAME \
       LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION \

--- a/spec/classes/00_classes/admin_spec.rb
+++ b/spec/classes/00_classes/admin_spec.rb
@@ -20,179 +20,189 @@ describe 'simp::admin' do
             _facts
           end
 
-          context 'with default parameters' do
-            it { is_expected.to compile.with_all_deps }
-            it { is_expected.to create_class('simp::admin') }
-            it { is_expected.to create_class('simp::sudoers') }
-            it { is_expected.to create_sudo__alias__user('admins') }
-            it { is_expected.to create_sudo__alias__user('auditors') }
-            it { is_expected.to create_file('/etc/profile.d/sudosh2.sh').with_ensure('absent') }
-            it { is_expected.to create_class('tlog::rec_session') }
-            it { is_expected.to create_sudo__user_specification('admin global').with({
-              :user_list => ['%administrators'],
-              :cmnd      => ['/bin/su - root'],
-              :runas     => 'root',
-              :passwd    => false,
-              :options   => {
-                'role' => 'unconfined_r'
-              },
-            }) }
-            it { is_expected.to create_sudo__user_specification('auditors').with({
-              :user_list => ['%security'],
-              :cmnd      => ['AUDIT'],
-              :runas     => 'root',
-              :options   => {},
-              :passwd    => false
-            }) }
-            it { is_expected.to create_sudo__user_specification('admin clean puppet certs').with({
-              :user_list => ['%administrators'],
-              :cmnd      => ['/bin/rm -rf /opt/puppet/somewhere/ssl'],
-              :runas     => 'root',
-              :passwd    => false,
-              :options   => {
-                'role' => 'unconfined_r'
-              },
-            }) }
-            it { is_expected.to create_polkit__authorization__rule('Set administrators group to a policykit administrator').with({
-              :ensure => 'present',
-              :priority => 10,
-              :content => <<~EOF
-                polkit.addAdminRule(function(action, subject) {
-                  return ["unix-group:administrators"];
-                });
-              EOF
-            }) }
+          context 'with common aliases in place' do
+            let(:pre_condition) do
+              'class { "simp::sudoers": common_aliases => true }'
+            end
 
-            it { is_expected.to_not create_selinux_login('%administrators') }
-          end
-
-          context 'when setting tlog as the logged shell' do
-            let(:params) {{
-              :logged_shell => 'tlog'
-            }}
-
-            it { is_expected.to create_class('tlog::rec_session') }
-            it { is_expected.to_not create_class('sudosh') }
-
-            it { is_expected.to create_sudo__user_specification('admin global').with({
-              :user_list => ['%administrators'],
-              :cmnd      => ['/bin/su - root'],
-              :passwd    => false
-            }) }
-          end
-
-          context 'when setting sudosh as the logged shell' do
-            let(:params) {{
-              :logged_shell => 'sudosh'
-            }}
-
-            it { is_expected.to create_class('sudosh') }
-            it { is_expected.to_not create_class('tlog::rec_session') }
-
-            it { is_expected.to create_sudo__user_specification('admin global').with({
-              :user_list => ['%administrators'],
-              :cmnd      => ['/usr/bin/sudosh'],
-              :passwd    => false
-            }) }
-          end
-
-          context 'with admin and auditor settings' do
-            let(:params) {{
-                :admin_group               => 'devs',
-                :passwordless_admin_sudo   => false,
-                :auditor_group             => 'auditors',
-                :passwordless_auditor_sudo => false,
-                :force_logged_shell        => false
-            }}
-            it { is_expected.to create_sudo__user_specification('admin global').with({
-              :user_list => ['%devs'],
-              :cmnd      => ['/bin/su - root'],
-              :passwd    => true
-            }) }
-            it { is_expected.to create_sudo__user_specification('auditors').with({
-              :user_list => ['%auditors'],
-              :cmnd      => ['AUDIT'],
-              :passwd    => true
-            }) }
-          end
-
-          context 'with admin and auditor settings with extra options' do
-            let(:params) {{
-                :admin_group               => 'admins',
-                :auditor_group             => 'auditors',
-                :admin_sudo_options        => {
+            context 'with default parameters' do
+              it { is_expected.to compile.with_all_deps }
+              it { is_expected.to create_class('simp::admin') }
+              it { is_expected.to create_class('simp::sudoers') }
+              it { is_expected.to create_sudo__alias__user('admins') }
+              it { is_expected.to create_sudo__alias__user('auditors') }
+              it { is_expected.to create_file('/etc/profile.d/sudosh2.sh').with_ensure('absent') }
+              it { is_expected.to create_class('tlog::rec_session') }
+              it { is_expected.to create_sudo__user_specification('admin global').with({
+                :user_list => ['%administrators'],
+                :cmnd      => ['/bin/su - root'],
+                :runas     => 'root',
+                :passwd    => false,
+                :options   => {
                   'role' => 'unconfined_r'
                 },
-                :auditor_sudo_options      => {
+              }) }
+              it { is_expected.to create_sudo__user_specification('auditors').with({
+                :user_list => ['%security'],
+                :cmnd      => ['AUDIT'],
+                :runas     => 'root',
+                :options   => {},
+                :passwd    => false
+              }) }
+              it { is_expected.to create_sudo__user_specification('admin clean puppet certs').with({
+                :user_list => ['%administrators'],
+                :cmnd      => ['/bin/rm -rf /opt/puppet/somewhere/ssl'],
+                :runas     => 'root',
+                :passwd    => false,
+                :options   => {
+                  'role' => 'unconfined_r'
+                },
+              }) }
+              it { is_expected.to create_polkit__authorization__rule('Set administrators group to a policykit administrator').with({
+                :ensure => 'present',
+                :priority => 10,
+                :content => <<~EOF
+                  polkit.addAdminRule(function(action, subject) {
+                    return ["unix-group:administrators"];
+                  });
+                EOF
+              }) }
+
+              it { is_expected.to_not create_selinux_login('%administrators') }
+            end
+
+            context 'when setting tlog as the logged shell' do
+              let(:params) {{
+                :logged_shell => 'tlog'
+              }}
+
+              it { is_expected.to create_class('tlog::rec_session') }
+              it { is_expected.to_not create_class('sudosh') }
+
+              it { is_expected.to create_sudo__user_specification('admin global').with({
+                :user_list => ['%administrators'],
+                :cmnd      => ['/bin/su - root'],
+                :passwd    => false
+              }) }
+            end
+
+            context 'when setting sudosh as the logged shell' do
+              let(:params) {{
+                :logged_shell => 'sudosh'
+              }}
+
+              it { is_expected.to create_class('sudosh') }
+              it { is_expected.to_not create_class('tlog::rec_session') }
+
+              it { is_expected.to create_sudo__user_specification('admin global').with({
+                :user_list => ['%administrators'],
+                :cmnd      => ['/usr/bin/sudosh'],
+                :passwd    => false
+              }) }
+            end
+
+            context 'with admin and auditor settings' do
+              let(:params) {{
+                  :admin_group               => 'devs',
+                  :passwordless_admin_sudo   => false,
+                  :auditor_group             => 'auditors',
+                  :passwordless_auditor_sudo => false,
+                  :force_logged_shell        => false
+              }}
+              it { is_expected.to create_sudo__user_specification('admin global').with({
+                :user_list => ['%devs'],
+                :cmnd      => ['/bin/su - root'],
+                :passwd    => true
+              }) }
+              it { is_expected.to create_sudo__user_specification('auditors').with({
+                :user_list => ['%auditors'],
+                :cmnd      => ['AUDIT'],
+                :passwd    => true
+              }) }
+            end
+
+            context 'with admin and auditor settings with extra options' do
+              let(:params) {{
+                  :admin_group               => 'admins',
+                  :auditor_group             => 'auditors',
+                  :admin_sudo_options        => {
+                    'role' => 'unconfined_r'
+                  },
+                  :auditor_sudo_options      => {
+                    'role' => 'staff_r'
+                  },
+                  :passwordless_auditor_sudo => false,
+                  :force_logged_shell        => false
+              }}
+              it { is_expected.to create_sudo__user_specification('admin global').with({
+                :user_list => ['%admins'],
+                :cmnd      => ['/bin/su - root'],
+                :options   => {
+                  'role' => 'unconfined_r'
+                },
+                :passwd    => false
+              }) }
+              it { is_expected.to create_sudo__user_specification('auditors').with({
+                :user_list => ['%auditors'],
+                :cmnd      => ['AUDIT'],
+                :options   => {
                   'role' => 'staff_r'
                 },
-                :passwordless_auditor_sudo => false,
-                :force_logged_shell        => false
-            }}
-            it { is_expected.to create_sudo__user_specification('admin global').with({
-              :user_list => ['%admins'],
-              :cmnd      => ['/bin/su - root'],
-              :options   => {
-                'role' => 'unconfined_r'
-              },
-              :passwd    => false
-            }) }
-            it { is_expected.to create_sudo__user_specification('auditors').with({
-              :user_list => ['%auditors'],
-              :cmnd      => ['AUDIT'],
-              :options   => {
-                'role' => 'staff_r'
-              },
-              :passwd    => true
-            }) }
-          end
-
-          context "when $facts['puppet_settings'] isn't available" do
-            let(:facts) do
-              _facts = Marshal.load(Marshal.dump(os_facts))
-              _facts[:puppet_settings] = nil
-
-              _facts
-            end
-            it { is_expected.to create_sudo__user_specification('admin clean puppet certs').with({
-              :user_list => ['%administrators'],
-              :cmnd      => ['/bin/rm -rf /etc/puppetlabs/puppet/ssl'],
-              :passwd    => false
-            }) }
-          end
-
-          context 'polkit settings' do
-            it { is_expected.to create_polkit__authorization__rule('Set administrators group to a policykit administrator').with({
-              :ensure   => 'present',
-              :priority => 10,
-              :content  => /unix-group:administrators/
-            }) }
-
-            context 'with set_polkit_admin_group => false' do
-              let(:params) {{ :set_polkit_admin_group => false }}
-              it { is_expected.to create_polkit__authorization__rule('Set administrators group to a policykit administrator').with({
-                :ensure => 'absent',
+                :passwd    => true
               }) }
             end
 
-            context 'with admin_group => coolkids' do
-              let(:params) {{ :admin_group => 'coolkids' }}
-              it { is_expected.to create_polkit__authorization__rule('Set coolkids group to a policykit administrator').with({
+            context "when $facts['puppet_settings'] isn't available" do
+              let(:facts) do
+                _facts = Marshal.load(Marshal.dump(os_facts))
+                _facts[:puppet_settings] = nil
+
+                _facts
+              end
+              it { is_expected.to create_sudo__user_specification('admin clean puppet certs').with({
+                :user_list => ['%administrators'],
+                :cmnd      => ['/bin/rm -rf /etc/puppetlabs/puppet/ssl'],
+                :passwd    => false
+              }) }
+            end
+
+            context 'polkit settings' do
+              it { is_expected.to create_polkit__authorization__rule('Set administrators group to a policykit administrator').with({
                 :ensure   => 'present',
                 :priority => 10,
-                :content  => /unix-group:coolkids/
+                :content  => /unix-group:administrators/
               }) }
+
+              context 'with set_polkit_admin_group => false' do
+                let(:params) {{ :set_polkit_admin_group => false }}
+                it { is_expected.to create_polkit__authorization__rule('Set administrators group to a policykit administrator').with({
+                  :ensure => 'absent',
+                }) }
+              end
+
+              context 'with admin_group => coolkids' do
+                let(:params) {{ :admin_group => 'coolkids' }}
+                it { is_expected.to create_polkit__authorization__rule('Set coolkids group to a policykit administrator').with({
+                  :ensure   => 'present',
+                  :priority => 10,
+                  :content  => /unix-group:coolkids/
+                }) }
+              end
+            end
+
+            context 'selinux settings' do
+              let(:params) {{ :set_selinux_login => true }}
+
+              it { is_expected.to create_selinux_login('%administrators').with({
+                  :seuser => 'staff_u',
+                  :mls_range => 's0-s0:c0.c1023'
+                })
+              }
             end
           end
 
-          context 'selinux settings' do
-            let(:params) {{ :set_selinux_login => true }}
-
-            it { is_expected.to create_selinux_login('%administrators').with({
-                :seuser => 'staff_u',
-                :mls_range => 's0-s0:c0.c1023'
-              })
-            }
+          context 'without common aliases' do
+            it { is_expected.not_to create_sudo__user_specification('auditors') }
           end
         end
       end

--- a/spec/classes/00_classes/nsswitch_spec.rb
+++ b/spec/classes/00_classes/nsswitch_spec.rb
@@ -43,7 +43,7 @@ describe 'simp::nsswitch' do
               passwd:     files [!NOTFOUND=return] sss mymachines systemd
               shadow:     files [!NOTFOUND=return] sss
               group:      files [!NOTFOUND=return] sss mymachines systemd
-              sudoers:    files [!NOTFOUND=return] sss
+              sudoers:    files sss
               hosts:      files mymachines dns myhostname
               bootparams: files
               ethers:     files


### PR DESCRIPTION
- Fixed
  - Ensure that nsswitch SSSD options for sudoers do not stop on files
  - Do not include the auditors sudo user specification if the aliases have not
    been included
  - Add the following to sudoers defaults
    - !visiblepw
    - always_set_home
    - match_group_by_gid
    - always_query_group_plugin

SIMP-10409 #comment simp module fixes found during debugging