### PR TITLE
Fix stale PUPPET_VERSION pin in tag_deploy workflow

### DIFF
--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -39,7 +39,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
 
 jobs:
   releng-checks:


### PR DESCRIPTION
The top-level `PUPPET_VERSION: '~> 7'` env in `tag_deploy.yml` survived the OpenVox migration because that workflow only runs on tags. The Gemfile maps `PUPPET_VERSION` onto the `openvox` gem, which cannot resolve against simp-rake-helpers 6.0 (requires openvox >= 8 < 9) — this is what failed the 7.0.1 release run (https://github.com/simp/pupmod-simp-simp/actions/runs/29258368732).

Set to `'~> 8'`, matching the modules that were already fixed in a previous pass.

After merging, the 7.0.1 tag needs to be moved to the fixed commit (tag_deploy uses the workflow file from the tag's own tree, so re-running the failed workflow would hit the same error):
```
git tag -fa 7.0.1 -m 7.0.1 <merge commit>
git push --force origin 7.0.1
```

Note: this same stale env exists in ~50 other modules' tag_deploy workflows — fixes are being pushed to their open openvox9-ruby4-preview PRs, the puppetsync templates (#42), and the affected rubygem repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCnDsYaJDLiP8z8tafz9Tp