### PR TITLE
(SIMP-14000) SIMP repo GPGKEYS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+* Thu Aug 12 2021 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 4.16.0
+- Add relative_gpgkey_path parameter to simp::yum::repo::simp_local
+  and default it to SIMP/GPGKEYS, the location that the simp-gpgkeys
+  rpm installs the gpgkeys.
+  The above fix is needed because SIMP local repos were split up to be
+  OS version specific  but the GPGkeys are placed in one location by
+  simp-gpgkeys.  This works
+  because simp::yum::repo::simp_local takes care to add only the OS
+  specific gpgkeys to the repo definition.
+
 * Wed Aug 04 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.16.0
 - Added
   - simp::puppetdb::disable_update_checking to disable default analytics in

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4052,6 +4052,7 @@ The following parameters are available in the `simp::yum::repo::local_simp` clas
 * [`enable_repo`](#enable_repo)
 * [`extra_gpgkey_urls`](#extra_gpgkey_urls)
 * [`relative_repo_path`](#relative_repo_path)
+* [`relative_gpgkey_path`](#relative_gpgkey_path)
 * [`baseurl`](#baseurl)
 * [`gpgkey`](#gpgkey)
 
@@ -4095,6 +4096,15 @@ This parameter has no effect if the `baseurl` parameter is set directly.
 
 Default value: `"SIMP/${facts['os'][name]}/${facts['os']['release']['major']}"`
 
+##### <a name="relative_gpgkey_path"></a>`relative_gpgkey_path`
+
+Data type: `String[1]`
+
+The relative path to the GPGKEYS for the SIMP repo.  It defaults
+to the directory where simp-gpgkeys installs the gpgkeys.
+
+Default value: `"SIMP/GPGKEYS"`
+
 ##### <a name="baseurl"></a>`baseurl`
 
 Data type: `Optional[String[1]]`
@@ -4114,7 +4124,7 @@ Set this parameter directly to completely skip default URL/path logic.
 Default value: `simp::yum::repo::gpgkey_string(
     $servers,
     simp::yum::repo::gpgkeys::simp(),
-    "${relative_repo_path}/GPGKEYS",
+    $relative_gpgkey_path,
     $extra_gpgkey_urls
   )`
 

--- a/manifests/yum/repo/local_simp.pp
+++ b/manifests/yum/repo/local_simp.pp
@@ -68,6 +68,10 @@
 #   In simp repos
 #   This parameter has no effect if the `baseurl` parameter is set directly.
 #
+# @param relative_gpgkey_path
+#   The relative path to the GPGKEYS for the SIMP repo.  It defaults
+#   to the directory where simp-gpgkeys installs the gpgkeys.
+#
 # @param baseurl
 #   The URL for this repository. Set this to absent to remove it from the file completely.
 #   Set this parameter directly to completely skip all automated URL logic.
@@ -77,14 +81,15 @@
 #   Set this parameter directly to completely skip default URL/path logic.
 class simp::yum::repo::local_simp (
   Array[Simp::HostOrURL] $servers,
-  Boolean                $enable_repo        = true,
-  Simp::Urls             $extra_gpgkey_urls  = [],
-  String[1]              $relative_repo_path = "SIMP/${facts['os'][name]}/${facts['os']['release']['major']}",
-  Optional[String[1]]    $baseurl            = simp::yum::repo::baseurl_string($servers, "${relative_repo_path}/${facts['architecture']}"),
-  Optional[String[1]]    $gpgkey             = simp::yum::repo::gpgkey_string(
+  Boolean                $enable_repo           = true,
+  Simp::Urls             $extra_gpgkey_urls     = [],
+  String[1]              $relative_repo_path    = "SIMP/${facts['os'][name]}/${facts['os']['release']['major']}",
+  String[1]              $relative_gpgkey_path  = "SIMP/GPGKEYS",
+  Optional[String[1]]    $baseurl               = simp::yum::repo::baseurl_string($servers, "${relative_repo_path}/${facts['architecture']}"),
+  Optional[String[1]]    $gpgkey                = simp::yum::repo::gpgkey_string(
     $servers,
     simp::yum::repo::gpgkeys::simp(),
-    "${relative_repo_path}/GPGKEYS",
+    $relative_gpgkey_path,
     $extra_gpgkey_urls
   )
 ){

--- a/spec/classes/00_classes/yum/repo/local_simp_spec.rb
+++ b/spec/classes/00_classes/yum/repo/local_simp_spec.rb
@@ -40,7 +40,7 @@ describe 'simp::yum::repo::local_simp' do
         let(:params) {{ :servers => ['puppet.example.simp'] }}
         let(:os_yum_path){ "SIMP/#{facts[:os][:name]}/#{facts[:os][:release][:major]}"}
         let(:os_baseurl){ "#{os_yum_path}/#{facts[:architecture]}" }
-        let(:os_gpgkey){ "#{os_yum_path}/GPGKEYS" }
+        let(:os_gpgkey){ "SIMP/GPGKEYS" }
 
         it { is_expected.to compile.with_all_deps }
         it {
@@ -53,8 +53,9 @@ describe 'simp::yum::repo::local_simp' do
           )
         }
 
-        context 'with relative_repo_path = x/y/z' do
-          let(:params){super().merge( relative_repo_path: 'x/y/z')}
+        context 'with relative_repo_path = x/y/z and relative_gpgkey_path x/y/z/GPGKEYS' do
+          let(:params){super().merge( relative_repo_path: 'x/y/z',
+                                      relative_gpgkey_path: 'x/y/z/GPGKEYS')}
           it { is_expected.to compile.with_all_deps }
           it {
             _keys = base_gpgkeys + other_gpgkeys.fetch( "#{facts[:os][:name]}-#{facts[:os][:release][:major]}" )
@@ -93,7 +94,7 @@ describe 'simp::yum::repo::local_simp' do
                           "SIMP/6/#{facts[:architecture]}"
 
           os_baseurl  = "#{os_yum_path}/#{facts[:architecture]}"
-          os_gpgkey   = "#{os_yum_path}/GPGKEYS"
+          os_gpgkey   = "SIMP/GPGKEYS"
           _keys = base_gpgkeys + other_gpgkeys.fetch( "#{facts[:os][:name]}-#{facts[:os][:release][:major]}" )
           _gpgkey = ['puppet.example.simp', '192.0.2.5']
             .map{ |y|  _keys.map{|x| "https://#{y}/yum/#{os_gpgkey}/#{x}"} }


### PR DESCRIPTION
- add yum::repo::local_simp::relative_gpg_keys parameter to
  point to the relative location of the gpgkeys in the repo.
  It defaults to location that simp-gpgkeys installs them,
  SIMP/GPGKEYS

SIMP-14000 #close