### PR TITLE
Replace legacy facts with structured facts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+* Wed Jul 29 2026 Steven Pritchard <steve@sicura.us> - 9.0.0
+- Replace legacy facts with structured facts (fixes #329)
+  - `simp::puppetdb` computes percentage-based Java heap sizes from
+    `$facts['memory']['system']['total_bytes']` in native Puppet instead
+    of an inline ERB template using the legacy `memorysize_mb` fact
+  - Acceptance tests query `networking.*` structured facts instead of
+    the flat `fqdn`, `domain`, `ipaddress_eth1`, and `macaddress_eth1`
+    facts
+
 * Wed Jul 29 2026 Hazel Caballero <hazel@sicura.us> - 9.0.0
 - (#374) Remove all references to the archived pupmod-simp-ntpd module: drop
   the `simp/ntpd` metadata dependency and fixture, consolidate the kickstart

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -108,7 +108,15 @@ class simp::puppetdb (
 
   $_simp_manage_firewall = ($manage_firewall and $firewall)
 
-  $_java_max_memory = inline_template('<% if @java_max_memory[-1].chr == "%" %><%= (@memorysize_mb.to_f * (@java_max_memory[0..-2].to_f/100.0)).round.to_s + "m" %><% else %><%= @java_max_memory %><% end %>')
+  # A percentage is converted to megabytes of system memory; anything else is
+  # passed to Java verbatim
+  if $java_max_memory =~ /^(\d+(?:\.\d+)?)%$/ {
+    $_system_memory_mb = Float($facts['memory']['system']['total_bytes']) / 1048576
+    $_java_max_memory = "${round($_system_memory_mb * Float($1) / 100.0)}m"
+  }
+  else {
+    $_java_max_memory = $java_max_memory
+  }
 
   if !defined('puppetdb::java_args') or empty($puppetdb::java_args) {
     $_java_heapdump_on_oom = $java_heapdump_on_oom ? {

--- a/spec/acceptance/suites/netconsole/netconsole_spec.rb
+++ b/spec/acceptance/suites/netconsole/netconsole_spec.rb
@@ -5,8 +5,8 @@ test_name 'simp::netconsole class'
 describe 'simp::netconsole class' do
   let(:shipper) { only_host_with_role(hosts, 'shipper') }
   let(:receiver) { only_host_with_role(hosts, 'receiver') }
-  let(:receiver_ip) { fact_on(receiver, 'ipaddress_eth1') }
-  let(:receiver_mac) { fact_on(receiver, 'macaddress_eth1') }
+  let(:receiver_ip) { fact_on(receiver, 'networking.interfaces.eth1.ip') }
+  let(:receiver_mac) { fact_on(receiver, 'networking.interfaces.eth1.mac') }
 
   context 'should send logs' do
     let(:manifest) do

--- a/spec/acceptance/suites/scenario_one_shot/00_simp_spec.rb
+++ b/spec/acceptance/suites/scenario_one_shot/00_simp_spec.rb
@@ -94,7 +94,7 @@ describe 'simp "one_shot" scenario' do
   end
 
   hosts.each do |host|
-    let(:host_fqdn) { fact_on(host, 'fqdn') }
+    let(:host_fqdn) { fact_on(host, 'networking.fqdn') }
     let(:ssh_authorized_key) do
       on(host, 'cat ~/.ssh/authorized_keys').stdout.strip.lines.first.split(%r{\s+})[1]
     end

--- a/spec/acceptance/suites/scenario_poss/00_simp_spec.rb
+++ b/spec/acceptance/suites/scenario_poss/00_simp_spec.rb
@@ -23,7 +23,7 @@ describe 'simp "poss" scenario' do
   end
 
   hosts.each do |host|
-    let(:host_fqdn) { fact_on(host, 'fqdn') }
+    let(:host_fqdn) { fact_on(host, 'networking.fqdn') }
     let(:ssh_authorized_key) do
       on(host, 'cat ~/.ssh/authorized_keys').stdout.strip.lines.first.split(%r{\s+})[1]
     end

--- a/spec/acceptance/suites/scenario_remote_access/00_remote_access_spec.rb
+++ b/spec/acceptance/suites/scenario_remote_access/00_remote_access_spec.rb
@@ -30,8 +30,8 @@ describe 'remote_access scenario' do
   # Both client and server need these
   hosts_with_role(hosts, 'ldap_server').each do |ldap_server|
     context 'Test running on current LDAP server #{ldap_server}' do
-      let(:server_fqdn) { fact_on(ldap_server, 'fqdn') }
-      let(:base_dn) { fact_on(ldap_server, 'domain').split('.').map { |d| "dc=#{d}" }.join(',') }
+      let(:server_fqdn) { fact_on(ldap_server, 'networking.fqdn') }
+      let(:base_dn) { fact_on(ldap_server, 'networking.domain').split('.').map { |d| "dc=#{d}" }.join(',') }
       # For now default to openldap server until test includes a 389DS server
       let(:ldap_type) do
         '389ds'
@@ -75,7 +75,7 @@ describe 'remote_access scenario' do
           let(:common_hieradata)      { File.read(File.expand_path('templates/common_hieradata.yaml.erb', File.dirname(__FILE__))) }
           let(:client_hieradata)      { File.read(File.expand_path('templates/client_hieradata.yaml.erb', File.dirname(__FILE__))) }
           let(:cc_hieradata)          { common_hieradata.to_s + "\n#{client_hieradata}" }
-          let(:client_fqdn) { fact_on(client, 'fqdn') }
+          let(:client_fqdn) { fact_on(client, 'networking.fqdn') }
 
           it 'configures hiera' do
             set_hieradata_on(client, ERB.new(cc_hieradata).result(binding))

--- a/spec/acceptance/suites/win_client/00_default_spec.rb
+++ b/spec/acceptance/suites/win_client/00_default_spec.rb
@@ -20,7 +20,7 @@ describe 'windows node' do
 
   # A Linux host has to be in the nodeset for the setup code
   hosts_with_role(hosts, 'windows').each do |host|
-    let(:host_fqdn) { fact_on(host, 'fqdn') }
+    let(:host_fqdn) { fact_on(host, 'networking.fqdn') }
 
     it 'applies the test manifest' do
       set_hieradata_on(host, hieradata)

--- a/spec/classes/00_classes/puppetdb_spec.rb
+++ b/spec/classes/00_classes/puppetdb_spec.rb
@@ -139,6 +139,31 @@ describe 'simp::puppetdb' do
             }
           end
 
+          context 'with a percentage java_max_memory' do
+            let(:hieradata) { 'simp__puppetdb' }
+            let(:params) { { java_max_memory: '40%' } }
+            let(:expected_xmx) do
+              "#{(os_facts[:memory][:system][:total_bytes].to_f / 1_048_576 * 0.40).round}m"
+            end
+
+            it { is_expected.to compile.with_all_deps }
+            it 'computes -Xmx from the system memory fact' do
+              java_args = catalogue.resource('Class[puppetdb]')[:java_args]
+              expect(java_args['-Xmx']).to eq(expected_xmx)
+            end
+          end
+
+          context 'with an absolute java_max_memory' do
+            let(:hieradata) { 'simp__puppetdb' }
+            let(:params) { { java_max_memory: '2g' } }
+
+            it { is_expected.to compile.with_all_deps }
+            it 'passes -Xmx through verbatim' do
+              java_args = catalogue.resource('Class[puppetdb]')[:java_args]
+              expect(java_args['-Xmx']).to eq('2g')
+            end
+          end
+
           context 'with read_database_ssl = true' do
             let(:hieradata) { 'simp__puppetdb' }
             let(:params) { { read_database_ssl: true } }


### PR DESCRIPTION
Fixes #329 (no other open PR addresses it — verified).

- **`simp::puppetdb`**: the percentage-based Java heap computation moves from an inline ERB template using the legacy `memorysize_mb` fact to native Puppet using `$facts['memory']['system']['total_bytes']`. Behavior is identical (MiB × percent, rounded, `m` suffix; non-percentage values pass through verbatim) — locked in with new unit assertions for both forms, which pass across the OS matrix (379 examples, 0 failures on the puppetdb spec).
- **Acceptance suites**: `fact_on` calls move to structured facts — `networking.fqdn`, `networking.domain`, `networking.interfaces.eth1.ip`/`.mac` — replacing the flat `fqdn`/`domain`/`ipaddress_eth1`/`macaddress_eth1` facts.

Two items from the issue's listing needed no change: the `bootstrap_simp_client` spec stubs are already structured `os.selinux` values (matching what the script reads via `Facter.value(:os).dig('selinux', ...)`), and the kickstart templates were already fixed to `@facts['networking']['domain']` on master. A final sweep of `manifests/`, `lib/`, `templates/`, and `spec/acceptance/` finds no remaining flat-fact usage.

Rides the unreleased 9.0.0 (CHANGELOG entry added; no additional bump needed). syntax/lint/rubocop/validate:strings/RELENG all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)