### PR TITLE
Add AGENTS.md AI-assistant configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,21 @@ dist
 /log
 /doc
 /Gemfile.lock
+
+## AI coding assistant-specific configuration
+## The standard is AGENTS.md
+# Claude Code
+/CLAUDE.md
+/.claude/
+# GitHub Copilot
+/.github/copilot-instructions.md
+# Cursor
+/.cursor/
+/.cursorrules
+# Windsurf
+/.windsurf/
+/.windsurfrules
+# Gemini CLI
+/GEMINI.md
+# Cline
+/.clinerules/

--- a/.pdkignore
+++ b/.pdkignore
@@ -55,3 +55,4 @@
 /spec/
 /.vscode/
 /tests/
+/AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,13 +96,40 @@ The remaining classes implement individual baseline concerns and are included
 via the scenario map / scenario classes rather than directly. Grouped by
 subdirectory:
 
-- **top-level `manifests/*.pp`** — `simp::admin` (admin/auditor group access
-  and default sudo rules), `simp::base_apps` (common apps such as irqbalance),
-  `simp::base_services` (**deprecated**, slated for removal), `simp::ctrl_alt_del`,
-  `simp::kmod_blacklist`, `simp::mountpoints`, `simp::netconsole`,
-  `simp::nsswitch`, `simp::prelink`, `simp::puppetdb`, `simp::rc_local`,
-  `simp::root_user`, `simp::server` (the SIMP server role), `simp::sudoers`,
-  `simp::sysctl`, and `simp::version`.
+- **top-level `manifests/*.pp`** — each of these directly manages a concrete
+  piece of system state (they are the "what a SIMP baseline touches" classes):
+  - `simp::sysctl` — sets a large set of kernel `sysctl` parameters via the
+    `sysctl` type, covering both performance tuning and security hardening
+    (values validated with `simplib::validate_sysctl_value`); can also disable
+    IPv6.
+  - `simp::sudoers` — manages the global `sudoers` defaults (`default_entry`)
+    and, optionally, a set of common sudoers aliases (via
+    `simp::sudoers::aliases`).
+  - `simp::root_user` — manages the `root` user and group (UID/GID, shell, home
+    directory), the root password hash, and the home directory's permissions
+    and SELinux context.
+  - `simp::rc_local` — manages the content of `/etc/rc.d/rc.local`; disables the
+    file by default.
+  - `simp::puppetdb` — enables and configures a PuppetDB server with
+    SIMP-compatible defaults (wraps `puppetdb` / `puppetdb::master::config`),
+    including TLS settings and `trusted_nets`-based access.
+  - `simp::prelink` — manages prelinking; disabled by default and forcibly
+    removed under FIPS (satisfies the SCAP Security Guide `disable_prelink`
+    check).
+  - `simp::netconsole` — configures `/etc/sysconfig/netconsole` and the
+    netconsole service (kernel console messages over UDP syslog).
+  - `simp::mountpoints` — applies secure mount options and permissions to the
+    `/tmp` family, `/proc`, `/sys`, and `/dev/pts` (delegating to
+    `simp::mountpoints::proc` / `simp::mountpoints::tmp`).
+  - `simp::kmod_blacklist` — blacklists kernel modules per the SCAP Security
+    Guide (a default list plus a custom list), optionally locking further module
+    loading (via `simp::kmod_blacklist::lock_modules`).
+  - `simp::ctrl_alt_del` — controls whether Ctrl-Alt-Del reboots the system and
+    whether the key combination (and the logged-in users) is logged.
+  - `simp::admin` (admin/auditor group access and default sudo rules),
+    `simp::base_apps` (common apps such as irqbalance), `simp::server` (the SIMP
+    server role), `simp::nsswitch`, `simp::version`, and `simp::base_services`
+    (**deprecated**, slated for removal).
 - **`kmod_blacklist/`** — `lock_modules`.
 - **`mountpoints/`** — `proc`, `tmp` (secure mount options).
 - **`pam_limits/`** — `max_logins` (simultaneous-login restriction).
@@ -110,7 +137,8 @@ subdirectory:
   `rsync_shares`, `yum` (server-role provisioning).
 - **`sssd/`** — `client` (stock SSSD stack).
 - **`sudoers/`** — `aliases` (SIMP site sudoers aliases).
-- **`yum/`** — `schedule`, plus a set of `yum/repo/*` repo-definition classes
+- **`yum/`** — `schedule` (sets up a cron-based YUM update schedule via
+  `simp::yum::schedule`), plus a set of `yum/repo/*` repo-definition classes
   (`internet_simp`, `internet_simp_dependencies`, `internet_simp_server`,
   `local_os_updates`, `local_simp`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,291 @@
+# AGENTS.md
+
+This file provides guidance to AI agents when working with code in this repository.
+
+## What this module does
+
+`simp-simp` is the **top-level meta/profile module** of the SIMP (Secure
+Infrastructure Management Platform) stack. Unlike a typical SIMP module, it does
+not manage one service — it **orchestrates the entire SIMP system**. `include
+'simp'` is the single entry point that classifies a node into a coherent,
+security-hardened configuration by selecting and including a curated list of
+classes drawn from across the whole SIMP module ecosystem.
+
+The orchestration is driven by a **scenario** abstraction. The `simp` class
+looks up a `scenario` name, resolves it against a `scenario_map` (a Hash from
+module data mapping each scenario to its class list), and `include`s the
+resulting classes (`manifests/init.pp:201-212`). This is why the module depends
+on essentially the entire SIMP stack: it is the thing that wires those modules
+together into a working system.
+
+The module is deliberately declarative about *what* a SIMP system is: the
+scenario classes (`simp::scenario::base`, `simp::scenario::poss`) encode the
+supported configurations, and a large set of `simp::*` helper classes implement
+the individual pieces (base packages, mountpoints, sysctl, sudoers, PAM limits,
+the SIMP server role, one-shot bootstrap, etc.).
+
+### The scenario model
+
+The `simp` class (`manifests/init.pp:153-225`) is the public entry class —
+consumers `include 'simp'`. Its behaviour is governed by two data-driven
+parameters:
+
+- **`$scenario`** (`String`, default `'simp'`, `init.pp:159`) — the SIMP
+  scenario to apply.
+- **`$scenario_map`** (`Hash`, no default; set from module data,
+  `init.pp:158`) — the internal map from scenario name to class list. Defined in
+  `data/common.yaml` (`simp::scenario_map`) with the keys `none`,
+  `remote_access`, `poss`, `simp_lite`, and `simp`.
+
+Control flow (`init.pp:201-212`):
+
+- If `$scenario` is a key in `$scenario_map`, the class list is computed as
+  `simp::knockout(union($scenario_map[$scenario], $classes))` — the scenario's
+  classes unioned with the caller-supplied `$classes` array, then filtered
+  through the `simp::knockout` function which honours a `--` knockout prefix
+  (an entry `--ntpd` removes `ntpd` from the list).
+- If the resulting list is empty, it emits a `notify` warning that
+  auto-classification is disabled (gated on `$classification_warning`) rather
+  than failing.
+- Otherwise it `include`s the whole computed class list.
+- If `$scenario` is **not** a key in the map, the compile `fail`s with
+  `ERROR - Invalid scenario '<scenario>' for the given scenario map.`
+
+Two scenario classes are the orchestration entry points:
+
+- **`simp::scenario::base` (`manifests/scenario/base.pp`)** — "what a native
+  SIMP system should be." An `assert_private()` class that `inherits simp` and
+  conditionally includes the pieces of a hardened baseline based on the boolean
+  seams inherited from `simp`: `simp::sssd::client` (when `$sssd and
+  $stock_sssd`), `simp::sudoers`, `simp::ctrl_alt_del`, `simp::root_user`,
+  `simp::pam_limits::max_logins` (when `$restrict_max_logins and $pam`),
+  `postfix`/`postfix::server` (mail), `simp::rc_local`, a `host` entry for the
+  Puppet server (from `$server_facts`), optional `ssh::global_known_hosts`, and
+  an `rsync` stunnel connection to the Puppet server on port 8730
+  (`scenario/base.pp:97-153`).
+- **`simp::scenario::poss` (`manifests/scenario/poss.pp`)** — the "Puppet Open
+  Source Software" scenario. An `assert_private()` class (`inherits simp`) that
+  provides a *minimal* client which merely connects to a SIMP Puppet server. It
+  applies **no security hardening** — its only resource is an optional `host`
+  entry for the Puppet server. This is the scenario to use for a stock Puppet
+  experience (it also works on Puppet Enterprise).
+
+### one_shot: bootstrap-only logic
+
+The `simp::one_shot` subtree is **not** part of the standard SIMP run — it
+exists to bootstrap or tear down a stand-alone system that disconnects from the
+Puppet server after a successful run.
+
+- **`simp::one_shot` (`manifests/one_shot.pp`)** — asserts the module metadata
+  with `Windows` blacklisted (`one_shot.pp:93`), `contain`s
+  `simp::one_shot::user`, defines a late run `stage`
+  (`simp_one_shot_finalization`, ordered after `simp_finalize`), and runs
+  `simp::one_shot::finalize` in that stage so finalization only happens if all
+  prior configuration succeeded.
+- **`simp::one_shot::user` (`manifests/one_shot/user.pp`)** —
+  `assert_private()`; creates/removes a stand-alone local user with SSH key,
+  `pam::access` rule, and a `sudo::user_specification`.
+- **`simp::one_shot::finalize` (`manifests/one_shot/finalize.pp`)** —
+  `assert_private()`; drops a `simp_one_shot_finalize.sh` script and runs it in
+  the background (`&`, `provider => shell`) so it can remove PKI, the puppet
+  package, and itself without breaking the in-flight Puppet run.
+
+### Other resource classes
+
+The remaining classes implement individual baseline concerns and are included
+via the scenario map / scenario classes rather than directly. Grouped by
+subdirectory:
+
+- **top-level `manifests/*.pp`** — `simp::admin` (admin/auditor group access
+  and default sudo rules), `simp::base_apps` (common apps such as irqbalance),
+  `simp::base_services` (**deprecated**, slated for removal), `simp::ctrl_alt_del`,
+  `simp::kmod_blacklist`, `simp::mountpoints`, `simp::netconsole`,
+  `simp::nsswitch`, `simp::prelink`, `simp::puppetdb`, `simp::rc_local`,
+  `simp::root_user`, `simp::server` (the SIMP server role), `simp::sudoers`,
+  `simp::sysctl`, and `simp::version`.
+- **`kmod_blacklist/`** — `lock_modules`.
+- **`mountpoints/`** — `proc`, `tmp` (secure mount options).
+- **`pam_limits/`** — `max_logins` (simultaneous-login restriction).
+- **`server/`** — `kickstart`, `kickstart/simp_client_bootstrap`,
+  `rsync_shares`, `yum` (server-role provisioning).
+- **`sssd/`** — `client` (stock SSSD stack).
+- **`sudoers/`** — `aliases` (SIMP site sudoers aliases).
+- **`yum/`** — `schedule`, plus a set of `yum/repo/*` repo-definition classes
+  (`internet_simp`, `internet_simp_dependencies`, `internet_simp_server`,
+  `local_os_updates`, `local_simp`).
+
+There are roughly **39 classes** in total across `manifests/` (18 top-level
+`manifests/*.pp` plus ~21 subclasses under the subdirectories above). Summarize
+by role rather than enumerating each one when working here.
+
+### Gotchas / non-obvious details
+
+- **This is a meta-module, not a service module.** Almost nothing here manages a
+  daemon directly; the module's job is *classification* — pick a scenario, union
+  in extra classes, knock out unwanted ones, and `include` the result
+  (`init.pp:201-212`). Changes to what a "SIMP system" includes usually belong
+  in the `scenario_map` in `data/common.yaml`, not in new manifest logic.
+- **The scenario is data-driven.** `$scenario_map` and `$classes` both merge
+  across the Hiera hierarchy (`data/common.yaml` sets deep/unique merge
+  behaviour and defines the `simp::knockout` `--` prefix semantics). An
+  invalid scenario name is a hard compile `fail` (`init.pp:211`).
+- **`simplib::module_metadata::assert` is intentionally NOT called in
+  `simp::init`** — this is deliberate, to permit non-SIMP OSes to use the `poss`
+  scenario (`init.pp:195-199`). Contrast `simp::one_shot`, which *does* assert
+  (with `Windows` blacklisted, `one_shot.pp:93`).
+- **`poss` provides no security.** It is a bare client-to-server connection;
+  do not assume any hardening is applied under the `poss` scenario
+  (`scenario/poss.pp:5-8`).
+- **Bolt-awareness.** The `$facts['puppet_vardir']}/simp` directory and the
+  filebucket are skipped under `simplib::in_bolt()` because the vardir would be
+  on the Bolt host, not the target (`init.pp:184,214-215`).
+- **`simp::base_services` is deprecated** and will be removed in a future
+  version (`manifests/base_services.pp:1`); do not build new logic on it.
+- **`enable_data_includes` is deprecated and has no effect** (`init.pp:22-25`);
+  it is slated for removal in the next major release.
+- **one_shot finalization is destructive and asynchronous.** It runs a script in
+  the background that can remove PKI and the puppet package
+  (`one_shot/finalize.pp:37-43`); it is not part of a normal run and should not
+  be enabled on managed clients.
+- **Windows in the OS matrix is vestigial.** `metadata.json` still carries a
+  legacy Windows entry, but the module and its acceptance suite are EL-only in
+  practice.
+
+## The `simp_options` / `simplib::lookup` seam
+
+Like every SIMP module, `simp` routes cross-cutting feature toggles through the
+`simp_options::*` namespace via `simplib::lookup(..., { 'default_value' => ...
+})`, so a site can flip a capability once and have it propagate. There are **15**
+distinct `simp_options::*` seams consumed across the manifests:
+
+`simp_options::auditd`, `simp_options::authselect`, `simp_options::clamav`,
+`simp_options::fips`, `simp_options::firewall`, `simp_options::ldap`,
+`simp_options::ntpd::servers`, `simp_options::package_ensure`,
+`simp_options::pam`, `simp_options::puppet::ca`, `simp_options::puppet::ca_port`,
+`simp_options::puppet::server`, `simp_options::sssd`, `simp_options::stunnel`,
+`simp_options::trusted_nets`.
+
+In `simp::init` specifically, `$rsync_stunnel`, `$pam`, `$ldap`, and `$sssd`
+default off the `simp_options::stunnel` / `::pam` / `::ldap` / `::sssd` seams
+(`init.pp:163,178-180`). Keep new toggles flowing through
+`simplib::lookup('simp_options::*', { 'default_value' => ... })` with an
+explicit default rather than assuming `simp_options` is included.
+
+## Dependencies
+
+This is a **meta-module: it depends on essentially the entire SIMP stack.**
+`metadata.json` declares **43** dependencies — do not transcribe them all when
+editing; treat the dependency list as "the whole SIMP ecosystem." A
+representative handful:
+
+- `simp/pupmod` `>= 10.0.0 < 11.0.0`
+- `simp/simplib` `>= 4.9.0 < 5.0.0` (provides `simplib::lookup`,
+  `simplib::knockout`/`simp::knockout` support, `simplib::in_bolt`,
+  `simplib::module_metadata::assert`, `runlevel`, facts)
+- `simp/ssh` `>= 6.11.0 < 7.0.0`
+- `simp/sssd` `>= 7.0.0 < 8.0.0`
+- `simp/stunnel` `>= 7.0.0 < 8.0.0`
+- `puppetlabs/stdlib` `>= 8.0.0 < 10.0.0`
+
+There are **no optional dependencies** — the module makes no
+`simplib::assert_optional_dependency` calls.
+
+Runtime requirement (from `metadata.json` `requirements`): `puppet
+>= 8.0.0 < 9.0.0`. Note that the `Gemfile` `puppet_version` default is a
+separate, looser range (`>= 7 < 9`, see below) — the runtime requirement is the
+authoritative `>= 8 < 9`. (SIMP is migrating Puppet → OpenVox; when
+`metadata.json` switches `requirements` to `openvox`, update this line to match.)
+
+Supported OS matrix (from `metadata.json`): CentOS 9/10; RedHat 8/9/10;
+OracleLinux 8/9/10; Rocky 8/9/10; AlmaLinux 8/9/10. A legacy Windows entry
+(2008 / 2008 R2 / 2012 / 2012 R2 / 2016 / 2019 / 7 / 8.1 / 10) is also present in
+`metadata.json` but is **vestigial** — the module and its acceptance suite are
+EL-only in practice.
+
+## Repository layout
+
+- `manifests/init.pp` — the public `simp` class; scenario resolution +
+  classification (the orchestration core).
+- `manifests/scenario/base.pp`, `manifests/scenario/poss.pp` — the two
+  orchestration entry points (both `assert_private()`, both `inherits simp`).
+- `manifests/one_shot.pp`, `manifests/one_shot/user.pp`,
+  `manifests/one_shot/finalize.pp` — bootstrap/teardown for stand-alone hosts
+  (not part of a normal run).
+- `manifests/*.pp` and the `kmod_blacklist/`, `mountpoints/`, `pam_limits/`,
+  `server/`, `sssd/`, `sudoers/`, `yum/` subdirectories — the individual
+  baseline classes (~39 classes total).
+- `data/common.yaml` — the `scenario_map`, class lists, nsswitch defaults, and
+  merge behaviours. **This is where "what a SIMP system includes" lives.**
+- `data/os/`, `hiera.yaml` — module data hierarchy (v5): OS name+major → OS name
+  → kernel → common.
+- `metadata.json` — the 43 dependencies, OS matrix, and Puppet requirement.
+- `spec/classes/`, `spec/defines/` — rspec-puppet unit tests.
+- `spec/acceptance/suites/` — beaker suites (`default`, `base_apps`); nodesets
+  under `spec/acceptance/nodesets/` (**30** files: a `vagrant` set —
+  almalinux8/9/10, centos9/10, oel8/9/10, rhel8/9/10, rocky8/9/10, amzn2 — and a
+  `docker_*` set).
+- `REFERENCE.md` — generated Puppet Strings reference.
+- **`assert_private()` callers:** `manifests/one_shot/finalize.pp`,
+  `manifests/scenario/base.pp`, `manifests/one_shot/user.pp`,
+  `manifests/scenario/poss.pp` — these are internal-only classes reached through
+  `simp` / `simp::one_shot`, never included directly.
+- **Acceptance runs in CI:** `.github/workflows/pr_tests.yml` has an active
+  `acceptance` job (matrix node ∈ {`almalinux8`, `almalinux10`} × suite ∈
+  {`default`, `base_apps`}) whose final step runs `bundle exec rake
+  beaker:suites[<suite>,<node>]` under `BEAKER_HYPERVISOR=vagrant_libvirt` and
+  `VAGRANT_DEFAULT_PROVIDER=libvirt` (Ruby 3.4.9).
+
+## Common commands
+
+```sh
+# Install dependencies
+bundle install
+
+# Run all unit tests
+bundle exec rake spec
+
+# Puppet lint
+bundle exec rake lint
+
+# Ruby lint
+bundle exec rake rubocop
+
+# Regenerate REFERENCE.md from puppet-strings docstrings
+puppet strings generate --format markdown --out REFERENCE.md
+
+# Run a beaker acceptance suite (matches CI: suite x node)
+bundle exec rake beaker:suites[default,almalinux8]
+bundle exec rake beaker:suites[base_apps,almalinux10]
+```
+
+`spec/spec_helper.rb:11` requires `puppetlabs_spec_helper/module_spec_helper`.
+Relevant gem pins (from `Gemfile`): `puppetlabs_spec_helper ~> 8.0.0`,
+`simp-rake-helpers ~> 5.24.0`, `simp-beaker-helpers ~> 2.0.0`. Rubocop is pinned
+to `~> 1.88.0`. The `Gemfile` installs only the `puppet` gem (no `openvox` gem
+yet) and its `puppet_version` default is `>= 7 < 9`; the authoritative runtime
+requirement in `metadata.json` is `>= 8 < 9`.
+
+## Conventions
+
+- **Change the scenario map, not the manifest, to change what SIMP includes.**
+  The class list for each scenario is data (`data/common.yaml` →
+  `simp::scenario_map`); adding a class to the baseline usually means editing
+  that data, not `init.pp`.
+- **Keep the two public entry points thin.** `simp::init` classifies;
+  `simp::scenario::base` / `::poss` orchestrate. New per-concern logic belongs in
+  a dedicated `simp::*` class that the scenario includes, guarded by a boolean
+  seam.
+- **Preserve `assert_private()`** on scenario and one_shot classes — they are
+  internal and reached only through `simp` / `simp::one_shot`.
+- **Do not add `simplib::module_metadata::assert` to `simp::init`** — its
+  absence is intentional so non-SIMP OSes can use `poss` (`init.pp:195-199`).
+- Continue routing SIMP feature toggles through
+  `simplib::lookup('simp_options::*', { 'default_value' => ... })` with an
+  explicit default rather than assuming `simp_options` is included.
+- Preserve the `@summary` / `@param` puppet-strings docstrings — they drive
+  `REFERENCE.md`. Regenerate `REFERENCE.md` after changing docs or parameters.
+- `Gemfile`, `spec/spec_helper.rb`, and `.github/workflows/pr_tests.yml` carry a
+  **puppetsync** notice — they are baseline-managed and the next sync overwrites
+  local edits. Push changes to those files upstream to the baseline, not here.
+- Match the existing 2-space Puppet indentation and aligned-arrow parameter
+  style used across `manifests/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,8 +126,7 @@ by role rather than enumerating each one when working here.
   (`init.pp`). Changes to what a "SIMP system" includes usually belong
   in the `scenario_map` in `data/common.yaml`, not in new manifest logic.
 - **The scenario is data-driven.** `$scenario_map` and `$classes` both merge
-  across the Hiera hierarchy (`data/common.yaml` sets deep/unique merge
-  behaviour and defines the `simp::knockout` `--` prefix semantics). An
+  across the Hiera hierarchy (`data/common.yaml` sets deep/unique merge behaviour; the `--` knockout prefix is applied by the `simp::knockout`/`simplib::knockout` functions in the manifests, with Hiera `knockout_prefix` enabled only for `simp::puppetdb::cipher_suites`). An
   invalid scenario name is a hard compile `fail` (`init.pp`).
 - **`simplib::module_metadata::assert` is intentionally NOT called in
   `simp::init`** — this is deliberate, to permit non-SIMP OSes to use the `poss`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ classes drawn from across the whole SIMP module ecosystem.
 The orchestration is driven by a **scenario** abstraction. The `simp` class
 looks up a `scenario` name, resolves it against a `scenario_map` (a Hash from
 module data mapping each scenario to its class list), and `include`s the
-resulting classes (`manifests/init.pp:201-212`). This is why the module depends
+resulting classes (`manifests/init.pp`). This is why the module depends
 on essentially the entire SIMP stack: it is the thing that wires those modules
 together into a working system.
 
@@ -26,18 +26,18 @@ the SIMP server role, one-shot bootstrap, etc.).
 
 ### The scenario model
 
-The `simp` class (`manifests/init.pp:153-225`) is the public entry class —
+The `simp` class (`manifests/init.pp`) is the public entry class —
 consumers `include 'simp'`. Its behaviour is governed by two data-driven
 parameters:
 
-- **`$scenario`** (`String`, default `'simp'`, `init.pp:159`) — the SIMP
+- **`$scenario`** (`String`, default `'simp'`, `init.pp`) — the SIMP
   scenario to apply.
 - **`$scenario_map`** (`Hash`, no default; set from module data,
-  `init.pp:158`) — the internal map from scenario name to class list. Defined in
+  `init.pp`) — the internal map from scenario name to class list. Defined in
   `data/common.yaml` (`simp::scenario_map`) with the keys `none`,
   `remote_access`, `poss`, `simp_lite`, and `simp`.
 
-Control flow (`init.pp:201-212`):
+Control flow (`init.pp`):
 
 - If `$scenario` is a key in `$scenario_map`, the class list is computed as
   `simp::knockout(union($scenario_map[$scenario], $classes))` — the scenario's
@@ -62,7 +62,7 @@ Two scenario classes are the orchestration entry points:
   `postfix`/`postfix::server` (mail), `simp::rc_local`, a `host` entry for the
   Puppet server (from `$server_facts`), optional `ssh::global_known_hosts`, and
   an `rsync` stunnel connection to the Puppet server on port 8730
-  (`scenario/base.pp:97-153`).
+  (`scenario/base.pp`).
 - **`simp::scenario::poss` (`manifests/scenario/poss.pp`)** — the "Puppet Open
   Source Software" scenario. An `assert_private()` class (`inherits simp`) that
   provides a *minimal* client which merely connects to a SIMP Puppet server. It
@@ -77,7 +77,7 @@ exists to bootstrap or tear down a stand-alone system that disconnects from the
 Puppet server after a successful run.
 
 - **`simp::one_shot` (`manifests/one_shot.pp`)** — asserts the module metadata
-  with `Windows` blacklisted (`one_shot.pp:93`), `contain`s
+  with `Windows` blacklisted (`one_shot.pp`), `contain`s
   `simp::one_shot::user`, defines a late run `stage`
   (`simp_one_shot_finalization`, ordered after `simp_finalize`), and runs
   `simp::one_shot::finalize` in that stage so finalization only happens if all
@@ -123,29 +123,29 @@ by role rather than enumerating each one when working here.
 - **This is a meta-module, not a service module.** Almost nothing here manages a
   daemon directly; the module's job is *classification* — pick a scenario, union
   in extra classes, knock out unwanted ones, and `include` the result
-  (`init.pp:201-212`). Changes to what a "SIMP system" includes usually belong
+  (`init.pp`). Changes to what a "SIMP system" includes usually belong
   in the `scenario_map` in `data/common.yaml`, not in new manifest logic.
 - **The scenario is data-driven.** `$scenario_map` and `$classes` both merge
   across the Hiera hierarchy (`data/common.yaml` sets deep/unique merge
   behaviour and defines the `simp::knockout` `--` prefix semantics). An
-  invalid scenario name is a hard compile `fail` (`init.pp:211`).
+  invalid scenario name is a hard compile `fail` (`init.pp`).
 - **`simplib::module_metadata::assert` is intentionally NOT called in
   `simp::init`** — this is deliberate, to permit non-SIMP OSes to use the `poss`
-  scenario (`init.pp:195-199`). Contrast `simp::one_shot`, which *does* assert
-  (with `Windows` blacklisted, `one_shot.pp:93`).
+  scenario (`init.pp`). Contrast `simp::one_shot`, which *does* assert
+  (with `Windows` blacklisted, `one_shot.pp`).
 - **`poss` provides no security.** It is a bare client-to-server connection;
   do not assume any hardening is applied under the `poss` scenario
-  (`scenario/poss.pp:5-8`).
+  (`scenario/poss.pp`).
 - **Bolt-awareness.** The `$facts['puppet_vardir']}/simp` directory and the
   filebucket are skipped under `simplib::in_bolt()` because the vardir would be
-  on the Bolt host, not the target (`init.pp:184,214-215`).
+  on the Bolt host, not the target (`init.pp`).
 - **`simp::base_services` is deprecated** and will be removed in a future
-  version (`manifests/base_services.pp:1`); do not build new logic on it.
-- **`enable_data_includes` is deprecated and has no effect** (`init.pp:22-25`);
+  version (`manifests/base_services.pp`); do not build new logic on it.
+- **`enable_data_includes` is deprecated and has no effect** (`init.pp`);
   it is slated for removal in the next major release.
 - **one_shot finalization is destructive and asynchronous.** It runs a script in
   the background that can remove PKI and the puppet package
-  (`one_shot/finalize.pp:37-43`); it is not part of a normal run and should not
+  (`one_shot/finalize.pp`); it is not part of a normal run and should not
   be enabled on managed clients.
 - **Windows in the OS matrix is vestigial.** `metadata.json` still carries a
   legacy Windows entry, but the module and its acceptance suite are EL-only in
@@ -167,7 +167,7 @@ distinct `simp_options::*` seams consumed across the manifests:
 
 In `simp::init` specifically, `$rsync_stunnel`, `$pam`, `$ldap`, and `$sssd`
 default off the `simp_options::stunnel` / `::pam` / `::ldap` / `::sssd` seams
-(`init.pp:163,178-180`). Keep new toggles flowing through
+(`init.pp`). Keep new toggles flowing through
 `simplib::lookup('simp_options::*', { 'default_value' => ... })` with an
 explicit default rather than assuming `simp_options` is included.
 
@@ -258,7 +258,7 @@ bundle exec rake beaker:suites[default,almalinux8]
 bundle exec rake beaker:suites[base_apps,almalinux10]
 ```
 
-`spec/spec_helper.rb:11` requires `puppetlabs_spec_helper/module_spec_helper`.
+`spec/spec_helper.rb` requires `puppetlabs_spec_helper/module_spec_helper`.
 Relevant gem pins (from `Gemfile`): `puppetlabs_spec_helper ~> 8.0.0`,
 `simp-rake-helpers ~> 5.24.0`, `simp-beaker-helpers ~> 2.0.0`. Rubocop is pinned
 to `~> 1.88.0`. The `Gemfile` installs only the `puppet` gem (no `openvox` gem
@@ -278,7 +278,7 @@ requirement in `metadata.json` is `>= 8 < 9`.
 - **Preserve `assert_private()`** on scenario and one_shot classes — they are
   internal and reached only through `simp` / `simp::one_shot`.
 - **Do not add `simplib::module_metadata::assert` to `simp::init`** — its
-  absence is intentional so non-SIMP OSes can use `poss` (`init.pp:195-199`).
+  absence is intentional so non-SIMP OSes can use `poss` (`init.pp`).
 - Continue routing SIMP feature toggles through
   `simplib::lookup('simp_options::*', { 'default_value' => ... })` with an
   explicit default rather than assuming `simp_options` is included.


### PR DESCRIPTION
Adds an AGENTS.md documenting the simp meta-module for AI coding assistants, plus the standard AI-assistant plumbing: a .gitignore block for tool-specific files (the cross-tool standard is AGENTS.md) and /AGENTS.md added to .pdkignore so it is excluded from Forge builds.