### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -24,7 +24,6 @@ fixtures:
     augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl.git
     authselect: https://github.com/voxpupuli/puppet-authselect.git
     autofs: https://github.com/simp/pupmod-simp-autofs.git
-    chkrootkit: https://github.com/simp/pupmod-simp-chkrootkit.git
     chrony: https://github.com/simp/pupmod-voxpupuli-chrony.git
     clamav: https://github.com/simp/pupmod-simp-clamav.git
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git
@@ -73,7 +72,6 @@ fixtures:
     simp_apache: https://github.com/simp/pupmod-simp-apache.git
     simp_banners: https://github.com/simp/pupmod-simp-simp_banners.git
     simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
-    simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap.git
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git
     simp_rsyslog: https://github.com/simp/pupmod-simp-simp_rsyslog.git
     simp_ds389: https://github.com/simp/pupmod-simp-simp_ds389.git
@@ -84,10 +82,8 @@ fixtures:
     stunnel: https://github.com/simp/pupmod-simp-stunnel.git
     systemd: https://github.com/simp/puppet-systemd.git
     sudo: https://github.com/simp/pupmod-simp-sudo.git
-    sudosh: https://github.com/simp/pupmod-simp-sudosh.git
     svckill: https://github.com/simp/pupmod-simp-svckill.git
     swap: https://github.com/simp/pupmod-simp-swap.git
-    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
     tftpboot: https://github.com/simp/pupmod-simp-tftpboot.git
     timezone: https://github.com/simp/pupmod-simp-timezone.git
     tlog: https://github.com/simp/pupmod-simp-tlog.git
@@ -97,7 +93,6 @@ fixtures:
     vox_selinux:
       repo: https://github.com/simp/pupmod-voxpupuli-selinux.git
       branch: simp-master
-    xinetd: https://github.com/simp/pupmod-simp-xinetd.git
     yum: https://github.com/simp/voxpupuli-yum.git
     yumrepo_core: https://github.com/simp/pupmod-puppetlabs-yumrepo_core.git
     # Kluge for rsync data

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -24,7 +24,6 @@ fixtures:
     augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl.git
     authselect: https://github.com/voxpupuli/puppet-authselect.git
     autofs: https://github.com/simp/pupmod-simp-autofs.git
-    chkrootkit: https://github.com/simp/pupmod-simp-chkrootkit.git
     chrony: https://github.com/simp/pupmod-voxpupuli-chrony.git
     clamav: https://github.com/simp/pupmod-simp-clamav.git
     concat: https://github.com/simp/puppetlabs-concat.git
@@ -71,7 +70,6 @@ fixtures:
     simp_apache: https://github.com/simp/pupmod-simp-apache.git
     simp_banners: https://github.com/simp/pupmod-simp-simp_banners.git
     simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
-    simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap.git
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git
     simp_rsyslog: https://github.com/simp/pupmod-simp-simp_rsyslog.git
     simp_ds389: https://github.com/simp/pupmod-simp-simp_ds389.git
@@ -82,10 +80,8 @@ fixtures:
     stunnel: https://github.com/simp/pupmod-simp-stunnel.git
     systemd: https://github.com/simp/puppet-systemd.git
     sudo: https://github.com/simp/pupmod-simp-sudo.git
-    sudosh: https://github.com/simp/pupmod-simp-sudosh.git
     svckill: https://github.com/simp/pupmod-simp-svckill.git
     swap: https://github.com/simp/pupmod-simp-swap.git
-    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
     tftpboot: https://github.com/simp/pupmod-simp-tftpboot.git
     timezone: https://github.com/simp/pupmod-simp-timezone.git
     tlog: https://github.com/simp/pupmod-simp-tlog.git
@@ -95,7 +91,6 @@ fixtures:
     vox_selinux:
       repo: https://github.com/simp/pupmod-voxpupuli-selinux.git
       branch: simp-master
-    xinetd: https://github.com/simp/pupmod-simp-xinetd.git
     yum: https://github.com/simp/voxpupuli-yum.git
     yumrepo_core: https://github.com/simp/pupmod-puppetlabs-yumrepo_core.git
     # Kluge for rsync data

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Wed Jul 29 2026 Steven Pritchard <steve@sicura.us> - 9.0.0
+- Remove references to archived SIMP modules (sudosh, tcpwrappers, xinetd,
+  chkrootkit, simp_openldap): drop their fixtures and metadata dependencies
+- BREAKING CHANGE: `simp::admin::logged_shell` no longer accepts `sudosh`;
+  `tlog` is the only supported logged shell
+
 * Wed Jul 29 2026 Hazel Caballero <hazel@sicura.us> - 9.0.0
 - (#374) Remove all references to the archived pupmod-simp-ntpd module: drop
   the `simp/ntpd` metadata dependency and fixture, consolidate the kickstart

--- a/files/scenarios/one_shot/simp_one_shot_finalize.sh
+++ b/files/scenarios/one_shot/simp_one_shot_finalize.sh
@@ -91,9 +91,8 @@ else
 This is a SIMP-based standalone image
 
 Some items you should be aware of:
-  * To get to 'root', you need to use 'sudo sudosh'
+  * To get to 'root', you need to use 'sudo su - root'
   * IPTables is *on*
-  * TCPWrappers is *on*
   * Host access restriction via PAM is *on* (/etc/security/access.conf)
   * Password quality restrictions are *enabled*
 

--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -101,7 +101,7 @@ class simp::admin (
   Simplib::Netlist      $admins_allowed_from       = ['ALL'],
   Simplib::Netlist      $auditors_allowed_from     = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] }),
   Boolean               $force_logged_shell        = true,
-  Enum['sudosh','tlog'] $logged_shell              = 'tlog',
+  Enum['tlog']          $logged_shell              = 'tlog',
   Array[String[2]]      $default_admin_sudo_cmnds  = ['/bin/su - root'],
   Hash                  $admin_sudo_options        = { 'role' => 'unconfined_r' },
   Hash                  $auditor_sudo_options      = {},
@@ -144,35 +144,15 @@ class simp::admin (
   }
 
   if $force_logged_shell {
-    # We restrict this so we don't need a fallback
-    if $logged_shell == 'sudosh' {
-      include 'sudosh'
+    include 'tlog::rec_session'
 
-      $_shell_cmd = ['/usr/bin/sudosh']
-    }
-    else {
-      # TODO: This should be removed when SIMP-5169 is resolved
-      file { '/etc/profile.d/sudosh2.sh': ensure => 'absent' }
-    }
+    $_shell_cmd = $default_admin_sudo_cmnds
 
-    if $logged_shell == 'tlog' {
-      include 'tlog::rec_session'
-
-      $_shell_cmd = $default_admin_sudo_cmnds
-    }
-    else {
-      # TODO: This should be removed when SIMP-5169 is resolved
-      tidy { 'Tlog profile.d files':
-        path    => '/etc/profile.d',
-        matches => ['00-simp-tlog.*'],
-        recurse => 1,
-      }
-    }
+    file { '/etc/profile.d/sudosh2.sh': ensure => 'absent' }
   }
   else {
     $_shell_cmd = $default_admin_sudo_cmnds
 
-    # TODO: These should be removed when SIMP-5169 is resolved
     tidy { 'Shell logging profile.d files':
       path    => '/etc/profile.d',
       matches => ['00-simp-tlog.*', 'sudosh2.*'],
@@ -198,7 +178,7 @@ class simp::admin (
     }
   }
 
-  # The following two are especially important if you're using sudosh.
+  # The following two are especially important for logged shell recovery.
   # They allow you to recover from destroying the certs in your environment.
   sudo::user_specification { 'admin run puppet':
     user_list => ["%${admin_group}"],

--- a/metadata.json
+++ b/metadata.json
@@ -56,10 +56,6 @@
       "version_requirement": ">= 8.5.0 < 10.0.0"
     },
     {
-      "name": "simp/chkrootkit",
-      "version_requirement": ">= 0.1.0 < 1.0.0"
-    },
-    {
       "name": "simp/clamav",
       "version_requirement": ">= 6.0.0 < 7.0.0"
     },
@@ -124,10 +120,6 @@
       "version_requirement": ">= 7.0.0 < 8.0.0"
     },
     {
-      "name": "simp/simp_openldap",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
-    },
-    {
       "name": "simp/simp_options",
       "version_requirement": ">= 1.6.1 < 2.0.0"
     },
@@ -154,10 +146,6 @@
     {
       "name": "simp/sudo",
       "version_requirement": ">= 5.1.1 < 6.0.0"
-    },
-    {
-      "name": "simp/sudosh",
-      "version_requirement": ">= 6.1.0 < 7.0.0"
     },
     {
       "name": "simp/svckill",

--- a/metadata.json
+++ b/metadata.json
@@ -56,10 +56,6 @@
       "version_requirement": ">= 8.5.0 < 11.0.0"
     },
     {
-      "name": "simp/chkrootkit",
-      "version_requirement": ">= 0.1.0 < 1.0.0"
-    },
-    {
       "name": "simp/clamav",
       "version_requirement": ">= 6.0.0 < 8.0.0"
     },
@@ -120,10 +116,6 @@
       "version_requirement": ">= 7.0.0 < 9.0.0"
     },
     {
-      "name": "simp/simp_openldap",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
-    },
-    {
       "name": "simp/simp_options",
       "version_requirement": ">= 1.6.1 < 3.0.0"
     },
@@ -150,10 +142,6 @@
     {
       "name": "simp/sudo",
       "version_requirement": ">= 5.1.1 < 7.0.0"
-    },
-    {
-      "name": "simp/sudosh",
-      "version_requirement": ">= 6.1.0 < 7.0.0"
     },
     {
       "name": "simp/svckill",

--- a/spec/acceptance/suites/default/05_shell_logger_spec.rb
+++ b/spec/acceptance/suites/default/05_shell_logger_spec.rb
@@ -26,65 +26,6 @@ describe 'simp_admin' do
           end
         end
 
-        os_major = fact_on(host, 'os.release.major')
-
-        if os_major == '7'
-          context 'switching to sudosh' do
-            let(:hieradata)  do
-              YAML.load_file(File.expand_path('files/default_hiera.yaml', __dir__)).merge(
-                'simp::admin::logged_shell' => 'sudosh',
-              )
-            end
-
-            it 'switches to sudosh via hiera' do
-              set_hieradata_on(host, hieradata)
-            end
-
-            it 'runs puppet' do
-              apply_manifest_on(host, manifest, catch_changes: false)
-            end
-
-            it 'is idempotent' do
-              apply_manifest_on(host, manifest, catch_changes: true)
-            end
-
-            it 'has sudosh2 installed' do
-              expect(host.check_for_package('sudosh2')).to be true
-            end
-
-            it 'does not have any tlog profile scripts installed' do
-              expect(on(host, 'ls /etc/profile.d/00-simp-tlog.*', accept_all_exit_codes: true).stdout.strip).to be_empty
-            end
-          end
-
-          context 'switching back to tlog' do
-            let(:hieradata)  do
-              YAML.load_file(File.expand_path('files/default_hiera.yaml', __dir__)).merge(
-                'simp::admin::logged_shell' => 'tlog',
-              )
-            end
-
-            it 'switches back to tlog via hiera' do
-              set_hieradata_on(host, hieradata)
-            end
-
-            it 'runs puppet' do
-              apply_manifest_on(host, manifest, catch_changes: false)
-            end
-
-            it 'is idempotent' do
-              apply_manifest_on(host, manifest, catch_changes: true)
-            end
-
-            it 'has tlog installed' do
-              expect(host.check_for_package('sudosh2')).to be true
-            end
-
-            it 'does not have any sudosh profile scripts installed' do
-              expect(on(host, 'ls /etc/profile.d/sudosh*', accept_all_exit_codes: true).stdout.strip).to be_empty
-            end
-          end
-        end
       end
     end
   end

--- a/spec/acceptance/suites/default/05_shell_logger_spec.rb
+++ b/spec/acceptance/suites/default/05_shell_logger_spec.rb
@@ -25,7 +25,6 @@ describe 'simp_admin' do
             expect(host.check_for_package('tlog')).to be true
           end
         end
-
       end
     end
   end

--- a/spec/acceptance/suites/scenario_one_shot/00_simp_spec.rb
+++ b/spec/acceptance/suites/scenario_one_shot/00_simp_spec.rb
@@ -64,7 +64,6 @@ describe 'simp "one_shot" scenario' do
       simp_options::pam: true
       simp_options::sssd: true
       simp_options::syslog: true
-      simp_options::tcpwrappers: true
       simp_options::pki: true
       simp_options::sssd: true
 

--- a/spec/acceptance/suites/scenario_remote_access/templates/client_hieradata.yaml.erb
+++ b/spec/acceptance/suites/scenario_remote_access/templates/client_hieradata.yaml.erb
@@ -21,7 +21,6 @@ simp_options::pam: true
 simp_options::sssd: true
 simp_options::stunnel: false
 simp_options::syslog: false
-simp_options::tcpwrappers: false
 simp_options::ipsec: false
 simp_options::kerberos: false
 

--- a/spec/classes/00_classes/admin_spec.rb
+++ b/spec/classes/00_classes/admin_spec.rb
@@ -87,31 +87,11 @@ describe 'simp::admin' do
               end
 
               it { is_expected.to create_class('tlog::rec_session') }
-              it { is_expected.not_to create_class('sudosh') }
 
               it {
                 is_expected.to create_sudo__user_specification('admin global').with(
                   user_list: ['%administrators'],
                   cmnd: ['/bin/su - root'],
-                  passwd: false,
-                )
-              }
-            end
-
-            context 'when setting sudosh as the logged shell' do
-              let(:params) do
-                {
-                  logged_shell: 'sudosh',
-                }
-              end
-
-              it { is_expected.to create_class('sudosh') }
-              it { is_expected.not_to create_class('tlog::rec_session') }
-
-              it {
-                is_expected.to create_sudo__user_specification('admin global').with(
-                  user_list: ['%administrators'],
-                  cmnd: ['/usr/bin/sudosh'],
                   passwd: false,
                 )
               }


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.