### PR TITLE
Remove nonexistent global keys from tests' data

### DIFF
--- a/spec/acceptance/suites/default/files/default_hiera.yaml
+++ b/spec/acceptance/suites/default/files/default_hiera.yaml
@@ -8,10 +8,8 @@ simp_options::ldap::bind_pw: 's00per sekr3t!'
 simp_options::ldap::bind_hash: '{SSHA}foobarbaz!!!!'
 simp_options::ldap::sync_pw: 's00per sekr3t!'
 simp_options::ldap::sync_hash: '{SSHA}foobarbaz!!!!'
-simp_options::ldap::root_hash: '{SSHA}foobarbaz!!!!'
 simp::scenario: simp
 simp_options::ldap: false
-simp_options::rsync: false
 simp_options::clamav: false
 simp_options::pki: true
 simp_options::pki::source: '/etc/pki/simp-testing/pki'

--- a/spec/acceptance/suites/scenario_one_shot/00_simp_spec.rb
+++ b/spec/acceptance/suites/scenario_one_shot/00_simp_spec.rb
@@ -52,7 +52,6 @@ describe 'simp "one_shot" scenario' do
       simp::one_shot::finalize_debug: true
 
       # Disable network stuff
-      simp_options::rsync: false
       simp_options::clamav: false
       simp_options::ldap: false
 

--- a/spec/acceptance/suites/scenario_remote_access/templates/client_hieradata.yaml.erb
+++ b/spec/acceptance/suites/scenario_remote_access/templates/client_hieradata.yaml.erb
@@ -25,9 +25,6 @@ simp_options::tcpwrappers: false
 simp_options::ipsec: false
 simp_options::kerberos: false
 
-# Extra tweaks for acceptance
-simp_options::rsync: false
-
 # Settings to make beaker happy
 pam::access::default_deny: false
 ssh::server::conf::permitrootlogin: true

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -16,7 +16,6 @@ simp_options::ldap::sync_dn : "cn=sync,ou=Hosts,%{lookup('ldap::base_dn')}"
 simp_options::ldap::sync_pw : 's00per sekr3t!'
 simp_options::ldap::sync_hash : '{SSHA}foobarbaz!!!!'
 simp_options::ldap::root_dn : "cn=LDAPAdmin,ou=People,%{lookup('ldap::base_dn')}"
-simp_options::ldap::root_hash : '{SSHA}foobarbaz!!!!'
 simp_options::ldap::uri :
   - 'ldap://server1.bar.baz'
   - 'ldap://server2.bar.baz'


### PR DESCRIPTION
This patch removes a ancient global catalysts that no longer
exist from a few tests' staged data