### PR TITLE
(SIMP-10429)  SSSD set schema for ldap provider

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,8 +8,6 @@
     rfc2307 schema.
   * In 389-DS group members are added using the "member" attribute and dn
     of the user as defined in the rfc2307bis schema.
-
-* Thu Aug 12 2021 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 4.16.0
 - Add relative_gpgkey_path parameter to simp::yum::repo::simp_local
   and default it to SIMP/GPGKEYS, the location that the simp-gpgkeys
   rpm installs the gpgkeys.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+* Tue Aug 17 2021 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 4.16.0
+- Update the sssd client configuration to set the ldap_schema
+  for ldap providers based on the setting simp::sssd::client::ldap_server_type,
+  which uses "plain" for openldap servers and "389ds" for 389-DS servers.
+  SIMP configuration and documentation for each of those servers is:
+  - In openldap group members are added using the attribute
+    "memberUid" and the cn of the user entry as defined in the
+    rfc2307 schema.
+  * In 389-DS group members are added using the "member" attribute and dn
+    of the user as defined in the rfc2307bis schema.
+
 * Thu Aug 12 2021 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 4.16.0
 - Add relative_gpgkey_path parameter to simp::yum::repo::simp_local
   and default it to SIMP/GPGKEYS, the location that the simp-gpgkeys

--- a/manifests/sssd/client.pp
+++ b/manifests/sssd/client.pp
@@ -119,13 +119,15 @@ class simp::sssd::client (
     if $ldap_server_type in ['389ds'] {
       $_ldap_server_type_defaults = {
         'ldap_account_expire_policy' => 'ipa',
-        'ldap_user_ssh_public_key'   => 'nsSshPublicKey'
+        'ldap_user_ssh_public_key'   => 'nsSshPublicKey',
+        'ldap_schema'                => 'rfc2307bis'
       }
     }
     elsif $ldap_server_type in ['plain'] {
       $_ldap_server_type_defaults = {
         'ldap_account_expire_policy' => 'shadow',
-        'ldap_user_ssh_public_key'   => 'sshPublicKey'
+        'ldap_user_ssh_public_key'   => 'sshPublicKey',
+        'ldap_schema'                => 'rfc2307'
       }
     }
 

--- a/spec/classes/01_classes/sssd/client_spec.rb
+++ b/spec/classes/01_classes/sssd/client_spec.rb
@@ -25,6 +25,26 @@ describe 'simp::sssd::client' do
           context 'with alternate params' do
             let(:params) {{
               :ldap_domain           => true,
+              :ldap_server_type      => 'plain',
+            }}
+            it_should_behave_like 'sssd client'
+            it {
+              is_expected.to contain_sssd__provider__ldap('LDAP')
+                .with_ldap_account_expire_policy('shadow')
+                .with_ldap_user_ssh_public_key('sshPublicKey')
+                .with_ldap_schema('rfc2307')
+            }
+            it {
+              is_expected.to contain_sssd__domain('LDAP')
+                .with_id_provider('ldap')
+                .with_min_id(500)
+                .with_enumerate(false)
+                .with_cache_credentials(true)
+            }
+          end
+          context 'with alternate params' do
+            let(:params) {{
+              :ldap_domain           => true,
               :ldap_domain_options   => { 'max_id' => 23456 },
               :ldap_provider_options => { 'ldap_user_name' => 'bob' },
               :ldap_server_type      => '389ds',
@@ -48,6 +68,7 @@ describe 'simp::sssd::client' do
               is_expected.to contain_sssd__provider__ldap('LDAP')
                 .with_ldap_account_expire_policy('ipa')
                 .with_ldap_user_ssh_public_key('nsSshPublicKey')
+                .with_ldap_schema('rfc2307bis')
             }
           end
           context 'with LOCAL domain set in hiera' do


### PR DESCRIPTION
- Update the sssd configuration to set the ldap schema according to
  the type of ldap server. Set the ldap_schema to "rfc2307" for openldap
  and to "rfc2307bis" for 389-DS.
  The default SIMP configuration and documentation for adding
  members to groups is different for 389-DS and openldap.
  The default SIMP configuration and documentation for Openldap
  uses the attribute "memberUid" and the "cn" of the user.  This is
  in general not determinate because more then one user can have
  the same "cn".  This is configuration defined in sssd by ldap_schema
  rfc2307.
  In the new 389-DS server, the SIMP configuration, documentation and
  transiton script, use the configuration defined in sssd as rfc2307bis.
  This used the attribute "member" and the "dn" of the user.  The
  "dn" of the user must be unique in the LDAp database.

SIMP-10429 #close