### PR TITLE
Removes puppet 6 from .gitlab-ci.yml

### DIFF
--- a/.github/workflows/pr_glci.yml
+++ b/.github/workflows/pr_glci.yml
@@ -23,15 +23,6 @@
 #   The secure vars will be filtered in GitHub Actions log output, and aren't
 #   provided to untrusted builds (i.e, triggered by PR from another repository)
 #
-#
-# GitHub Action Variables available for this pipeline:
-#
-#   GitHub variable                   Notes
-#   ------------------------------    ----------------------------------------
-#   GITLAB_API_CI_LINT_PROJECT_URL    API url up to .../projects/:id
-#                                     if omitted, tries to use the identical
-#                                     org/project on gitlab.com
-#
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # WARNING   WARNING   WARNING   WARNING   WARNING   WARNING   WARNING   WARNING
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!V!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -67,6 +58,7 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
+
   # The ONLY reason we can validate the PR HEAD's content safely here is that
   # we restrict ourselves to sending data elsewhere.
   glci-syntax:
@@ -76,20 +68,15 @@ jobs:
       valid: ${{ steps.validate-glci-file.outputs.valid }}
     steps:
       - uses: actions/checkout@v3
-      - name: Validate required secrets and vars
-        env:
-          _API: ${{ vars.GITLAB_API_CI_LINT_PROJECT_URL }}
-          _TOK: ${{ secrets.GITLAB_API_PRIVATE_TOKEN }}
-        run: |
-          [[ -n $_API ]] || echo '::warning ::vars.GITLAB_API_CI_LINT_PROJECT_URL is empty!'
-          [[ -n $_TOK ]] || echo '::error ::secrets.GITLAB_API_PRIVATE_TOKEN is empty!'
-          [[ -n $_TOK ]]
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: 'Validate GLCI file syntax'
         id: validate-glci-file
-        uses: simp/github-action-gitlab-ci-syntax-check@tests/fix-gitlab-api
+        uses: simp/github-action-gitlab-ci-syntax-check@main
         with:
           gitlab_api_private_token: ${{ secrets.GITLAB_API_PRIVATE_TOKEN }}
-          gitlab_api_url: ${{ vars.GITLAB_API_CI_LINT_PROJECT_URL || format('https://gitlab.com/api/v4/projects/{0}%2F{1}', github.event.organization.login, github.event.repository.name) }}
+          gitlab_api_url: ${{ secrets.GITLAB_API_URL }}       # https://gitlab.com/api/v4
 
   contributor-permissions:
     name: 'PR contributor check'

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: "bundle exec rake syntax"
 
@@ -50,7 +50,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: "bundle exec rake lint"
       - run: "bundle exec rake metadata_lint"
@@ -65,7 +65,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: |
           bundle show
@@ -76,10 +76,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: 'Install Ruby 2.5'
+      - name: 'Install Ruby 2.7'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
@@ -92,7 +92,7 @@ jobs:
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - name: 'Tags and changelogs'
         run: |
@@ -109,12 +109,12 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 6.22 [SIMP 6.6/PE 2019.8]'
-            puppet_version: '~> 6.22.1'
-            ruby_version: '2.5'
           - label: 'Puppet 7.x'
-            puppet_version: '~> 7.0'
+            puppet_version: '~> 7.21.0'
             ruby_version: '2.7'
+          - label: 'Puppet 8.x'
+            puppet_version: '~> 8.0'
+            ruby_version: '3.2'
     env:
       PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
     steps:

--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -117,11 +117,10 @@ jobs:
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IS_PRERELASE: ${{ steps.tag-check.outputs.prerelease }}
         run: |
           echo "${RELEASE_MESSAGE}" > /tmp/.commit-msg.txt
           args=(--file /tmp/.commit-msg.txt)
-          [[ $IS_PRERELASE == yes ]] && args+=(--prerelease)
+          [[ ${{ steps.tag-check.outputs.prerelease }} == yes ]] && args+=(--prerelease)
 
           hub release create ${args[@]} "$TARGET_TAG"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -232,26 +232,26 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_6_x: &pup_6_x
-  image: 'ruby:2.5'
-  variables:
-    PUPPET_VERSION: '~> 6.0'
-    BEAKER_PUPPET_COLLECTION: 'puppet6'
-    MATRIX_RUBY_VERSION: '2.5'
-
-.pup_6_pe: &pup_6_pe
-  image: 'ruby:2.5'
-  variables:
-    PUPPET_VERSION: '6.18.0'
-    BEAKER_PUPPET_COLLECTION: 'puppet6'
-    MATRIX_RUBY_VERSION: '2.5'
-
 .pup_7_x: &pup_7_x
   image: 'ruby:2.7'
   variables:
     PUPPET_VERSION: '~> 7.0'
     BEAKER_PUPPET_COLLECTION: 'puppet7'
     MATRIX_RUBY_VERSION: '2.7'
+
+.pup_7_pe: &pup_7_pe
+  image: 'ruby:2.7'
+  variables:
+    PUPPET_VERSION: '7.21.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet7'
+    MATRIX_RUBY_VERSION: '2.7'
+
+.pup_8_x: &pup_8_x
+  image: 'ruby:3.2'
+  variables:
+    PUPPET_VERSION: '~> 8.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet8'
+    MATRIX_RUBY_VERSION: '3.2'
     RUBYOPT: '-W0'
 
 
@@ -320,7 +320,7 @@ variables:
 #=======================================================================
 
 releng_checks:
-  <<: *pup_6_x
+  <<: *pup_7_x
   <<: *setup_bundler_env
   stage: 'validation'
   tags: ['docker']
@@ -343,36 +343,36 @@ releng_checks:
 #       different Puppet versions won't accomplish anything.
 
 pup-lint:
-  <<: *pup_6_x
+  <<: *pup_7_x
   <<: *lint_tests
 
 # Unit Tests
 #-----------------------------------------------------------------------
 
-pup6.x-unit:
-  <<: *pup_6_x
-  <<: *unit_tests
-  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
-
-pup6.x-unit_slow:
-  <<: *pup_6_x
-  <<: *slow_unit_tests
-  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
-
-pup6.pe-unit:
-  <<: *pup_6_pe
-  <<: *unit_tests
-
-pup6.pe-unit_slow:
-  <<: *pup_6_pe
-  <<: *slow_unit_tests
-
 pup7.x-unit:
   <<: *pup_7_x
   <<: *unit_tests
+  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
 pup7.x-unit_slow:
   <<: *pup_7_x
+  <<: *slow_unit_tests
+  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
+
+pup7.pe-unit:
+  <<: *pup_7_pe
+  <<: *unit_tests
+
+pup7.pe-unit_slow:
+  <<: *pup_7_pe
+  <<: *slow_unit_tests
+
+pup8.x-unit:
+  <<: *pup_8_x
+  <<: *unit_tests
+
+pup8.x-unit_slow:
+  <<: *pup_8_x
   <<: *slow_unit_tests
 
 # ------------------------------------------------------------------------------
@@ -385,64 +385,64 @@ pup7.x-unit_slow:
 # Repo-specific content
 # ==============================================================================
 
-pup6.x:
-  <<: *pup_6_x
+pup7.x:
+  <<: *pup_7_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'bundle exec rake beaker:suites[default,default]'
 
-pup6.x-base-apps:
-  <<: *pup_6_x
+pup7.x-base-apps:
+  <<: *pup_7_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'bundle exec rake beaker:suites[base_apps,default]'
 
-pup6.x-fips:
-  <<: *pup_6_x
+pup7.x-fips:
+  <<: *pup_7_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
 
-pup6.x-no_simp_server:
-  <<: *pup_6_x
+pup7.x-no_simp_server:
+  <<: *pup_7_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[no_simp_server,default]'
 
-pup6.x-netconsole:
-  <<: *pup_6_x
+pup7.x-netconsole:
+  <<: *pup_7_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[netconsole,default]'
 
-pup6.x-one_shot_scenario:
-  <<: *pup_6_x
+pup7.x-one_shot_scenario:
+  <<: *pup_7_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[scenario_one_shot,default]'
 
-pup6.x-poss_scenario:
-  <<: *pup_6_x
+pup7.x-poss_scenario:
+  <<: *pup_7_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[scenario_poss,default]'
 
-pup6.x-remote_access_scenario:
-  <<: *pup_6_x
+pup7.x-remote_access_scenario:
+  <<: *pup_7_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[scenario_remote_access,default]'
 
-pup6.pe-win:
-  <<: *pup_6_pe
+pup7.pe-win:
+  <<: *pup_7_pe
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
@@ -459,63 +459,63 @@ pup6.pe-win:
   # test running, a pull request would be most welcome.
   allow_failure: true
 
-pup6.pe:
-  <<: *pup_6_pe
+pup7.pe:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,default]'
 
-pup6.pe-base-apps:
-  <<: *pup_6_pe
+pup7.pe-base-apps:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[base_apps,default]'
 
-pup6.pe-fips:
-  <<: *pup_6_pe
+pup7.pe-fips:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
 
-pup6.pe-netconsole:
-  <<: *pup_6_pe
+pup7.pe-netconsole:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[netconsole,default]'
 
-pup6.pe-one_shot_scenario:
-  <<: *pup_6_pe
+pup7.pe-one_shot_scenario:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[scenario_one_shot,default]'
 
-pup6.pe-poss_scenario:
-  <<: *pup_6_pe
+pup7.pe-poss_scenario:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[scenario_poss,default]'
 
-pup6.pe-remote_access_scenario:
-  <<: *pup_6_pe
+pup7.pe-remote_access_scenario:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[scenario_remote_access,default]'
 
-pup6.pe-oel:
-  <<: *pup_6_pe
+pup7.pe-oel:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup6.pe-oel-fips:
-  <<: *pup_6_pe
+pup7.pe-oel-fips:
+  <<: *pup_7_pe
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
 
-pup7.x:
-  <<: *pup_7_x
+pup8.x:
+  <<: *pup_8_x
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,default]'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -367,13 +367,13 @@ pup7.pe-unit_slow:
   <<: *pup_7_pe
   <<: *slow_unit_tests
 
-pup8.x-unit:
-  <<: *pup_8_x
-  <<: *unit_tests
+#pup8.x-unit:
+#  <<: *pup_8_x
+#  <<: *unit_tests
 
-pup8.x-unit_slow:
-  <<: *pup_8_x
-  <<: *slow_unit_tests
+#pup8.x-unit_slow:
+#  <<: *pup_8_x
+#  <<: *slow_unit_tests
 
 # ------------------------------------------------------------------------------
 #             NOTICE: **This file is maintained with puppetsync**
@@ -514,8 +514,8 @@ pup7.pe-oel-fips:
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
 
-pup8.x:
-  <<: *pup_8_x
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites[default,default]'
+#pup8.x:
+#  <<: *pup_8_x
+#  <<: *acceptance_base
+#  script:
+#    - 'bundle exec rake beaker:suites[default,default]'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.22'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 7'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -1,51 +1,44 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
+---
 HOSTS:
   server-oel7.simp.beaker:
     roles:
-      - server
-      - default
-      - master
-      - simp_server
-      - el7
-    platform:   el-7-x86_64
-    box:        generic/oracle7
-    hypervisor: <%= hypervisor %>
+    - server
+    - default
+    - master
+    - simp_server
+    - el7
+    platform: el-7-x86_64
+    box: generic/oracle7
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     yum_repos:
       updates:
-        baseurl: 'https://public-yum.oracle.com/repo/OracleLinux/OL7/latest/$basearch'
+        baseurl: https://public-yum.oracle.com/repo/OracleLinux/OL7/latest/$basearch
         gpgkeys:
-          - http://public-yum.oracle.com/RPM-GPG-KEY-oracle-ol7
+        - http://public-yum.oracle.com/RPM-GPG-KEY-oracle-ol7
       simp:
         baseurl: https://download.simp-project.com/simp/yum/rolling/6/el/$releasever/$basearch/simp
         gpgkeys:
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-UNSTABLE
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-UNSTABLE
       simp_epel:
         baseurl: https://download.simp-project.com/simp/yum/rolling/6/el/$releasever/$basearch/epel
         gpgkeys:
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-CentOS-$releasever
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-redhat-release
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-EPEL-$releasever
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-CentOS-$releasever
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-redhat-release
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-EPEL-$releasever
       simp_postgresql:
         baseurl: https://download.simp-project.com/simp/yum/rolling/6/el/$releasever/$basearch/postgresql
         gpgkeys:
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-PGDG-96
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-PGDG-96
       simp_puppet:
         baseurl: https://download.simp-project.com/simp/yum/rolling/6/el/$releasever/$basearch/puppet
         gpgkeys:
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-puppet
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-puppetlabs
-
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-puppet
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-puppetlabs
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
   type: aio
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"

--- a/spec/acceptance/nodesets/oel8.yml
+++ b/spec/acceptance/nodesets/oel8.yml
@@ -1,30 +1,23 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
+---
 HOSTS:
   server-oel8.simp.beaker:
     roles:
-      - server
-      - default
-      - master
-      - simp_server
-      - el8
-    platform:   el-8-x86_64
-    box:        generic/oracle8
-    hypervisor: <%= hypervisor %>
+    - server
+    - default
+    - master
+    - simp_server
+    - el8
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     yum_repos:
       updates:
-        baseurl: 'https://yum$ociregion.oracle.com/repo/OracleLinux/OL8/baseos/latest/$basearch/'
+        baseurl: https://yum$ociregion.oracle.com/repo/OracleLinux/OL8/baseos/latest/$basearch/
         gpgkeys:
-          - http://public-yum.oracle.com/RPM-GPG-KEY-oracle-ol8
-
+        - http://public-yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
   type: aio
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"

--- a/spec/acceptance/suites/netconsole/nodesets/oel7.yml
+++ b/spec/acceptance/suites/netconsole/nodesets/oel7.yml
@@ -1,29 +1,23 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
+---
 HOSTS:
   oel7-shipper:
     roles:
-      - default
-      - shipper
-    platform:   el-7-x86_64
-    box:        generic/oracle7
-    hypervisor: <%= hypervisor %>
-
+    - default
+    - shipper
+    platform: el-7-x86_64
+    box: generic/oracle7
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
   oel7-receiver:
     roles:
-      - receiver
-    platform:   el-7-x86_64
-    box:        generic/oracle7
-    hypervisor: <%= hypervisor %>
-
+    - receiver
+    platform: el-7-x86_64
+    box: generic/oracle7
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
   type: aio
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"

--- a/spec/acceptance/suites/netconsole/nodesets/oel8.yml
+++ b/spec/acceptance/suites/netconsole/nodesets/oel8.yml
@@ -1,29 +1,23 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
+---
 HOSTS:
   oel8-shipper:
     roles:
-      - default
-      - shipper
-    platform:   el-8-x86_64
-    box:        generic/oracle8
-    hypervisor: <%= hypervisor %>
-
+    - default
+    - shipper
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
   oel8-receiver:
     roles:
-      - receiver
-    platform:   el-8-x86_64
-    box:        generic/oracle8
-    hypervisor: <%= hypervisor %>
-
+    - receiver
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
   type: aio
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"

--- a/spec/acceptance/suites/no_simp_server/nodesets/oel7.yml
+++ b/spec/acceptance/suites/no_simp_server/nodesets/oel7.yml
@@ -1,29 +1,23 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
+---
 HOSTS:
   oel7-server:
     roles:
-      - default
-      - server
-    platform:   el-7-x86_64
-    box:        generic/oracle7
-    hypervisor: <%= hypervisor %>
-
+    - default
+    - server
+    platform: el-7-x86_64
+    box: generic/oracle7
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
   oel7-client:
     roles:
-      - client
-    platform:   el-7-x86_64
-    box:        generic/oracle7
-    hypervisor: <%= hypervisor %>
-
+    - client
+    platform: el-7-x86_64
+    box: generic/oracle7
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
   type: aio
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"

--- a/spec/acceptance/suites/no_simp_server/nodesets/oel8.yml
+++ b/spec/acceptance/suites/no_simp_server/nodesets/oel8.yml
@@ -1,29 +1,23 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
+---
 HOSTS:
   oel8-server:
     roles:
-      - default
-      - server
-    platform:   el-8-x86_64
-    box:        generic/oracle8
-    hypervisor: <%= hypervisor %>
-
+    - default
+    - server
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
   oel8-client:
     roles:
-      - client
-    platform:   el-8-x86_64
-    box:        generic/oracle8
-    hypervisor: <%= hypervisor %>
-
+    - client
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
   type: aio
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"

--- a/spec/acceptance/suites/scenario_poss/nodesets/default.yml
+++ b/spec/acceptance/suites/scenario_poss/nodesets/default.yml
@@ -1,45 +1,38 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
+---
 HOSTS:
   oel7:
     roles:
-      - default
-    platform:   el-7-x86_64
-    box:        generic/oracle7
-    hypervisor: <%= hypervisor %>
+    - default
+    platform: el-7-x86_64
+    box: generic/oracle7
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     yum_repos:
       simp:
         baseurl: https://download.simp-project.com/simp/yum/rolling/6/el/$releasever/$basearch/simp
         gpgkeys:
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-UNSTABLE
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-UNSTABLE
       simp_epel:
         baseurl: https://download.simp-project.com/simp/yum/rolling/6/el/$releasever/$basearch/epel
         gpgkeys:
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-CentOS-$releasever
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-redhat-release
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-EPEL-$releasever
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-CentOS-$releasever
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-redhat-release
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-EPEL-$releasever
       simp_postgresql:
         baseurl: https://download.simp-project.com/simp/yum/rolling/6/el/$releasever/$basearch/postgresql
         gpgkeys:
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-PGDG-96
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-PGDG-96
       simp_puppet:
         baseurl: https://download.simp-project.com/simp/yum/rolling/6/el/$releasever/$basearch/puppet
         gpgkeys:
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-puppet
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-puppetlabs
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-puppet
+        - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-puppetlabs
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
-  type:      aio
+  type: aio
   vagrant_memsize: 256
   synced_folder: disabled
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
-  # vb_gui: true
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"

--- a/spec/acceptance/suites/scenario_poss/nodesets/oel8.yml
+++ b/spec/acceptance/suites/scenario_poss/nodesets/oel8.yml
@@ -1,24 +1,16 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
+---
 HOSTS:
   oel8:
     roles:
-      - default
-    platform:   el-8-x86_64
-    box:        generic/oracle8
-    hypervisor: <%= hypervisor %>
-
+    - default
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
-  type:      aio
+  type: aio
   vagrant_memsize: 256
   synced_folder: disabled
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
-  # vb_gui: true
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"

--- a/spec/acceptance/suites/scenario_remote_access/nodesets/oel.yml
+++ b/spec/acceptance/suites/scenario_remote_access/nodesets/oel.yml
@@ -1,49 +1,45 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
+---
 HOSTS:
   server-oel7.simp.beaker:
     roles:
-      - server
-      - ldap_server
-      - openldap
-    platform:   el-7-x86_64
-    box:        generic/oracle7
-    hypervisor: <%= hypervisor %>
-
+    - server
+    - ldap_server
+    - openldap
+    platform: el-7-x86_64
+    box: generic/oracle7
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
   server-oel8.simp.beaker:
     roles:
-      - server
-      - default
-      - ldap_server
-      - ds389
-    platform:   el-8-x86_64
-    box:        generic/oracle8
-    hypervisor: <%= hypervisor %>
-
+    - server
+    - default
+    - ldap_server
+    - ds389
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
   client-oel7.simp.beaker:
     roles:
-      - client
-    platform:   el-7-x86_64
-    box:        generic/oracle7
-    hypervisor: <%= hypervisor %>
-
+    - client
+    platform: el-7-x86_64
+    box: generic/oracle7
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
   client-oel8.simp.beaker:
     roles:
-      - client
-    platform:   el-8-x86_64
-    box:        generic/oracle8
-    hypervisor: <%= hypervisor %>
-
+    - client
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
   type: aio
   vagrant_memsize: 2048
   synced_folder: disabled
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"

--- a/spec/acceptance/suites/win_client/nodesets/default.yml
+++ b/spec/acceptance/suites/win_client/nodesets/default.yml
@@ -13,7 +13,7 @@ HOSTS:
     is_cygwin: false
     ssh:
       host_key: "+ssh-dss"
-    family: windows-cloud/windows-2012-r2
+    family: 
     gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose


### PR DESCRIPTION
This patch moves puppet 6 refs to 7, puppet 7 refs to 8. Then we manually
update all spec nodesets to point to sicura oel boxes and comment out all 
pup8 tests.

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.