### PR TITLE
(#310, #325, #366) Sysctl opt-out, ptrace_scope, mail_server opt-in

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+* Thu Jul 16 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 8.0.0
+- (#325) Default `simp::mail_server` to `false` so Postfix is opt-in rather
+  than installed on every node (BREAKING CHANGE for sites that relied on the
+  implicit local MTA; set `simp::mail_server: true` to restore prior behavior).
+- (#366) Manage `kernel.yama.ptrace_scope` in `simp::sysctl` (defaults to `1`
+  per STIG RHEL-08-040282 / CCE-80953-8).
+- (#310) Add `simp::sysctl::unmanaged_sysctls` to let sites opt individual
+  sysctl keys out of management without re-specifying the other defaults.
+
 * Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 7.0.1
 - Added exec idempotency guards and resolved puppet-lint offenses
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,11 @@
-* Thu Jul 16 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 8.0.0
+* Fri Jul 24 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 8.0.0
 - (#325) Default `simp::mail_server` to `false` so Postfix is opt-in rather
   than installed on every node (BREAKING CHANGE for sites that relied on the
   implicit local MTA; set `simp::mail_server: true` to restore prior behavior).
-- (#366) Manage `kernel.yama.ptrace_scope` in `simp::sysctl` (defaults to `1`
-  per STIG RHEL-08-040282 / CCE-80953-8).
+- (#366) Add a `kernel.yama.ptrace_scope` parameter to `simp::sysctl`. The
+  setting is available but unmanaged by default (`undef`), leaving the OS
+  default in place; set it to `1` to satisfy STIG RHEL-08-040282 /
+  CCE-80953-8.
 - (#310) Add `simp::sysctl::unmanaged_sysctls` to let sites opt individual
   sysctl keys out of management without re-specifying the other defaults.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -178,13 +178,16 @@ Data type: `Variant[Boolean,Enum['remote']]`
 
 Install a local mail service on the system
 
+* Defaults to ``false`` so the MTA is opt-in: installing Postfix on every
+  node adds attack surface that is unnecessary for sites that use a
+  dedicated relay or no MTA at all
 * If ``true`` will install only a locally usable MTA
 * If ``remote`` will install a full mail server capable of processing
   remote connections
     * If you use a remote server, you'll need to set the appropriate
       parameters for the ``postfix`` class
 
-Default value: `true`
+Default value: `false`
 
 ##### <a name="-simp--rsync_stunnel"></a>`rsync_stunnel`
 
@@ -2065,6 +2068,8 @@ Data type: `Variant[Boolean,Enum['remote']]`
 
 Install a local mail service on the system
 
+* Defaults to ``false`` so the MTA is opt-in (inherited from
+  ``simp::mail_server``)
 * If ``true`` will install only a locally usable MTA
 * If ``remote`` will install a full mail server capable of processing
   remote connections
@@ -3118,6 +3123,7 @@ The following parameters are available in the `simp::sysctl` class:
 * [`kernel__panic`](#-simp--sysctl--kernel__panic)
 * [`kernel__randomize_va_space`](#-simp--sysctl--kernel__randomize_va_space)
 * [`kernel__sysrq`](#-simp--sysctl--kernel__sysrq)
+* [`kernel__yama__ptrace_scope`](#-simp--sysctl--kernel__yama__ptrace_scope)
 * [`net__ipv4__conf__all__accept_redirects`](#-simp--sysctl--net__ipv4__conf__all__accept_redirects)
 * [`net__ipv4__conf__all__accept_source_route`](#-simp--sysctl--net__ipv4__conf__all__accept_source_route)
 * [`net__ipv4__conf__all__log_martians`](#-simp--sysctl--net__ipv4__conf__all__log_martians)
@@ -3154,6 +3160,7 @@ The following parameters are available in the `simp::sysctl` class:
 * [`core_dump_dir`](#-simp--sysctl--core_dump_dir)
 * [`pam`](#-simp--sysctl--pam)
 * [`ipv6`](#-simp--sysctl--ipv6)
+* [`unmanaged_sysctls`](#-simp--sysctl--unmanaged_sysctls)
 
 ##### <a name="-simp--sysctl--net__netfilter__nf_conntrack_max"></a>`net__netfilter__nf_conntrack_max`
 
@@ -3395,6 +3402,18 @@ Data type: `Integer[0]`
 
 
 Default value: `0`
+
+##### <a name="-simp--sysctl--kernel__yama__ptrace_scope"></a>`kernel__yama__ptrace_scope`
+
+Data type: `Optional[Integer[0,3]]`
+
+Restricts the use of ``ptrace`` to processes with a defined relationship
+(parent/child by default).  Unmanaged by default (``undef``) so the OS
+default (``0`` on EL) is left in place; set to ``1`` to satisfy STIG/SSG
+controls that require ``kernel.yama.ptrace_scope`` >= 1 on EL 8/9 (e.g.
+RHEL-08-040282 / CCE-80953-8).  Valid kernel values are ``0``-``3``.
+
+Default value: `undef`
 
 ##### <a name="-simp--sysctl--net__ipv4__conf__all__accept_redirects"></a>`net__ipv4__conf__all__accept_redirects`
 
@@ -3684,6 +3703,18 @@ Data type: `Optional[Boolean]`
 Set to ``false`` to disable IPv6 on your system via ``sysctl``
 
 Default value: `undef`
+
+##### <a name="-simp--sysctl--unmanaged_sysctls"></a>`unmanaged_sysctls`
+
+Data type: `Array[String]`
+
+List of sysctl keys (e.g. ``net.core.somaxconn``) that this class should
+leave alone. Use when another tool (``tuned``, ``NetworkManager``, a
+container runtime, a vendor installer) already manages the value and SIMP
+should not fight over it. Keys must match the actual sysctl name, not the
+class parameter name.
+
+Default value: `[]`
 
 ### <a name="simp--version"></a>`simp::version`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,9 @@
 # @param mail_server
 #   Install a local mail service on the system
 #
+#   * Defaults to ``false`` so the MTA is opt-in: installing Postfix on every
+#     node adds attack surface that is unnecessary for sites that use a
+#     dedicated relay or no MTA at all
 #   * If ``true`` will install only a locally usable MTA
 #   * If ``remote`` will install a full mail server capable of processing
 #     remote connections
@@ -159,7 +162,7 @@ class simp (
   String                          $scenario                   = 'simp',
   Boolean                         $enable_data_includes       = true,
   Array                           $classes                    = [],
-  Variant[Boolean,Enum['remote']] $mail_server                = true,
+  Variant[Boolean,Enum['remote']] $mail_server                = false,
   Variant[Boolean,Simplib::Host]  $rsync_stunnel              = simplib::lookup('simp_options::stunnel', { 'default_value' => true }),
   Boolean                         $use_ssh_global_known_hosts = false,
   Boolean                         $version_info               = true,

--- a/manifests/scenario/base.pp
+++ b/manifests/scenario/base.pp
@@ -7,6 +7,8 @@
 # @param mail_server
 #   Install a local mail service on the system
 #
+#   * Defaults to ``false`` so the MTA is opt-in (inherited from
+#     ``simp::mail_server``)
 #   * If ``true`` will install only a locally usable MTA
 #   * If ``remote`` will install a full mail server capable of processing
 #     remote connections

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -47,6 +47,11 @@
 # @param kernel__panic
 # @param kernel__randomize_va_space
 # @param kernel__sysrq
+# @param kernel__yama__ptrace_scope
+#   Restricts the use of ``ptrace`` to processes with a defined relationship
+#   (parent/child by default).  Set to ``1`` to satisfy STIG/SSG controls that
+#   require ``kernel.yama.ptrace_scope`` >= 1 on EL 8/9 (e.g. RHEL-08-040282).
+#   Valid kernel values are ``0``-``3``.
 # @param net__ipv4__conf__all__accept_redirects
 # @param net__ipv4__conf__all__accept_source_route
 # @param net__ipv4__conf__all__log_martians
@@ -88,6 +93,15 @@
 # @param ipv6
 #   Set to ``false`` to disable IPv6 on your system via ``sysctl``
 #
+# @param unmanaged_sysctls
+#   List of sysctl keys (e.g. ``net.core.somaxconn``) that this class should
+#   leave alone. Use when another tool (``tuned``, ``NetworkManager``, a
+#   container runtime, a vendor installer) already manages the value and SIMP
+#   should not fight over it. Keys must match the actual sysctl name, not the
+#   class parameter name.
+#
+# @author https://github.com/simp/pupmod-simp-simp/graphs/contributors
+#
 class simp::sysctl (
   Integer[0]           $net__netfilter__nf_conntrack_max               = 655360,
   Integer[0]           $net__unix__max_dgram_qlen                      = 50,
@@ -119,6 +133,7 @@ class simp::sysctl (
   Integer[0]           $kernel__panic                                  = 10,
   Integer[0,2]         $kernel__randomize_va_space                     = 2,          # CCE-26999-3
   Integer[0]           $kernel__sysrq                                  = 0,
+  Integer[0,3]         $kernel__yama__ptrace_scope                     = 1,          # STIG RHEL-08-040282 / CCE-80953-8
   Integer[0,1]         $net__ipv4__conf__all__accept_redirects         = 0,          # CCE-27027-2
   Integer[0,1]         $net__ipv4__conf__all__accept_source_route      = 0,          # CCE-27037-1
   Integer[0,1]         $net__ipv4__conf__all__log_martians             = 1,          # CCE-27066-0
@@ -155,82 +170,99 @@ class simp::sysctl (
   Boolean              $core_dumps                                     = false,
   Stdlib::AbsolutePath $core_dump_dir                                  = '/var/core',
   Boolean              $pam                                            = simplib::lookup('simp_options::pam', { 'default_value' => false }),
-  Optional[Boolean]    $ipv6                                           = undef
+  Optional[Boolean]    $ipv6                                           = undef,
+  Array[String]        $unmanaged_sysctls                              = []
 ) {
   simplib::module_metadata::assert($module_name, { 'blacklist' => ['Windows'] })
 
   simplib::validate_sysctl_value('kernel.core_pattern',$kernel__core_pattern)
   simplib::validate_sysctl_value('fs.inotify.max_user_watches', $fs__inotify__max_user_watches)
 
-  sysctl {
-    'net.unix.max_dgram_qlen'           : value => $net__unix__max_dgram_qlen;
-    'net.ipv4.neigh.default.gc_thresh3' : value => $net__ipv4__neigh__default__gc_thresh3;
-    'net.ipv4.neigh.default.gc_thresh2' : value => $net__ipv4__neigh__default__gc_thresh2;
-    'net.ipv4.neigh.default.gc_thresh1' : value => $net__ipv4__neigh__default__gc_thresh1;
-    'net.ipv4.neigh.default.proxy_qlen' : value => $net__ipv4__neigh__default__proxy_qlen;
-    'net.ipv4.neigh.default.unres_qlen' : value => $net__ipv4__neigh__default__unres_qlen;
-    'net.ipv4.tcp_rmem'                 : value => join($net__ipv4__tcp_rmem,' ');
-    'net.ipv4.tcp_wmem'                 : value => join($net__ipv4__tcp_wmem,' ');
-    'net.ipv4.tcp_fin_timeout'          : value => $net__ipv4__tcp_fin_timeout;
-    'net.ipv4.tcp_rfc1337'              : value => $net__ipv4__tcp_rfc1337;
-    'net.ipv4.tcp_keepalive_time'       : value => $net__ipv4__tcp_keepalive_time;
-    'net.ipv4.tcp_mtu_probing'          : value => $net__ipv4__tcp_mtu_probing;
-    'net.ipv4.tcp_no_metrics_save'      : value => $net__ipv4__tcp_no_metrics_save;
-    'net.core.rmem_max'                 : value => $net__core__rmem_max;
-    'net.core.wmem_max'                 : value => $net__core__wmem_max;
-    'net.core.optmem_max'               : value => $net__core__optmem_max;
-    'net.core.netdev_max_backlog'       : value => $net__core__netdev_max_backlog;
-    'net.core.somaxconn'                : value => $net__core__somaxconn;
-    'net.ipv4.tcp_tw_reuse'             : value => $net__ipv4__tcp_tw_reuse;
-    'fs.inotify.max_user_watches'       : value => $fs__inotify__max_user_watches,
+  $_perf_settings = {
+    'net.unix.max_dgram_qlen'           => $net__unix__max_dgram_qlen,
+    'net.ipv4.neigh.default.gc_thresh3' => $net__ipv4__neigh__default__gc_thresh3,
+    'net.ipv4.neigh.default.gc_thresh2' => $net__ipv4__neigh__default__gc_thresh2,
+    'net.ipv4.neigh.default.gc_thresh1' => $net__ipv4__neigh__default__gc_thresh1,
+    'net.ipv4.neigh.default.proxy_qlen' => $net__ipv4__neigh__default__proxy_qlen,
+    'net.ipv4.neigh.default.unres_qlen' => $net__ipv4__neigh__default__unres_qlen,
+    'net.ipv4.tcp_rmem'                 => join($net__ipv4__tcp_rmem, ' '),
+    'net.ipv4.tcp_wmem'                 => join($net__ipv4__tcp_wmem, ' '),
+    'net.ipv4.tcp_fin_timeout'          => $net__ipv4__tcp_fin_timeout,
+    'net.ipv4.tcp_rfc1337'              => $net__ipv4__tcp_rfc1337,
+    'net.ipv4.tcp_keepalive_time'       => $net__ipv4__tcp_keepalive_time,
+    'net.ipv4.tcp_mtu_probing'          => $net__ipv4__tcp_mtu_probing,
+    'net.ipv4.tcp_no_metrics_save'      => $net__ipv4__tcp_no_metrics_save,
+    'net.core.rmem_max'                 => $net__core__rmem_max,
+    'net.core.wmem_max'                 => $net__core__wmem_max,
+    'net.core.optmem_max'               => $net__core__optmem_max,
+    'net.core.netdev_max_backlog'       => $net__core__netdev_max_backlog,
+    'net.core.somaxconn'                => $net__core__somaxconn,
+    'net.ipv4.tcp_tw_reuse'             => $net__ipv4__tcp_tw_reuse,
+    'fs.inotify.max_user_watches'       => $fs__inotify__max_user_watches,
+  }
+
+  $_perf_settings.each |$_key, $_value| {
+    unless $_key in $unmanaged_sysctls {
+      sysctl { $_key: value => $_value }
+    }
   }
 
   # This may not exist until additional packages are present
-  sysctl { 'net.netfilter.nf_conntrack_max':
-    value  => $net__netfilter__nf_conntrack_max,
-    silent => true,
+  unless 'net.netfilter.nf_conntrack_max' in $unmanaged_sysctls {
+    sysctl { 'net.netfilter.nf_conntrack_max':
+      value  => $net__netfilter__nf_conntrack_max,
+      silent => true,
+    }
   }
 
   # Security Related Settings
-  sysctl {
-    'fs.suid_dumpable'                                 : value => $fs__suid_dumpable;
-    'kernel.core_pattern'                              : value => $kernel__core_pattern;
-    'kernel.core_pipe_limit'                           : value => $kernel__core_pipe_limit;
-    'kernel.core_uses_pid'                             : value => $kernel__core_uses_pid;
-    'kernel.dmesg_restrict'                            : value => $kernel__dmesg_restrict;
-    'kernel.panic'                                     : value => $kernel__panic;
-    'kernel.randomize_va_space'                        : value => $kernel__randomize_va_space;
-    'kernel.sysrq'                                     : value => $kernel__sysrq;
-    'net.ipv4.conf.all.accept_redirects'               : value => $net__ipv4__conf__all__accept_redirects;
-    'net.ipv4.conf.all.accept_source_route'            : value => $net__ipv4__conf__all__accept_source_route;
-    'net.ipv4.conf.all.log_martians'                   : value => $net__ipv4__conf__all__log_martians;
-    'net.ipv4.conf.all.rp_filter'                      : value => $net__ipv4__conf__all__rp_filter;
-    'net.ipv4.conf.all.secure_redirects'               : value => $net__ipv4__conf__all__secure_redirects;
-    'net.ipv4.conf.all.send_redirects'                 : value => $net__ipv4__conf__all__send_redirects;
-    'net.ipv4.conf.default.accept_redirects'           : value => $net__ipv4__conf__default__accept_redirects;
-    'net.ipv4.conf.default.accept_source_route'        : value => $net__ipv4__conf__default__accept_source_route;
-    'net.ipv4.conf.default.log_martians'               : value => $net__ipv4__conf__default__log_martians;
+  $_security_settings = {
+    'fs.suid_dumpable'                           => $fs__suid_dumpable,
+    'kernel.core_pattern'                        => $kernel__core_pattern,
+    'kernel.core_pipe_limit'                     => $kernel__core_pipe_limit,
+    'kernel.core_uses_pid'                       => $kernel__core_uses_pid,
+    'kernel.dmesg_restrict'                      => $kernel__dmesg_restrict,
+    'kernel.panic'                               => $kernel__panic,
+    'kernel.randomize_va_space'                  => $kernel__randomize_va_space,
+    'kernel.sysrq'                               => $kernel__sysrq,
+    'kernel.yama.ptrace_scope'                   => $kernel__yama__ptrace_scope,
+    'net.ipv4.conf.all.accept_redirects'         => $net__ipv4__conf__all__accept_redirects,
+    'net.ipv4.conf.all.accept_source_route'      => $net__ipv4__conf__all__accept_source_route,
+    'net.ipv4.conf.all.log_martians'             => $net__ipv4__conf__all__log_martians,
+    'net.ipv4.conf.all.rp_filter'                => $net__ipv4__conf__all__rp_filter,
+    'net.ipv4.conf.all.secure_redirects'         => $net__ipv4__conf__all__secure_redirects,
+    'net.ipv4.conf.all.send_redirects'           => $net__ipv4__conf__all__send_redirects,
+    'net.ipv4.conf.default.accept_redirects'     => $net__ipv4__conf__default__accept_redirects,
+    'net.ipv4.conf.default.accept_source_route'  => $net__ipv4__conf__default__accept_source_route,
+    'net.ipv4.conf.default.log_martians'         => $net__ipv4__conf__default__log_martians,
     # Done since we're applying heavy IPTables rules.
-    'net.ipv4.conf.default.rp_filter'                  : value => $net__ipv4__conf__default__rp_filter;
-    'net.ipv4.conf.default.secure_redirects'           : value => $net__ipv4__conf__default__secure_redirects;
-    'net.ipv4.conf.default.send_redirects'             : value => $net__ipv4__conf__default__send_redirects;
-    'net.ipv4.icmp_echo_ignore_broadcasts'             : value => $net__ipv4__icmp_echo_ignore_broadcasts;
-    'net.ipv4.icmp_ignore_bogus_error_responses'       : value => $net__ipv4__icmp_ignore_bogus_error_responses;
-    'net.ipv4.tcp_challenge_ack_limit'                 : value => $net__ipv4__tcp_challenge_ack_limit;
-    'net.ipv4.tcp_max_syn_backlog'                     : value => $net__ipv4__tcp_max_syn_backlog;
-    'net.ipv4.tcp_syncookies'                          : value => $net__ipv4__tcp_syncookies;
+    'net.ipv4.conf.default.rp_filter'            => $net__ipv4__conf__default__rp_filter,
+    'net.ipv4.conf.default.secure_redirects'     => $net__ipv4__conf__default__secure_redirects,
+    'net.ipv4.conf.default.send_redirects'       => $net__ipv4__conf__default__send_redirects,
+    'net.ipv4.icmp_echo_ignore_broadcasts'       => $net__ipv4__icmp_echo_ignore_broadcasts,
+    'net.ipv4.icmp_ignore_bogus_error_responses' => $net__ipv4__icmp_ignore_bogus_error_responses,
+    'net.ipv4.tcp_challenge_ack_limit'           => $net__ipv4__tcp_challenge_ack_limit,
+    'net.ipv4.tcp_max_syn_backlog'               => $net__ipv4__tcp_max_syn_backlog,
+    'net.ipv4.tcp_syncookies'                    => $net__ipv4__tcp_syncookies,
+  }
+
+  $_security_settings.each |$_key, $_value| {
+    unless $_key in $unmanaged_sysctls {
+      sysctl { $_key: value => $_value }
+    }
   }
 
   if $core_dumps {
+    $_core_before = ['kernel.core_pattern', 'kernel.core_uses_pid']
+      .filter |$_k| { !($_k in $unmanaged_sysctls) }
+      .map    |$_k| { Sysctl[$_k] }
+
     file { $core_dump_dir:
       ensure => 'directory',
       owner  => 'root',
       group  => 'root',
       mode   => '0640',
-      before => [
-        Sysctl['kernel.core_pattern'],
-        Sysctl['kernel.core_uses_pid'],
-      ],
+      before => $_core_before,
     }
   }
   if ($pam and !$core_dumps) {
@@ -253,23 +285,29 @@ class simp::sysctl (
   }
 
   if $facts.dig('simplib_sysctl', 'net.ipv6.conf.all.disable_ipv6') {
-    sysctl {
-      'net.ipv6.conf.all.accept_redirects'         : value => $net__ipv6__conf__all__accept_redirects;
-      'net.ipv6.conf.all.accept_source_route'      : value => $net__ipv6__conf__all__accept_source_route;
-      'net.ipv6.conf.all.autoconf'                 : value => $net__ipv6__conf__all__autoconf;
-      'net.ipv6.conf.all.disable_ipv6'             : value => $_disable_ipv6;
-      'net.ipv6.conf.all.forwarding'               : value => $net__ipv6__conf__all__forwarding;
-      'net.ipv6.conf.all.accept_ra'                : value => $net__ipv6__conf__all__accept_ra;
-      'net.ipv6.conf.default.accept_ra'            : value => $net__ipv6__conf__default__accept_ra;
-      'net.ipv6.conf.default.accept_ra_defrtr'     : value => $net__ipv6__conf__default__accept_ra_defrtr;
-      'net.ipv6.conf.default.accept_ra_pinfo'      : value => $net__ipv6__conf__default__accept_ra_pinfo;
-      'net.ipv6.conf.default.accept_ra_rtr_pref'   : value => $net__ipv6__conf__default__accept_ra_rtr_pref;
-      'net.ipv6.conf.default.accept_redirects'     : value => $net__ipv6__conf__default__accept_redirects;
-      'net.ipv6.conf.default.accept_source_route'  : value => $net__ipv6__conf__default__accept_source_route;
-      'net.ipv6.conf.default.autoconf'             : value => $net__ipv6__conf__default__autoconf;
-      'net.ipv6.conf.default.dad_transmits'        : value => $net__ipv6__conf__default__dad_transmits;
-      'net.ipv6.conf.default.max_addresses'        : value => $net__ipv6__conf__default__max_addresses;
-      'net.ipv6.conf.default.router_solicitations' : value => $net__ipv6__conf__default__router_solicitations;
+    $_ipv6_settings = {
+      'net.ipv6.conf.all.accept_redirects'         => $net__ipv6__conf__all__accept_redirects,
+      'net.ipv6.conf.all.accept_source_route'      => $net__ipv6__conf__all__accept_source_route,
+      'net.ipv6.conf.all.autoconf'                 => $net__ipv6__conf__all__autoconf,
+      'net.ipv6.conf.all.disable_ipv6'             => $_disable_ipv6,
+      'net.ipv6.conf.all.forwarding'               => $net__ipv6__conf__all__forwarding,
+      'net.ipv6.conf.all.accept_ra'                => $net__ipv6__conf__all__accept_ra,
+      'net.ipv6.conf.default.accept_ra'            => $net__ipv6__conf__default__accept_ra,
+      'net.ipv6.conf.default.accept_ra_defrtr'     => $net__ipv6__conf__default__accept_ra_defrtr,
+      'net.ipv6.conf.default.accept_ra_pinfo'      => $net__ipv6__conf__default__accept_ra_pinfo,
+      'net.ipv6.conf.default.accept_ra_rtr_pref'   => $net__ipv6__conf__default__accept_ra_rtr_pref,
+      'net.ipv6.conf.default.accept_redirects'     => $net__ipv6__conf__default__accept_redirects,
+      'net.ipv6.conf.default.accept_source_route'  => $net__ipv6__conf__default__accept_source_route,
+      'net.ipv6.conf.default.autoconf'             => $net__ipv6__conf__default__autoconf,
+      'net.ipv6.conf.default.dad_transmits'        => $net__ipv6__conf__default__dad_transmits,
+      'net.ipv6.conf.default.max_addresses'        => $net__ipv6__conf__default__max_addresses,
+      'net.ipv6.conf.default.router_solicitations' => $net__ipv6__conf__default__router_solicitations,
+    }
+
+    $_ipv6_settings.each |$_key, $_value| {
+      unless $_key in $unmanaged_sysctls {
+        sysctl { $_key: value => $_value }
+      }
     }
   }
 }

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -49,9 +49,10 @@
 # @param kernel__sysrq
 # @param kernel__yama__ptrace_scope
 #   Restricts the use of ``ptrace`` to processes with a defined relationship
-#   (parent/child by default).  Set to ``1`` to satisfy STIG/SSG controls that
-#   require ``kernel.yama.ptrace_scope`` >= 1 on EL 8/9 (e.g. RHEL-08-040282).
-#   Valid kernel values are ``0``-``3``.
+#   (parent/child by default).  Unmanaged by default (``undef``) so the OS
+#   default (``0`` on EL) is left in place; set to ``1`` to satisfy STIG/SSG
+#   controls that require ``kernel.yama.ptrace_scope`` >= 1 on EL 8/9 (e.g.
+#   RHEL-08-040282 / CCE-80953-8).  Valid kernel values are ``0``-``3``.
 # @param net__ipv4__conf__all__accept_redirects
 # @param net__ipv4__conf__all__accept_source_route
 # @param net__ipv4__conf__all__log_martians
@@ -133,7 +134,7 @@ class simp::sysctl (
   Integer[0]           $kernel__panic                                  = 10,
   Integer[0,2]         $kernel__randomize_va_space                     = 2,          # CCE-26999-3
   Integer[0]           $kernel__sysrq                                  = 0,
-  Integer[0,3]         $kernel__yama__ptrace_scope                     = 1,          # STIG RHEL-08-040282 / CCE-80953-8
+  Optional[Integer[0,3]] $kernel__yama__ptrace_scope                   = undef,       # Set to 1 for STIG RHEL-08-040282 / CCE-80953-8
   Integer[0,1]         $net__ipv4__conf__all__accept_redirects         = 0,          # CCE-27027-2
   Integer[0,1]         $net__ipv4__conf__all__accept_source_route      = 0,          # CCE-27037-1
   Integer[0,1]         $net__ipv4__conf__all__log_martians             = 1,          # CCE-27066-0
@@ -247,7 +248,9 @@ class simp::sysctl (
   }
 
   $_security_settings.each |$_key, $_value| {
-    unless $_key in $unmanaged_sysctls {
+    # $_value =~ Undef skips optional settings (e.g. kernel.yama.ptrace_scope)
+    # that are left unmanaged by default
+    unless $_key in $unmanaged_sysctls or $_value =~ Undef {
       sysctl { $_key: value => $_value }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp",
-  "version": "7.0.1",
+  "version": "8.0.0",
   "author": "SIMP Team",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",

--- a/spec/classes/00_classes/sysctl_spec.rb
+++ b/spec/classes/00_classes/sysctl_spec.rb
@@ -18,6 +18,7 @@ describe 'simp::sysctl' do
             it { is_expected.to create_sysctl('net.ipv6.conf.all.accept_source_route').with(value: 0) }
             it { is_expected.to create_sysctl('net.ipv6.conf.default.accept_source_route').with(value: 0) }
             it { is_expected.to create_sysctl('fs.inotify.max_user_watches').with(value: 102_400) }
+            it { is_expected.to create_sysctl('kernel.yama.ptrace_scope').with(value: 1) }
           end
 
           context 'with ipv6 enabled' do
@@ -122,6 +123,42 @@ describe 'simp::sysctl' do
             end
 
             it { is_expected.to create_pam__limits__rule('prevent_core') }
+          end
+
+          context 'with unmanaged_sysctls listing specific keys' do
+            let(:params) do
+              {
+                unmanaged_sysctls: [
+                  'net.core.somaxconn',
+                  'fs.inotify.max_user_watches',
+                  'kernel.randomize_va_space',
+                  'net.netfilter.nf_conntrack_max',
+                ],
+              }
+            end
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.not_to create_sysctl('net.core.somaxconn') }
+            it { is_expected.not_to create_sysctl('fs.inotify.max_user_watches') }
+            it { is_expected.not_to create_sysctl('kernel.randomize_va_space') }
+            it { is_expected.not_to create_sysctl('net.netfilter.nf_conntrack_max') }
+            # untouched neighbors are still managed
+            it { is_expected.to create_sysctl('net.core.rmem_max').with(value: 16_777_216) }
+            it { is_expected.to create_sysctl('kernel.dmesg_restrict').with(value: 1) }
+          end
+
+          context 'with core_dumps => true and kernel.core_pattern in unmanaged_sysctls' do
+            let(:params) do
+              {
+                core_dumps: true,
+                unmanaged_sysctls: ['kernel.core_pattern'],
+              }
+            end
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to create_file('/var/core') }
+            it { is_expected.not_to create_sysctl('kernel.core_pattern') }
+            it { is_expected.to create_file('/var/core').that_comes_before('Sysctl[kernel.core_uses_pid]') }
           end
         end
       end

--- a/spec/classes/00_classes/sysctl_spec.rb
+++ b/spec/classes/00_classes/sysctl_spec.rb
@@ -18,6 +18,13 @@ describe 'simp::sysctl' do
             it { is_expected.to create_sysctl('net.ipv6.conf.all.accept_source_route').with(value: 0) }
             it { is_expected.to create_sysctl('net.ipv6.conf.default.accept_source_route').with(value: 0) }
             it { is_expected.to create_sysctl('fs.inotify.max_user_watches').with(value: 102_400) }
+            it { is_expected.not_to create_sysctl('kernel.yama.ptrace_scope') }
+          end
+
+          context 'with kernel__yama__ptrace_scope set' do
+            let(:params) { { kernel__yama__ptrace_scope: 1 } }
+
+            it { is_expected.to compile.with_all_deps }
             it { is_expected.to create_sysctl('kernel.yama.ptrace_scope').with(value: 1) }
           end
 

--- a/spec/classes/01_classes/scenario/base_spec.rb
+++ b/spec/classes/01_classes/scenario/base_spec.rb
@@ -45,7 +45,8 @@ describe 'simp' do
         it { is_expected.to create_class('simp::root_user') }
         # simp_options::pam is not set in spec/fixtures/hieradata/default.yaml
         it { is_expected.not_to create_class('simp::pam_limits::max_logins') }
-        it { is_expected.to create_class('postfix') }
+        # mail_server defaults to false; postfix is opt-in
+        it { is_expected.not_to create_class('postfix') }
         it { is_expected.not_to create_class('postfix::server') }
         # simp_options::ldap is not set in spec/fixtures/hieradata/default.yaml
         it { is_expected.not_to create_class('simp_openldap::client') }
@@ -114,6 +115,14 @@ describe 'simp' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.not_to create_class('postfix') }
+        it { is_expected.not_to create_class('postfix::server') }
+      end
+
+      context 'mail_server = true' do
+        let(:params) { { mail_server: true } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('postfix') }
         it { is_expected.not_to create_class('postfix::server') }
       end
 


### PR DESCRIPTION
- #310: Add simp::sysctl::unmanaged_sysctls (Array[String]). Each managed sysctl is now gated by an `unless $key in $unmanaged_sysctls` check so a site can knock out individual keys (e.g. net.core.somaxconn) when another tool already owns them, without re-specifying every other default.
- #366: Add a kernel.yama.ptrace_scope parameter to simp::sysctl. The setting is available but unmanaged by default (`undef`), leaving the EL OS default (0) in place; set it to 1 to satisfy STIG RHEL-08-040282 / CCE-80953-8 on EL 8/9.
- #325: Default simp::mail_server to false so Postfix is opt-in rather than installed on every node. BREAKING: sites that relied on the implicit local MTA must now set `simp::mail_server: true`. Bumps module to 8.0.0.