### PR TITLE
Remove Upstart

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri May 13 2022 Trevor Vaughan <trevor@sicura.us> - 4.16.3
+- Remove upstart as a dependency since it is not used on any of our supported
+  operating systems
+
 * Mon Oct 18 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.16.2
 - Updated simp::yum::repo::local_os_updates to use the GPGKEYS installed by
   simp-gpgkeys and the iso install  into <yum directory>/SIMP/GPGKEYS.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.16.2",
+  "version": "4.16.3",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",
@@ -178,10 +178,6 @@
     {
       "name": "simp/tuned",
       "version_requirement": ">= 0.1.0 < 1.0.0"
-    },
-    {
-      "name": "simp/upstart",
-      "version_requirement": ">= 6.0.3 < 7.0.0"
     },
     {
       "name": "simp/useradd",

--- a/spec/classes/00_classes/ctrl_alt_del_spec.rb
+++ b/spec/classes/00_classes/ctrl_alt_del_spec.rb
@@ -25,15 +25,6 @@ describe 'simp::ctrl_alt_del' do
             }
           end
 
-          shared_examples_for "an upstart system" do
-            it { is_expected.to compile.with_all_deps }
-
-            it { is_expected.to create_class('simp::ctrl_alt_del') }
-            it { is_expected.to create_class('upstart') }
-
-            it { is_expected.to create_upstart__job('control-alt-delete').with_start_on('control-alt-delete') }
-          end
-
           if os_facts.fetch(:init_systems, []).include?('systemd')
             it_behaves_like 'a systemd system'
 
@@ -79,42 +70,6 @@ describe 'simp::ctrl_alt_del' do
 
               it { is_expected.to create_file('/etc/systemd/system/ctrl-alt-del.target').with_ensure('absent') }
               it { is_expected.to create_file('/etc/systemd/system/ctrl-alt-del-capture.service').with_ensure('absent') }
-            end
-          elsif os_facts.fetch(:init_systems, []).include?('upstart')
-            it_behaves_like 'an upstart system'
-
-            it { is_expected.to create_upstart__job('control-alt-delete').with_main_process(
-              %{/bin/sh -c "/bin/logger -p local6.warning 'Ctrl-Alt-Del detected - Logged in users:' `/usr/bin/who | /bin/cut -f1 -d' ' | /bin/sort -u | /usr/bin/tr '\\n' ' '`"}
-            )}
-
-            context 'when not logging users' do
-              let(:params){{
-                :log_users => false
-              }}
-
-              it_behaves_like 'an upstart system'
-
-              it { is_expected.to create_upstart__job('control-alt-delete').with_main_process(%{/bin/sh -c "/bin/logger -p local6.warning 'Ctrl-Alt-Del detected'"}) }
-            end
-
-            context 'when not logging' do
-              let(:params){{
-                :log => false
-              }}
-
-              it_behaves_like 'an upstart system'
-
-              it { is_expected.to create_upstart__job('control-alt-delete').with_main_process('/bin/true') }
-            end
-
-            context 'when allowing ctrl-alt-del' do
-              let(:params){{
-                :enable => true
-              }}
-
-              it_behaves_like 'an upstart system'
-
-              it { is_expected.to create_upstart__job('control-alt-delete').with_main_process('/sbin/shutdown -r now "Control-Alt-Delete pressed"') }
             end
           else
             it {

--- a/spec/classes/10_classes/server/kickstart/files/default_simp_client_bootstrap
+++ b/spec/classes/10_classes/server/kickstart/files/default_simp_client_bootstrap
@@ -62,8 +62,7 @@ case "$1" in
 
       echo "Rebooting to complete the bootstrap."
       reboot;
-      # This is here to keep this script from interfering with upstart
-      # parallelism.
+      # This is here to keep this script from interfering with startup parallelism.
       sleep 999999999;
     elif [ $result -eq 2 ]; then
       echo -n "$servername bootstrapping has already completed."
@@ -76,8 +75,7 @@ case "$1" in
 
       echo "Rebooting to retry."
       reboot;
-      # This is here to keep this script from interfering with upstart
-      # parallelism.
+      # This is here to keep this script from interfering with startup parallelism.
       sleep 999999999;
     fi
     ;;

--- a/spec/classes/10_classes/server/kickstart/files/simp_client_bootstrap_with_ntp_servers
+++ b/spec/classes/10_classes/server/kickstart/files/simp_client_bootstrap_with_ntp_servers
@@ -63,8 +63,7 @@ case "$1" in
 
       echo "Rebooting to complete the bootstrap."
       reboot;
-      # This is here to keep this script from interfering with upstart
-      # parallelism.
+      # This is here to keep this script from interfering with startup parallelism.
       sleep 999999999;
     elif [ $result -eq 2 ]; then
       echo -n "$servername bootstrapping has already completed."
@@ -77,8 +76,7 @@ case "$1" in
 
       echo "Rebooting to retry."
       reboot;
-      # This is here to keep this script from interfering with upstart
-      # parallelism.
+      # This is here to keep this script from interfering with startup parallelism.
       sleep 999999999;
     fi
     ;;

--- a/spec/classes/10_classes/server/kickstart/files/simp_client_bootstrap_without_print_stats
+++ b/spec/classes/10_classes/server/kickstart/files/simp_client_bootstrap_without_print_stats
@@ -62,8 +62,7 @@ case "$1" in
 
       echo "Rebooting to complete the bootstrap."
       reboot;
-      # This is here to keep this script from interfering with upstart
-      # parallelism.
+      # This is here to keep this script from interfering with startup parallelism.
       sleep 999999999;
     elif [ $result -eq 2 ]; then
       echo -n "$servername bootstrapping has already completed."
@@ -76,8 +75,7 @@ case "$1" in
 
       echo "Rebooting to retry."
       reboot;
-      # This is here to keep this script from interfering with upstart
-      # parallelism.
+      # This is here to keep this script from interfering with startup parallelism.
       sleep 999999999;
     fi
     ;;

--- a/spec/classes/10_classes/server/kickstart/files/simp_client_bootstrap_without_reboot_on_failure
+++ b/spec/classes/10_classes/server/kickstart/files/simp_client_bootstrap_without_reboot_on_failure
@@ -62,8 +62,7 @@ case "$1" in
 
       echo "Rebooting to complete the bootstrap."
       reboot;
-      # This is here to keep this script from interfering with upstart
-      # parallelism.
+      # This is here to keep this script from interfering with startup parallelism.
       sleep 999999999;
     elif [ $result -eq 2 ]; then
       echo -n "$servername bootstrapping has already completed."

--- a/spec/classes/10_classes/server/kickstart/files/simp_client_bootstrap_without_wait_for_cert
+++ b/spec/classes/10_classes/server/kickstart/files/simp_client_bootstrap_without_wait_for_cert
@@ -62,8 +62,7 @@ case "$1" in
 
       echo "Rebooting to complete the bootstrap."
       reboot;
-      # This is here to keep this script from interfering with upstart
-      # parallelism.
+      # This is here to keep this script from interfering with startup parallelism.
       sleep 999999999;
     elif [ $result -eq 2 ]; then
       echo -n "$servername bootstrapping has already completed."
@@ -76,8 +75,7 @@ case "$1" in
 
       echo "Rebooting to retry."
       reboot;
-      # This is here to keep this script from interfering with upstart
-      # parallelism.
+      # This is here to keep this script from interfering with startup parallelism.
       sleep 999999999;
     fi
     ;;

--- a/templates/www/ks/simp_client_bootstrap.erb
+++ b/templates/www/ks/simp_client_bootstrap.erb
@@ -86,8 +86,7 @@ case "$1" in
 
       echo "Rebooting to complete the bootstrap."
       reboot;
-      # This is here to keep this script from interfering with upstart
-      # parallelism.
+      # This is here to keep this script from interfering with startup parallelism.
       sleep 999999999;
     elif [ $result -eq 2 ]; then
       echo -n "$servername bootstrapping has already completed."
@@ -103,8 +102,7 @@ case "$1" in
 
       echo "Rebooting to retry."
       reboot;
-      # This is here to keep this script from interfering with upstart
-      # parallelism.
+      # This is here to keep this script from interfering with startup parallelism.
       sleep 999999999;
 <% end -%>
     fi


### PR DESCRIPTION
* Upstart is not supported on any of our supported operating systems and
  should have been removed in the past.

Closes #282
