### PR TITLE
(SIMP-10435) Fix simp::sssd::client::ldap_server_type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,23 @@
+* Tue Aug 24 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.16.0
+- Added
+  - simp::puppetdb::disable_update_checking to disable default analytics in
+    accordance with NIST guidance
+  - PuppetDB now sets UseCodeCacheFlushing by default
+- Changed
+  - Migrated from camptocamp/kmod to puppet/kmod
+- Fixed
+  - Corrected the HeapDumpOnOutOfMemoryError setting for PuppetDB
+  - Ensure that nsswitch SSSD options for sudoers do not stop on files
+  - Do not include the auditors sudo user specification if the aliases have not
+    been included
+  - Add the following to sudoers defaults
+    - !visiblepw
+    - always_set_home
+    - match_group_by_gid
+    - always_query_group_plugin
+  - Ensured that users setting `simp_options::ldap` to `false` would not be
+    prompted to set `simp::sssd::client::ldap_server_type
+
 * Tue Aug 17 2021 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 4.16.0
 - Update the sssd client configuration to set the ldap_schema
   for ldap providers based on the setting simp::sssd::client::ldap_server_type,
@@ -16,36 +36,6 @@
   simp-gpgkeys.  This works
   because simp::yum::repo::simp_local takes care to add only the OS
   specific gpgkeys to the repo definition.
-
-* Wed Aug 04 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.16.0
-- Added
-  - simp::puppetdb::disable_update_checking to disable default analytics in
-    accordance with NIST guidance
-  - PuppetDB now sets UseCodeCacheFlushing by default
-- Changed
-  - Migrated from camptocamp/kmod to puppet/kmod
-- Fixed
-  - Corrected the HeapDumpOnOutOfMemoryError setting for PuppetDB
-  - Ensure that nsswitch SSSD options for sudoers do not stop on files
-  - Do not include the auditors sudo user specification if the aliases have not
-    been included
-  - Add the following to sudoers defaults
-    - !visiblepw
-    - always_set_home
-    - match_group_by_gid
-    - always_query_group_plugin
-
-* Wed Jul 28 2021 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 4.16.0
-- Added the latest GPG key for Puppet RPMs (RPM-GPG-KEY-20250406) to the list
-  of GPG keys for the local `simp` repo.
-
-* Wed Jul 14 2021 Steven Pritchard <steven.pritchard@onyxpoint.com> - 4.16.0
-- Support all valid values for simp::pam_limits::max_logins::value
-
-* Wed Jun 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.16.0
-- Ensured support for Puppet 7 in requirements and stdlib
-
-* Tue Jun 08 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.16.0
 - Changed:
   - sssd::client no longer creates a local provider.
     - The version of pupmod-simp-sssd required by this module was updated to 7.0
@@ -61,6 +51,14 @@
       fail to start because it will not find a provider for the "LOCAL" domain.
   - Added warning if LOCAL domain was found in sssd::domains. Also added ability
     to disable the warning.
+- Added the latest GPG key for Puppet RPMs (RPM-GPG-KEY-20250406) to the list
+  of GPG keys for the local `simp` repo.
+
+* Wed Jul 14 2021 Steven Pritchard <steven.pritchard@onyxpoint.com> - 4.16.0
+- Support all valid values for simp::pam_limits::max_logins::value
+
+* Wed Jun 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.16.0
+- Ensured support for Puppet 7 in requirements and stdlib
 
 * Tue Jun 08 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 4.15.0
 - Removed

--- a/manifests/sssd/client.pp
+++ b/manifests/sssd/client.pp
@@ -56,19 +56,19 @@
 # @author https://github.com/simp/pupmod-simp-simp/graphs/contributors
 #
 class simp::sssd::client (
-  Boolean               $local_domain          = false, #deprecated
-  Hash                  $local_domain_options  = {},    #deprecated
-  Boolean               $ldap_domain           = simplib::lookup('simp_options::ldap', { 'default_value' => false }),
-  Hash                  $ldap_domain_options   = {},
-  Enum['plain','389ds'] $ldap_server_type,
-  Hash                  $ldap_provider_options = {},
-  Boolean               $autofs                = true, #deprecated
-  Boolean               $sudo                  = true, #deprecated
-  Boolean               $ssh                   = true, #deprecated
-  Boolean               $enumerate_users       = false,
-  Boolean               $cache_credentials     = true,
-  Integer               $min_id                = 500,
-  Boolean               $enable_domain_warn    = true
+  Boolean                                        $local_domain          = false, #deprecated
+  Hash                                           $local_domain_options  = {},    #deprecated
+  Boolean                                        $ldap_domain           = simplib::lookup('simp_options::ldap', { 'default_value' => false }),
+  Hash                                           $ldap_domain_options   = {},
+  Variant[Boolean[false], Enum['plain','389ds']] $ldap_server_type      = $ldap_domain ? { false => false, default => undef },
+  Hash                                           $ldap_provider_options = {},
+  Boolean                                        $autofs                = true, #deprecated
+  Boolean                                        $sudo                  = true, #deprecated
+  Boolean                                        $ssh                   = true, #deprecated
+  Boolean                                        $enumerate_users       = false,
+  Boolean                                        $cache_credentials     = true,
+  Integer                                        $min_id                = 500,
+  Boolean                                        $enable_domain_warn    = true
 ){
 
   simplib::module_metadata::assert($module_name, { 'blacklist' => ['Windows'] })
@@ -98,7 +98,7 @@ class simp::sssd::client (
     }
   }
 
-  if $ldap_domain {
+  if $ldap_server_type and $ldap_domain {
     $_ldap_domain_defaults = {
       'description' => 'LOCAL Users Domain',
       'min_id'      => $min_id

--- a/spec/classes/01_classes/sssd/client_spec.rb
+++ b/spec/classes/01_classes/sssd/client_spec.rb
@@ -10,7 +10,6 @@ describe 'simp::sssd::client' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) { os_facts }
-        let(:params) {{ :ldap_server_type => 'plain' }}
 
         if os_facts[:kernel] == 'windows'
           it { expect{ is_expected.to compile.with_all_deps }.to raise_error(/'windows .+' is not supported/) }
@@ -22,10 +21,26 @@ describe 'simp::sssd::client' do
             it { is_expected.to_not create_notify('SSSD LOCAL domain warning') }
           end
 
-          context 'with alternate params' do
+          context 'with ldap_domain=true' do
+            let(:params) do
+              new_params = {
+                :ldap_domain => true
+              }
+
+              if os_facts[:os][:release][:major] != '7'
+                new_params[:ldap_server_type] = 'plain'
+              end
+
+              new_params
+            end
+
+            it_should_behave_like 'sssd client'
+          end
+
+          context 'with ldap_domain and ldap_server_type=plain' do
             let(:params) {{
-              :ldap_domain           => true,
-              :ldap_server_type      => 'plain',
+              :ldap_domain      => true,
+              :ldap_server_type => 'plain',
             }}
             it_should_behave_like 'sssd client'
             it {
@@ -42,7 +57,8 @@ describe 'simp::sssd::client' do
                 .with_cache_credentials(true)
             }
           end
-          context 'with alternate params' do
+
+          context 'with multiple parameters set' do
             let(:params) {{
               :ldap_domain           => true,
               :ldap_domain_options   => { 'max_id' => 23456 },
@@ -71,6 +87,7 @@ describe 'simp::sssd::client' do
                 .with_ldap_schema('rfc2307bis')
             }
           end
+
           context 'with LOCAL domain set in hiera' do
             let(:hieradata) { 'sssd_domains' }
             it { is_expected.to create_notify('SSSD LOCAL domain warning') }

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -35,8 +35,6 @@ simp_options::firewall : true
 sssd::domains :
   - 'LDAP'
 
-#Need to default this for EL8 systems
-simp::sssd::client::ldap_server_type: 'plain'
 simp::yum::repo::local_simp::servers:
   - 'yum.bar.baz'
 simp::yum::repo::local_os_updates::servers:


### PR DESCRIPTION
- Fixed
  - Ensured that users setting `simp_options::ldap` to `false` would not be
    prompted to set `simp::sssd::client::ldap_server_type

SIMP-10435 #comment fixed simp::sssd::client::ldap_server_type bug discovered while debugging