### PR TITLE
(#issue_318) Added ability for users to switch between '/bin/true' and '/bin/false' when disabling kernel modules via the kmod_blacklist class

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Mon Jul 09 2024 Mike Riddle <mike@sicura.us> - 4.22.0
+* Tue Jul 09 2024 Mike Riddle <mike@sicura.us> - 4.22.0
 - Added ability for users to switch between '/bin/true' and '/bin/false' when disabling kernel modules via the kmod_blacklist class
 
 * Tue Jul 02 2024 Steven Pritchard <steve@sicura.us> - 4.21.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jul 09 2024 Mike Riddle <mike@sicura.us> - 4.22.0
+- Added ability for users to switch between '/bin/true' and '/bin/false' when disabling kernel modules via the kmod_blacklist class
+
 * Tue Jul 02 2024 Steven Pritchard <steve@sicura.us> - 4.21.0
 - Clean up use of legacy facts to better support Puppet 8
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -714,6 +714,7 @@ The following parameters are available in the `simp::kmod_blacklist` class:
 
 * [`enable_defaults`](#-simp--kmod_blacklist--enable_defaults)
 * [`blacklist`](#-simp--kmod_blacklist--blacklist)
+* [`produce_error`](#-simp--kmod_blacklist--produce_error)
 * [`custom_blacklist`](#-simp--kmod_blacklist--custom_blacklist)
 * [`allow_overrides`](#-simp--kmod_blacklist--allow_overrides)
 * [`lock_modules`](#-simp--kmod_blacklist--lock_modules)
@@ -757,6 +758,16 @@ Default value:
     'usb-storage'
   ]
 ```
+
+##### <a name="-simp--kmod_blacklist--produce_error"></a>`produce_error`
+
+Data type: `Boolean`
+
+If set to true, any disabled modules will point to '/bin/false', which will
+produce an error when anyone attempts to load the module. Default is false,
+which will point to '/bin/true', which will not produce any error.
+
+Default value: `false`
 
 ##### <a name="-simp--kmod_blacklist--custom_blacklist"></a>`custom_blacklist`
 

--- a/manifests/kmod_blacklist.pp
+++ b/manifests/kmod_blacklist.pp
@@ -8,6 +8,11 @@
 # @param blacklist
 #   List of kernel modules to be blacklisted by default
 #
+# @param produce_error
+#   If set to true, any disabled modules will point to '/bin/false', which will
+#   produce an error when anyone attempts to load the module. Default is false,
+#   which will point to '/bin/true', which will not produce any error.
+#
 # @param custom_blacklist
 #   Additional kernel modules to be blacklisted
 #
@@ -50,6 +55,7 @@ class simp::kmod_blacklist (
     'usb-storage'
   ],
   Array[String]   $custom_blacklist          = [],
+  Boolean         $produce_error             = false,
   Boolean         $allow_overrides           = true,
   Boolean         $lock_modules              = false,
   Boolean         $notify_if_reboot_required = true
@@ -80,7 +86,12 @@ class simp::kmod_blacklist (
     $_obsolete_disable_file = '/etc/modprobe.d/zz_simp_disable.conf'
   }
 
-  $_disable_file_content = join($_blacklist.map |$mod| { "install ${mod} /bin/true" }, "\n")
+  $_produce_error = $produce_error ? {
+    true  => '/bin/false',
+    false => '/bin/true'
+  }
+
+  $_disable_file_content = join($_blacklist.map |$mod| { "install ${mod} ${_produce_error}" }, "\n")
 
   file { $_disable_file:
     ensure  => file,

--- a/manifests/kmod_blacklist.pp
+++ b/manifests/kmod_blacklist.pp
@@ -88,7 +88,7 @@ class simp::kmod_blacklist (
 
   $_produce_error = $produce_error ? {
     true  => '/bin/false',
-    false => '/bin/true'
+    false => '/bin/true',
   }
 
   $_disable_file_content = join($_blacklist.map |$mod| { "install ${mod} ${_produce_error}" }, "\n")

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "4.21.0",
+  "version": "4.22.0",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/spec/classes/00_classes/kmod_blacklist_spec.rb
+++ b/spec/classes/00_classes/kmod_blacklist_spec.rb
@@ -183,6 +183,16 @@ describe 'simp::kmod_blacklist' do
 
           end
 
+          context 'when producing an error on module load' do
+            let(:params){{
+              :produce_error => true
+            }}
+
+            it 'should blacklist all the default kmods and point to /bin/false' do
+              is_expected.to create_file("/etc/modprobe.d/00_simp_disable.conf").with_content(stock_blacklist.map{|x| x = "install #{x} /bin/false" }.join("\n") + "\n")
+            end
+          end
+
         end
       end
     end

--- a/spec/classes/00_classes/kmod_blacklist_spec.rb
+++ b/spec/classes/00_classes/kmod_blacklist_spec.rb
@@ -189,7 +189,7 @@ describe 'simp::kmod_blacklist' do
             }}
 
             it 'should blacklist all the default kmods and point to /bin/false' do
-              is_expected.to create_file("/etc/modprobe.d/00_simp_disable.conf").with_content(stock_blacklist.map{|x| x = "install #{x} /bin/false" }.join("\n") + "\n")
+              is_expected.to create_file("/etc/modprobe.d/zz_simp_disable.conf").with_content(stock_blacklist.map{|x| x = "install #{x} /bin/false" }.join("\n") + "\n")
             end
           end
 


### PR DESCRIPTION
Fixes #318